### PR TITLE
Replace `WithTitle` trait with `impl Into<WidgetText>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/Adanos020/egui_dock"
 categories = ["gui", "game-development"]
 
 [dependencies]
-egui = "0.18"
+egui = "0.19"
 
 [dev-dependencies]
-eframe = "0.18"
+eframe = "0.19"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,7 +3,7 @@
 use eframe::{egui, NativeOptions};
 use egui::color_picker::{color_picker_color32, Alpha};
 use egui::{Color32, Id, LayerId, RichText, Slider, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree, WithTitle};
+use egui_dock::{NodeIndex, Style, TabBuilder, Tree};
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 use eframe::{egui, NativeOptions};
 use egui::{Id, LayerId, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree, WithTitle};
+use egui_dock::{NodeIndex, Style, TabBuilder, Tree};
 
 fn main() {
     let options = NativeOptions::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust
 //! use egui::{Color32, RichText, style::Margin};
-//! use egui_dock::{TabBuilder, Tree, WithTitle};
+//! use egui_dock::{TabBuilder, Tree};
 //!
 //! let tab1 = TabBuilder::default()
 //!     .title(RichText::new("Tab 1").color(Color32::BLUE))
@@ -39,17 +39,18 @@
 //! # });
 //! ```
 
+use egui::*;
+
+pub use style::{Style, StyleBuilder};
+use utils::*;
+
+pub use self::tab::{Tab, TabBuilder};
+pub use self::tree::{Node, NodeIndex, Split, Tree};
+
 mod style;
 mod tab;
 mod tree;
 mod utils;
-
-pub use self::tab::{Tab, TabBuilder, WithTitle};
-pub use self::tree::{Node, NodeIndex, Split, Tree};
-pub use style::{Style, StyleBuilder};
-
-use egui::*;
-use utils::*;
 
 struct HoverData {
     rect: Rect,

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1,5 +1,5 @@
 use egui::style::Margin;
-use egui::{Frame, RichText, ScrollArea, Ui, WidgetText};
+use egui::{Frame, ScrollArea, Ui, WidgetText};
 
 pub type TabContent = Box<dyn FnMut(&mut Ui) + 'static>;
 
@@ -7,11 +7,6 @@ pub struct TabBuilder {
     title: Option<WidgetText>,
     inner_margin: Margin,
     add_content: Option<TabContent>,
-}
-
-pub trait WithTitle<TextType> {
-    /// Sets the text displayed in the tab bar.
-    fn title(self, title: TextType) -> Self;
 }
 
 /// Dockable tab that can be used in `Tree`s.
@@ -31,34 +26,6 @@ impl Default for TabBuilder {
     }
 }
 
-impl WithTitle<String> for TabBuilder {
-    fn title(mut self, title: String) -> Self {
-        self.title = Some(RichText::new(title).strong().into());
-        self
-    }
-}
-
-impl WithTitle<&'static str> for TabBuilder {
-    fn title(mut self, title: &'static str) -> Self {
-        self.title = Some(RichText::new(title).strong().into());
-        self
-    }
-}
-
-impl WithTitle<RichText> for TabBuilder {
-    fn title(mut self, title: RichText) -> Self {
-        self.title = Some(title.into());
-        self
-    }
-}
-
-impl WithTitle<WidgetText> for TabBuilder {
-    fn title(mut self, title: WidgetText) -> Self {
-        self.title = Some(title);
-        self
-    }
-}
-
 impl TabBuilder {
     /// Constructs a `Tab` out of accumulated data.
     ///
@@ -70,6 +37,12 @@ impl TabBuilder {
             inner_margin: self.inner_margin,
             add_content: self.add_content.expect("Missing tab content"),
         }
+    }
+
+    /// Sets the text displayed in the tab bar.
+    pub fn title(mut self, title: impl Into<WidgetText>) -> Self {
+        self.title = Some(title.into());
+        self
     }
 
     /// Sets the margins around the tab's content.


### PR DESCRIPTION
The `WithTitle` trait is redundant since `WidgetText` already implements `From` for various types.

This PR also bumps egui to the latest version (0.18 -> 0.19).