### PR TITLE
`Tab` rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,27 +48,31 @@ impl Tab<MyContext> for MyTab {
 Then construct the initial tree using your tab widget:
 
 ```rust
-use egui_dock::{NodeIndex, Tree};
+use egui::style::Margin;
+use egui_dock::{TabBuilder, Tree};
 
-let tab1 = Box::new(MyTab::new("Tab 1"));
-let tab2 = Box::new(MyTab::new("Tab 2"));
-let tab3 = Box::new(MyTab::new("Tab 3"));
-let tab4 = Box::new(MyTab::new("Tab 4"));
-let tab5 = Box::new(MyTab::new("Tab 5"));
+let tab1 = TabBuilder::default()
+    .title("Tab 1")
+    .content(|ui| {
+        ui.label("Tab 1");
+    })
+    .build();
+let tab2 = TabBuilder::default()
+    .title("Tab 2")
+    .inner_margin(Margin::same(4.0))
+    .content(|ui| {
+        ui.label("Tab 2");
+    })
+    .build();
 
 let mut tree = Tree::new(vec![tab1, tab2]);
-
-// You can modify the tree in runtime
-let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![tab3]);
-let [_, _] = tree.split_below(a, 0.7, vec![tab4]);
-let [_, _] = tree.split_below(b, 0.5, vec![tab5]);
 ```
 
 Finally, you can show the tree.
 
 ```rust
 let id = ui.id();
-egui_dock::show(&mut ui, id, style, tree, context);
+egui_dock::show(&mut ui, id, &style, &mut tree);
 ```
 
 ## Contribution

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::{egui, NativeOptions};
-use egui::{Id, LayerId, Slider, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree};
+use egui::color_picker::{color_picker_color32, Alpha};
+use egui::{Color32, Id, LayerId, RichText, Slider, Ui};
+use egui_dock::{NodeIndex, Style, TabBuilder, Tree, WithTitle};
 use std::cell::RefCell;
 use std::rc::Rc;
-use egui::color_picker::{Alpha, color_picker_color32};
 
 fn main() {
     let options = NativeOptions::default();
@@ -38,7 +38,7 @@ impl Default for MyApp {
 
         let mt_ctx = context.clone();
         let node_tree = TabBuilder::default()
-            .title("Simple Demo")
+            .title(RichText::new("Simple Demo").color(Color32::BLUE))
             .content(move |ui| {
                 let mut ctx = mt_ctx.borrow_mut();
                 ui.heading("My egui Application");
@@ -120,11 +120,6 @@ impl Default for MyApp {
 
                     ui.label("Bar background color");
                     color_picker_color32(ui, &mut style.tab_bar_background_color, Alpha::OnlyBlend);
-
-                    ui.separator();
-
-                    ui.label("Text color");
-                    color_picker_color32(ui, &mut style.tab_text_color, Alpha::OnlyBlend);
 
                     ui.separator();
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{NativeOptions, egui};
-use egui::{Frame, Id, LayerId, Ui, style::Margin};
-use egui_dock::{NodeIndex, Style, Tab, Tree};
+use eframe::{egui, NativeOptions};
+use egui::{Id, LayerId, Ui};
+use egui_dock::{NodeIndex, Style, TabBuilder, Tree};
 
 fn main() {
     let options = NativeOptions::default();
@@ -14,18 +14,42 @@ fn main() {
 }
 
 struct MyApp {
-    context: MyContext,
     style: Style,
-    tree: Tree<MyContext>,
+    tree: Tree,
 }
 
 impl Default for MyApp {
     fn default() -> Self {
-        let tab1 = Box::new(MyTab::new("Tab 1"));
-        let tab2 = Box::new(MyTab::new("Tab 2"));
-        let tab3 = Box::new(MyTab::new("Tab 3"));
-        let tab4 = Box::new(MyTab::new("Tab 4"));
-        let tab5 = Box::new(MyTab::new("Tab 5"));
+        let tab1 = TabBuilder::default()
+            .title("Tab 1")
+            .content(|ui| {
+                ui.label("Tab 1");
+            })
+            .build();
+        let tab2 = TabBuilder::default()
+            .title("Tab 2")
+            .content(|ui| {
+                ui.label("Tab 2");
+            })
+            .build();
+        let tab3 = TabBuilder::default()
+            .title("Tab 3")
+            .content(|ui| {
+                ui.label("Tab 3");
+            })
+            .build();
+        let tab4 = TabBuilder::default()
+            .title("Tab 4")
+            .content(|ui| {
+                ui.label("Tab 4");
+            })
+            .build();
+        let tab5 = TabBuilder::default()
+            .title("Tab 5")
+            .content(|ui| {
+                ui.label("Tab 5");
+            })
+            .build();
 
         let mut tree = Tree::new(vec![tab1, tab2]);
 
@@ -36,7 +60,6 @@ impl Default for MyApp {
 
         Self {
             style: Style::default(),
-            context: MyContext,
             tree,
         }
     }
@@ -52,34 +75,6 @@ impl eframe::App for MyApp {
         let clip_rect = ctx.available_rect();
 
         let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
-        egui_dock::show(&mut ui, id, &self.style, &mut self.tree, &mut self.context)
-    }
-}
-
-struct MyContext;
-
-struct MyTab {
-    text: String,
-}
-
-impl MyTab {
-    fn new(text: impl ToString) -> Self {
-        Self {
-            text: text.to_string(),
-        }
-    }
-}
-
-impl Tab<MyContext> for MyTab {
-    fn title(&self) -> &str {
-        &self.text
-    }
-
-    fn ui(&mut self, ui: &mut Ui, _ctx: &mut MyContext) {
-        let margin = Margin::same(4.0);
-
-        Frame::none().inner_margin(margin).show(ui, |ui| {
-            ui.label(&self.text);
-        });
+        egui_dock::show(&mut ui, id, &self.style, &mut self.tree)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,65 +6,33 @@
 //!
 //! ## Usage
 //!
-//! First, create your context type and your tab widget:
+//! First, construct the initial tree:
 //!
 //! ```rust
-//! use egui::{Frame, Ui, style::Margin};
-//! use egui_dock::Tab;
+//! use egui::style::Margin;
+//! use egui_dock::{TabBuilder, Tree};
 //!
-//! struct MyContext;
-//!
-//! struct MyTab {
-//!     text: String,
-//! }
-//!
-//! impl MyTab {
-//!     fn new(text: impl ToString) -> Self {
-//!         Self {
-//!             text: text.to_string(),
-//!         }
-//!     }
-//! }
-//!
-//! impl Tab<MyContext> for MyTab {
-//!     fn title(&self) -> &str {
-//!         &self.title
-//!     }
-//!
-//!     fn ui(&mut self, ui: &mut Ui, _ctx: &mut MyContext) {
-//!         let margin = Margin::same(4.0);
-//!
-//!         Frame::none().inner_margin(margin).show(ui, |ui| {
-//!             ui.label(&self.text);
-//!         });
-//!     }
-//! }
-//! ```
-//!
-//! Then construct the initial tree using your tab widget:
-//!
-//! ```rust
-//! use egui_dock::{NodeIndex, Tree};
-//!
-//! let tab1 = Box::new(MyTab::new("Tab 1"));
-//! let tab2 = Box::new(MyTab::new("Tab 2"));
-//! let tab3 = Box::new(MyTab::new("Tab 3"));
-//! let tab4 = Box::new(MyTab::new("Tab 4"));
-//! let tab5 = Box::new(MyTab::new("Tab 5"));
-//!
+//! let tab1 = TabBuilder::default()
+//!     .title("Tab 1")
+//!     .content(|ui| {
+//!         ui.label("Tab 1");
+//!     })
+//!     .build();
+//! let tab2 = TabBuilder::default()
+//!     .title("Tab 2")
+//!     .inner_margin(Margin::same(4.0))
+//!     .content(|ui| {
+//!         ui.label("Tab 2");
+//!     })
+//!     .build();
 //! let mut tree = Tree::new(vec![tab1, tab2]);
-//!
-//! // You can modify the tree in runtime
-//! let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![tab3]);
-//! let [_, _] = tree.split_below(a, 0.7, vec![tab4]);
-//! let [_, _] = tree.split_below(b, 0.5, vec![tab5]);
 //! ```
 //!
-//! Finally, you can show the tree.
+//! Then, you can show the tree.
 //!
 //! ```rust
 //! let id = ui.id();
-//! egui_dock::show(&mut ui, id, style, tree, context);
+//! egui_dock::show(&mut ui, id, &style, &mut tree)
 //! ```
 
 mod style;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! ```rust
 //! let id = ui.id();
-//! egui_dock::show(&mut ui, id, &style, &mut tree)
+//! egui_dock::show(&mut ui, id, &style, &mut tree);
 //! ```
 
 mod style;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ mod tab;
 mod tree;
 mod utils;
 
-pub use self::tab::{Tab, TabDowncast};
+pub use self::tab::{Tab, TabBuilder};
 pub use self::tree::{Node, NodeIndex, Split, Tree};
 pub use style::{Style, StyleBuilder};
 
@@ -139,7 +139,7 @@ impl State {
 }
 
 /// Shows the docking hierarchy inside a `Ui`.
-pub fn show<Ctx>(ui: &mut Ui, id: Id, style: &Style, tree: &mut Tree<Ctx>, context: &mut Ctx) {
+pub fn show(ui: &mut Ui, id: Id, style: &Style, tree: &mut Tree) {
     let mut state = State::load(ui.ctx(), id);
     let mut rect = ui.max_rect();
 
@@ -221,7 +221,7 @@ pub fn show<Ctx>(ui: &mut Ui, id: Id, style: &Style, tree: &mut Tree<Ctx>, conte
                             let is_being_dragged = ui.memory().is_being_dragged(id);
 
                             let is_active = *active == tab_index || is_being_dragged;
-                            let label = tab.title().to_string();
+                            let label = tab.title.clone();
 
                             if is_being_dragged {
                                 let layer_id = LayerId::new(Order::Tooltip, id);
@@ -281,7 +281,7 @@ pub fn show<Ctx>(ui: &mut Ui, id: Id, style: &Style, tree: &mut Tree<Ctx>, conte
                         .rect_filled(rect, 0.0, style.tab_background_color);
 
                     let mut ui = ui.child_ui(rect, Default::default());
-                    tab.ui(&mut ui, context);
+                    tab.ui(&mut ui);
                 }
 
                 let is_being_dragged = ui.memory().is_anything_being_dragged();
@@ -289,7 +289,7 @@ pub fn show<Ctx>(ui: &mut Ui, id: Id, style: &Style, tree: &mut Tree<Ctx>, conte
                     hover_data = ui.input().pointer.hover_pos().map(|pointer| HoverData {
                         rect,
                         dst: tree_index,
-                        tabs: tabs_response.hovered().then(|| tabs_response.rect),
+                        tabs: tabs_response.hovered().then_some(tabs_response.rect),
                         pointer,
                     });
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod tab;
 mod tree;
 mod utils;
 
-pub use self::tab::{Tab, TabBuilder};
+pub use self::tab::{Tab, TabBuilder, WithTitle};
 pub use self::tree::{Node, NodeIndex, Split, Tree};
 pub use style::{Style, StyleBuilder};
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -16,7 +16,6 @@ pub struct Style {
 
     pub tab_bar_background_color: Color32,
 
-    pub tab_text_color: Color32,
     pub tab_outline_color: Color32,
     pub tab_rounding: Rounding,
     pub tab_background_color: Color32,
@@ -37,7 +36,6 @@ impl Default for Style {
 
             tab_bar_background_color: Color32::WHITE,
 
-            tab_text_color: Color32::BLACK,
             tab_outline_color: Color32::BLACK,
             tab_background_color: Color32::WHITE,
             tab_rounding: Default::default(),
@@ -58,7 +56,6 @@ impl Style {
 
             separator_color: style.visuals.faint_bg_color,
             border_color: style.visuals.faint_bg_color,
-            tab_text_color: style.visuals.widgets.active.fg_stroke.color,
             tab_outline_color: style.visuals.widgets.active.bg_stroke.color,
             tab_background_color: style.visuals.window_fill(),
 
@@ -151,17 +148,14 @@ impl Style {
     pub(crate) fn tab_title(
         &self,
         ui: &mut Ui,
-        label: String,
+        label: WidgetText,
         active: bool,
         is_being_dragged: bool,
     ) -> Response {
         let px = ui.ctx().pixels_per_point().recip();
         let rounding = self.tab_rounding;
 
-        let font_id = FontId::proportional(14.0);
-        let galley = ui
-            .painter()
-            .layout_no_wrap(label, font_id, self.tab_text_color);
+        let galley = label.into_galley(ui, None, 14.0, TextStyle::Button);
 
         let offset = vec2(8.0, 0.0);
         let text_size = galley.size();
@@ -202,7 +196,7 @@ impl Style {
             .anchor_rect(rect.shrink2(vec2(8.0, 5.0)))
             .min;
 
-        ui.painter().galley(pos, galley);
+        ui.painter().galley(pos, galley.galley);
 
         response
     }
@@ -273,13 +267,6 @@ impl StyleBuilder {
     #[inline(always)]
     pub fn with_tab_bar_background(mut self, tab_bar_background_color: Color32) -> Self {
         self.style.tab_bar_background_color = tab_bar_background_color;
-        self
-    }
-
-    /// Sets `tab_text_color` for the tab's text color. By `Default` it's [`Color32::BLACK`].
-    #[inline(always)]
-    pub fn with_tab_text_color(mut self, tab_text_color: Color32) -> Self {
-        self.style.tab_text_color = tab_text_color;
         self
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -3,13 +3,14 @@ use egui::style::Margin;
 use egui::*;
 
 /// Specifies the look and feel of egui_dock.
+#[derive(Clone)]
 pub struct Style {
     pub padding: Option<Margin>,
 
     pub border_color: Color32,
-    pub border_size: f32,
+    pub border_width: f32,
     pub selection_color: Color32,
-    pub separator_size: f32,
+    pub separator_width: f32,
     pub separator_extra: f32,
     pub separator_color: Color32,
 
@@ -27,10 +28,10 @@ impl Default for Style {
             padding: Default::default(),
 
             border_color: Color32::BLACK,
-            border_size: Default::default(),
+            border_width: Default::default(),
 
             selection_color: Color32::from_rgb(0, 191, 255).linear_multiply(0.5),
-            separator_size: 1.0,
+            separator_width: 1.0,
             separator_extra: 175.0,
             separator_color: Color32::BLACK,
 
@@ -71,8 +72,8 @@ impl Style {
         let mut separator = rect;
 
         let midpoint = rect.min.x + rect.width() * *fraction;
-        separator.min.x = midpoint - self.separator_size * 0.5;
-        separator.max.x = midpoint + self.separator_size * 0.5;
+        separator.min.x = midpoint - self.separator_width * 0.5;
+        separator.max.x = midpoint + self.separator_width * 0.5;
 
         let response = ui
             .allocate_rect(separator, Sense::click_and_drag())
@@ -89,12 +90,12 @@ impl Style {
 
         let midpoint = rect.min.x + rect.width() * *fraction;
         separator.min.x = map_to_pixel(
-            midpoint - self.separator_size * 0.5,
+            midpoint - self.separator_width * 0.5,
             pixels_per_point,
             f32::round,
         );
         separator.max.x = map_to_pixel(
-            midpoint + self.separator_size * 0.5,
+            midpoint + self.separator_width * 0.5,
             pixels_per_point,
             f32::round,
         );
@@ -112,8 +113,8 @@ impl Style {
         let mut separator = rect;
 
         let midpoint = rect.min.y + rect.height() * *fraction;
-        separator.min.y = midpoint - self.separator_size * 0.5;
-        separator.max.y = midpoint + self.separator_size * 0.5;
+        separator.min.y = midpoint - self.separator_width * 0.5;
+        separator.max.y = midpoint + self.separator_width * 0.5;
 
         let response = ui
             .allocate_rect(separator, Sense::click_and_drag())
@@ -130,12 +131,12 @@ impl Style {
 
         let midpoint = rect.min.y + rect.height() * *fraction;
         separator.min.y = map_to_pixel(
-            midpoint - self.separator_size * 0.5,
+            midpoint - self.separator_width * 0.5,
             pixels_per_point,
             f32::round,
         );
         separator.max.y = map_to_pixel(
-            midpoint + self.separator_size * 0.5,
+            midpoint + self.separator_width * 0.5,
             pixels_per_point,
             f32::round,
         );
@@ -162,7 +163,7 @@ impl Style {
             .painter()
             .layout_no_wrap(label, font_id, self.tab_text_color);
 
-        let offset = egui::vec2(8.0, 0.0);
+        let offset = vec2(8.0, 0.0);
         let text_size = galley.size();
 
         let mut desired_size = text_size + offset * 2.0;
@@ -225,7 +226,7 @@ impl StyleBuilder {
         self
     }
 
-    /// Sets `border_color` for the  window of "working area". By `Default` it's [`egui::Color32::BLACK`].
+    /// Sets `border_color` for the window of "working area". By `Default` it's [`egui::Color32::BLACK`].
     #[inline(always)]
     pub fn with_border_color(mut self, border_color: Color32) -> Self {
         self.style.border_color = border_color;
@@ -235,7 +236,7 @@ impl StyleBuilder {
     /// Sets `border_width` for the border. By `Default` it's `0.0`.
     #[inline(always)]
     pub fn with_border_width(mut self, border_width: f32) -> Self {
-        self.style.border_size = border_width;
+        self.style.border_width = border_width;
         self
     }
 
@@ -246,15 +247,15 @@ impl StyleBuilder {
         self
     }
 
-    /// Sets `separator_size` for the rectange separator between nodes. By `Default` it's `1.0`.
+    /// Sets `separator_size` for the rectangle separator between nodes. By `Default` it's `1.0`.
     #[inline(always)]
-    pub fn with_separator_size(mut self, separator_size: f32) -> Self {
-        self.style.separator_size = separator_size;
+    pub fn with_separator_width(mut self, separator_width: f32) -> Self {
+        self.style.separator_width = separator_width;
         self
     }
 
     /// Sets `separator_extra` it sets limit for the allowed area for the separator offset. By `Default` it's `175.0`.
-    /// `bigger value > less allowed offset` for the current widnow size.  
+    /// `bigger value > less allowed offset` for the current window size.
     #[inline(always)]
     pub fn with_separator_extra(mut self, separator_extra: f32) -> Self {
         self.style.separator_extra = separator_extra;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -54,7 +54,7 @@ impl WithTitle<RichText> for TabBuilder {
 
 impl WithTitle<WidgetText> for TabBuilder {
     fn title(mut self, title: WidgetText) -> Self {
-        self.title = Some(title.into());
+        self.title = Some(title);
         self
     }
 }
@@ -66,7 +66,7 @@ impl TabBuilder {
     /// Panics if `title` or `add_contents` is unset.
     pub fn build(self) -> Tab {
         Tab {
-            title: self.title.expect("Missing tab title").into(),
+            title: self.title.expect("Missing tab title"),
             inner_margin: self.inner_margin,
             add_content: self.add_content.expect("Missing tab content"),
         }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -27,6 +27,10 @@ impl Default for TabBuilder {
 }
 
 impl TabBuilder {
+    /// Constructs a `Tab` out of accumulated data.
+    ///
+    /// # Panics
+    /// Panics if `title` or `add_contents` is unset.
     pub fn build(self) -> Tab {
         Tab {
             title: self.title.expect("Missing tab title"),

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1,46 +1,64 @@
-use std::any::Any;
-use egui::Ui;
+use egui::style::Margin;
+use egui::{Frame, Ui};
 
-/// Implement this trait to use your widget as a dockable tab in `Tree`s.
-pub trait Tab<Context>: Send + Sync + TabDowncast {
-    /// Returns text displayed in the tab bar.
-    fn title(&self) -> &str;
+pub type TabContent = Box<dyn FnMut(&mut Ui) + 'static>;
 
+pub struct TabBuilder {
+    title: Option<String>,
+    inner_margin: Margin,
+    add_content: Option<TabContent>,
+}
+
+/// Dockable tab that can be used in `Tree`s.
+pub struct Tab {
+    pub title: String,
+    pub inner_margin: Margin,
+    pub add_content: TabContent,
+}
+
+impl Default for TabBuilder {
+    fn default() -> Self {
+        Self {
+            title: None,
+            inner_margin: Margin::same(4.0),
+            add_content: None,
+        }
+    }
+}
+
+impl TabBuilder {
+    pub fn build(self) -> Tab {
+        Tab {
+            title: self.title.expect("Missing tab title"),
+            inner_margin: self.inner_margin,
+            add_content: self.add_content.expect("Missing tab content"),
+        }
+    }
+
+    /// Sets the text displayed in the tab bar.
+    pub fn title(mut self, title: impl ToString) -> Self {
+        self.title = Some(title.to_string());
+        self
+    }
+
+    /// Sets the margins around the tab's content.
+    pub fn inner_margin(mut self, margin: Margin) -> Self {
+        self.inner_margin = margin;
+        self
+    }
+
+    /// Sets the function that adds content to the tab.
+    pub fn content(mut self, add_content: impl FnMut(&mut Ui) + 'static) -> Self {
+        self.add_content = Some(Box::new(add_content));
+        self
+    }
+}
+
+impl Tab {
     /// Displays the tab's content.
-    fn ui(&mut self, ui: &mut Ui, ctx: &mut Context);
-}
-
-pub trait TabDowncast {
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
-impl<T: Any> TabDowncast for T {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-}
-
-impl<Context> dyn Tab<Context> {
-    /// Returns true if the trait object wraps an object of type `T`.
-    #[inline]
-    pub fn is<T: Tab<Context> + 'static>(&self) -> bool {
-        TabDowncast::as_any(self).is::<T>()
-    }
-
-    /// Returns a reference to the object within the trait object if it is of type `T`, or `None` if it isn't.
-    #[inline]
-    pub fn downcast_ref<T: Tab<Context> + 'static>(&self) -> Option<&T> {
-        TabDowncast::as_any(self).downcast_ref::<T>()
-    }
-
-    /// Returns a mutable reference to the object within the trait object if it is of type `T`, or `None` if it isn't.
-    #[inline]
-    pub fn downcast_mut<T: Tab<Context> + 'static>(&mut self) -> Option<&mut T> {
-        TabDowncast::as_any_mut(self).downcast_mut::<T>()
+    pub fn ui(&mut self, ui: &mut Ui) {
+        Frame::none()
+            .inner_margin(self.inner_margin)
+            .show(ui, |ui| (self.add_content)(ui));
     }
 }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1,5 +1,5 @@
 use egui::style::Margin;
-use egui::{Frame, Ui};
+use egui::{Frame, ScrollArea, Ui};
 
 pub type TabContent = Box<dyn FnMut(&mut Ui) + 'static>;
 
@@ -63,6 +63,14 @@ impl Tab {
     pub fn ui(&mut self, ui: &mut Ui) {
         Frame::none()
             .inner_margin(self.inner_margin)
-            .show(ui, |ui| (self.add_content)(ui));
+            .show(ui, |ui| {
+                ScrollArea::both()
+                    .id_source(self.title.clone() + " - egui_dock::Tab")
+                    .show_viewport(ui, |ui, viewport| {
+                        let available_rect = ui.available_rect_before_wrap();
+                        ui.expand_to_include_rect(available_rect);
+                        (self.add_content)(ui);
+                    });
+            });
     }
 }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -88,11 +88,11 @@ impl TabBuilder {
 impl Tab {
     /// Displays the tab's content.
     pub fn ui(&mut self, ui: &mut Ui) {
-        Frame::none()
-            .inner_margin(self.inner_margin)
+        ScrollArea::both()
+            .id_source(self.title.text().to_string() + " - egui_dock::Tab")
             .show(ui, |ui| {
-                ScrollArea::both()
-                    .id_source(self.title.text().to_string() + " - egui_dock::Tab")
+                Frame::none()
+                    .inner_margin(self.inner_margin)
                     .show(ui, |ui| {
                         let available_rect = ui.available_rect_before_wrap();
                         ui.expand_to_include_rect(available_rect);


### PR DESCRIPTION
`Tab` is no longer a trait which the user has to implement on their own custom widget. A context type is also no longer required.

This makes creating trees easier without limiting customizability.

Example:

```rust
// Initial tree setup
let tab1 = TabBuilder::default()
    .title("Tab 1")
    .content(|ui| {
        ui.label("Tab 1");
    })
    .build();
let tab2 = TabBuilder::default()
    .title("Tab 2")
    .inner_margin(Margin::same(4.0))
    .content(|ui| {
        ui.label("Tab 2");
    })
    .build();
let mut tree = Tree::new(vec![tab1, tab2]);

// Then, in your app's `update` function:
egui_dock::show(&mut ui, id, &style, &mut tree)
```

Part of this PR is closing #1 and #5