### PR TITLE
Added the ability to close tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@
 - When dragging tabs onto the tab bar if the tab will be inserted a highlighted region will show where the tab will end up if dropped.
 - The dock will keep track of the currently focused leaf.
 - Using `push_to_active_leaf` will push the given tab to the currently active leaf.
-- Fix to prevent Id clashes from multiple tabs being displayed at once.
 - `StyleBuilder` for the `Style`
 - New fields in `Style:` `separator_color`, `border_color`, and `border_size` (last two for the cases when used `Margin`)
-- `TabBuilder` for the `Tab`
+- `TabBuilder` for the `BuiltTab`
 - Support for all implementations of `Into<WidgetText>` in tab titles
 - Style editor in the `hello` example
 
@@ -32,3 +31,4 @@
 
 - Now selection color of the placing area for the tab isn't showing if the tab is targeted on its own node when the tab is the only member of  this node
 - Dock vertical and horizontal separators are now displayed properly
+- Prevent Id clashes from multiple tabs being displayed at once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Added
 
+- It is now possible to close tabs with a close button that can be shown/hidden through `Style`
+- When dragging tabs onto the tab bar if the tab will be inserted a highlighted region will show where the tab will end up if dropped.
+- The dock will keep track of the currently focused leaf.
+- Using `push_to_active_leaf` will push the given tab to the currently active leaf.
+- Fix to prevent Id clashes from multiple tabs being displayed at once.
 - `StyleBuilder` for the `Style`
 - New fields in `Style:` `separator_color`, `border_color`, and `border_size` (last two for the cases when used `Margin`)
 - `TabBuilder` for the `Tab`
@@ -10,12 +15,14 @@
 
 ## Changed
 
+- If a tab is dropped onto the tab bar it will be inserted into the index that it is dropped onto.
 - Now when you drag a tab it has an outline along the entire length of the edges of it
 - Bumped MSRV to `1.62`
 
 ## Breaking changes
 
-- `Tab` is no longer a trait for the user to implement, instead it is now a customizable widget constructed with `TabBuilder`
+- Ui code of the dock has been moved into `DockArea` and is displayed with `DockArea::show`
+- `Tree` cannot be directly accessed through `DockArea`
 - Renamed `Style::border_size` to `Style::border_width`
 - Renamed `Style::separator_size` to `Style::separator_width`
 - Removed `Style::tab_text_color` as you can now set the tab text color of a tab by passing `RichText` for its title
@@ -24,3 +31,4 @@
 ## Fixed
 
 - Now selection color of the placing area for the tab isn't showing if the tab is targeted on its own node when the tab is the only member of  this node
+- Dock vertical and horizontal separators are now displayed properly

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This fork aims to provide documentation and further development if necessary.
 
 ## Usage
 
-First, construct the initial tree:
+First, construct the initial dock:
 
 ```rust
 use egui::{Color32, RichText, style::Margin};
-use egui_dock::{TabBuilder, Tree};
+use egui_dock::{TabBuilder, Tree, DockArea};
 
 let tab1 = TabBuilder::default()
     .title(RichText::new("Tab 1").color(Color32::BLUE))
@@ -34,15 +34,15 @@ let tab2 = TabBuilder::default()
     })
     .build();
 
-let mut tree = Tree::new(vec![tab1, tab2]);
+let mut dock = DockArea::from_tabs(vec![tab1, tab2]);
 ```
 
-Then, you can show the tree.
+Then, you can show the dock.
 
 ```rust
 let style = egui_dock::Style::default();
 let id = ui.id();
-egui_dock::show(&mut ui, id, &style, &mut tree);
+dock.show(ui, id, &style);
 ```
 
 ## Contribution

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,7 +3,7 @@
 use eframe::{egui, NativeOptions};
 use egui::color_picker::{color_picker_color32, Alpha};
 use egui::{Color32, Id, LayerId, RichText, Slider, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree, DockArea};
+use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,7 +3,7 @@
 use eframe::{egui, NativeOptions};
 use egui::color_picker::{color_picker_color32, Alpha};
 use egui::{Color32, Id, LayerId, RichText, Slider, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree};
+use egui_dock::{NodeIndex, Style, TabBuilder, Tree, DockArea};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -25,7 +25,7 @@ struct MyContext {
 struct MyApp {
     _context: Rc<RefCell<MyContext>>,
     style: Rc<RefCell<Style>>,
-    tree: Tree,
+    dock: DockArea,
 }
 
 impl Default for MyApp {
@@ -171,7 +171,7 @@ impl Default for MyApp {
         Self {
             style,
             _context: context,
-            tree,
+            dock: DockArea::from_tree(tree),
         }
     }
 }
@@ -186,6 +186,6 @@ impl eframe::App for MyApp {
         let clip_rect = ctx.available_rect();
 
         let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
-        egui_dock::show(&mut ui, id, &style, &mut self.tree)
+        self.dock.show(&mut ui, id, &style)
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 use eframe::{egui, NativeOptions};
 use egui::{Id, LayerId, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree};
+use egui_dock::{NodeIndex, Style, TabBuilder, Tree, DockArea};
 
 fn main() {
     let options = NativeOptions::default();
@@ -15,7 +15,7 @@ fn main() {
 
 struct MyApp {
     style: Style,
-    tree: Tree,
+    dock: DockArea,
 }
 
 impl Default for MyApp {
@@ -60,7 +60,7 @@ impl Default for MyApp {
 
         Self {
             style: Style::default(),
-            tree,
+            dock: DockArea::from_tree(tree),
         }
     }
 }
@@ -75,6 +75,6 @@ impl eframe::App for MyApp {
         let clip_rect = ctx.available_rect();
 
         let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
-        egui_dock::show(&mut ui, id, &self.style, &mut self.tree)
+        self.dock.show(&mut ui, id, &self.style)
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 use eframe::{egui, NativeOptions};
 use egui::{Id, LayerId, Ui};
-use egui_dock::{NodeIndex, Style, TabBuilder, Tree, DockArea};
+use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
 
 fn main() {
     let options = NativeOptions::default();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -53,7 +53,7 @@ impl Default for MyApp {
 
         let mut tree = Tree::new(vec![tab1, tab2]);
 
-        // You can modify the tree in runtime
+        // You can modify the tree before constructing the dock
         let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![tab3]);
         let [_, _] = tree.split_below(a, 0.7, vec![tab4]);
         let [_, _] = tree.split_below(b, 0.5, vec![tab5]);

--- a/examples/traits.rs
+++ b/examples/traits.rs
@@ -1,0 +1,195 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use eframe::{egui, NativeOptions};
+use egui::{
+    style::Margin, text::LayoutJob, Align, Color32, FontId, Frame, Id, LayerId, TextFormat, Ui,
+    Window,
+};
+use egui_dock::{DockArea, NodeIndex, Style, Tab, TabBuilder, Tree};
+
+fn main() {
+    let options = NativeOptions::default();
+    eframe::run_native(
+        "My egui App",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
+    );
+}
+
+struct MyApp {
+    style: Style,
+    dock: DockArea,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        let tab1 = Box::new(Editor::new("Text".into()));
+
+        let tab2 = TabBuilder::default()
+            .title("Tab 2")
+            .content(|ui| {
+                ui.label("Tab 2");
+            })
+            .build();
+        let tab3 = TabBuilder::default()
+            .title("Tab 3")
+            .content(|ui| {
+                ui.label("Tab 3");
+            })
+            .build();
+        let tab4 = TabBuilder::default()
+            .title("Tab 4")
+            .content(|ui| {
+                ui.label("Tab 4");
+            })
+            .build();
+        let tab5 = TabBuilder::default()
+            .title("Tab 5")
+            .content(|ui| {
+                ui.label("Tab 5");
+            })
+            .build();
+
+        let mut tree = Tree::new(vec![tab1, tab2]);
+
+        // You can modify the tree before constructing the dock
+        let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![tab3]);
+        let [_, _] = tree.split_below(a, 0.7, vec![tab4]);
+        let [_, _] = tree.split_below(b, 0.5, vec![tab5]);
+
+        Self {
+            style: Style::default(),
+            dock: DockArea::from_tree(tree),
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.style = Style::from_egui(ctx.style().as_ref());
+
+        let id = Id::new("some hashable string");
+        let layer_id = LayerId::background();
+        let max_rect = ctx.available_rect();
+        let clip_rect = ctx.available_rect();
+
+        let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
+        Frame::none()
+            .inner_margin(Margin::same(2.0))
+            .show(&mut ui, |ui| {
+                if ui.button("Add Editor").clicked() {
+                    self.dock
+                        .push_to_active_leaf(Editor::new("New Text".into()));
+                }
+            });
+        ui.separator();
+        Frame::none().show(&mut ui, |ui| self.dock.show(ui, id, &self.style));
+    }
+}
+
+struct Editor {
+    name: String,
+    modified: bool,
+    text: String,
+    show_save: bool,
+    exit: bool,
+}
+
+impl Editor {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            modified: false,
+            text: "Important text to edit".into(),
+            show_save: false,
+            exit: false,
+        }
+    }
+
+    fn save(&mut self) {
+        self.modified = false;
+        //save text to file or someplace else
+    }
+}
+
+impl Tab for Editor {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        if self.show_save {
+            Window::new("Save")
+                .collapsible(false)
+                .collapsible(false)
+                .show(ui.ctx(), |ui| {
+                    ui.vertical(|ui| {
+                        ui.label(format!(
+                            "You have unsaved work on {} would you like to save",
+                            self.name
+                        ));
+                        ui.horizontal(|ui| {
+                            if ui.button("Save").clicked() {
+                                self.save();
+                                self.exit = true;
+                                self.show_save = false;
+                            }
+                            if ui.button("Don't Save").clicked() {
+                                self.exit = true;
+                                self.show_save = false;
+                            }
+                            if ui.button("Cancel").clicked() {
+                                self.exit = false;
+                                self.show_save = false;
+                            }
+                        });
+                    });
+                });
+        }
+        Frame::none()
+            .inner_margin(Margin::same(2.0))
+            .show(ui, |ui| {
+                ui.vertical(|ui| {
+                    ui.horizontal(|ui| {
+                        if ui.button("Save").clicked() {
+                            self.save();
+                        }
+                    });
+                    if ui.code_editor(&mut self.text).changed() {
+                        self.modified = true;
+                    }
+                });
+            });
+    }
+
+    fn title(&mut self) -> egui::WidgetText {
+        if self.modified {
+            let mut job = LayoutJob::default();
+            job.append(
+                self.name.as_str(),
+                0.0,
+                TextFormat::simple(FontId::default(), Color32::from_rgb(245, 245, 67)),
+            );
+
+            job.append(
+                " M",
+                0.0,
+                TextFormat {
+                    font_id: FontId::proportional(FontId::default().size / 1.5),
+                    color: Color32::from_rgb(245, 245, 67),
+                    valign: Align::Min,
+                    ..Default::default()
+                },
+            );
+
+            job.into()
+        } else {
+            self.name.clone().into()
+        }
+    }
+
+    fn force_close(&mut self) -> bool {
+        self.exit
+    }
+
+    fn on_close(&mut self) -> bool {
+        self.show_save = true;
+        self.exit || !self.modified
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,6 @@ impl DockArea {
 
         let focused = tree.focused_leaf();
 
-        //let mut removed = false;
         let mut to_remove = Vec::new();
         let mut new_focused = None;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,12 +300,9 @@ impl DockArea{
                                             is_active, 
                                             is_being_dragged, 
                                             id);
-                                    let sense;
-                                    if response.1{
-                                        sense = Sense::click();
-                                    }else{
-                                        sense = Sense::click_and_drag();
-                                    }
+                                    
+                                    let sense = if response.1 { Sense::click() } else { Sense::click_and_drag() };
+                                    
                                     if tab.force_close(){
                                         to_remove.push((tree_index, tab_index));
                                     }else if response.2{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,6 @@ impl DockArea{
                     let tabs_response = ui.allocate_rect(tabbar, Sense::hover());
                     let mut tab_hover_rect = Option::None;
 
-                    //let mut to_remove = None;
                     // tabs
                     ui.scope(|ui| {
                         ui.painter().rect_filled(
@@ -363,16 +362,6 @@ impl DockArea{
                             pointer,
                         });
                     }
-
-                    // if let Option::Some(to_remove) = to_remove{
-                    //     if tabs[to_remove].on_close(){
-                    //         tabs.remove(to_remove);
-                    //         if to_remove <= *active{
-                    //             *active = active.checked_sub(1).unwrap_or(0);
-                    //         }
-                    //         removed = true;
-                    //     }
-                    // }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@
 //! Then you can show the dock.
 //!
 //! ```rust
-//! # use egui_dock::DockArea;
+//! # use egui_dock::{DockArea, Style};
 //! # egui::__run_test_ui(|ui| {
 //! # let mut dock = DockArea::new_empty();
-//! let style = egui_dock::Style::default();
+//! let style = Style::default();
 //! let id = ui.id();
 //! dock.show(ui, id, &style);
 //! # });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ struct HoverData {
 
 impl HoverData {
     fn resolve(&self) -> (Option<Split>, Rect, Option<usize>) {
-        if let Some(tab) = self.tab{
+        if let Some(tab) = self.tab {
             return (None, tab.0, Some(tab.1));
         }
         if let Some(tabs) = self.tabs {
@@ -117,30 +117,35 @@ impl State {
 }
 
 #[derive(Default)]
-pub struct DockArea{
-    tree: Tree
+pub struct DockArea {
+    tree: Tree,
 }
 
-impl DockArea{
-
-    pub fn from_tree(tree: Tree) -> Self{
+impl DockArea {
+    pub fn from_tree(tree: Tree) -> Self {
         Self { tree }
     }
-    pub fn from_tabs(tabs: Vec<Box<dyn Tab>>) -> Self{
-        Self { tree: Tree::new(tabs) }
+    pub fn from_tabs(tabs: Vec<Box<dyn Tab>>) -> Self {
+        Self {
+            tree: Tree::new(tabs),
+        }
     }
-    pub fn from_tab(tab: Box<dyn Tab>) -> Self{
-        Self { tree: Tree::new(vec![tab]) }
+    pub fn from_tab(tab: Box<dyn Tab>) -> Self {
+        Self {
+            tree: Tree::new(vec![tab]),
+        }
     }
-    pub fn new_empty() -> Self{
-        Self { tree: Tree::default() }
+    pub fn new_empty() -> Self {
+        Self {
+            tree: Tree::default(),
+        }
     }
 
-    pub fn is_empty(&self) -> bool{
+    pub fn is_empty(&self) -> bool {
         self.tree.is_empty()
     }
 
-    pub fn push_to_active_leaf(&mut self, tab: impl Tab + 'static){
+    pub fn push_to_active_leaf(&mut self, tab: impl Tab + 'static) {
         self.tree.push_to_focused_leaf(Box::new(tab))
     }
 
@@ -160,8 +165,8 @@ impl DockArea{
                 Stroke::new(margin.top, style.border_color),
             );
         }
-        
-        if tree.is_empty(){
+
+        if tree.is_empty() {
             ui.allocate_rect(rect, Sense::hover());
             return;
         }
@@ -182,7 +187,7 @@ impl DockArea{
 
         for tree_index in 0..tree.len() {
             let tree_index = NodeIndex(tree_index);
-            
+
             match &mut tree[tree_index] {
                 Node::None => (),
                 Node::Horizontal { fraction, rect } => {
@@ -190,7 +195,8 @@ impl DockArea{
 
                     let (left, separator, right) = style.hsplit(ui, fraction, rect);
 
-                    ui.painter().rect_filled(separator, Rounding::none(), style.separator_color);
+                    ui.painter()
+                        .rect_filled(separator, Rounding::none(), style.separator_color);
 
                     tree[tree_index.left()].set_rect(left);
                     tree[tree_index.right()].set_rect(right);
@@ -200,7 +206,8 @@ impl DockArea{
 
                     let (bottom, separator, top) = style.vsplit(ui, fraction, rect);
 
-                    ui.painter().rect_filled(separator, Rounding::none(), style.separator_color);
+                    ui.painter()
+                        .rect_filled(separator, Rounding::none(), style.separator_color);
 
                     tree[tree_index.left()].set_rect(bottom);
                     tree[tree_index.right()].set_rect(top);
@@ -240,7 +247,6 @@ impl DockArea{
                         ui.spacing_mut().item_spacing = vec2(0.0, 0.0);
 
                         ui.horizontal(|ui| {
-                            
                             for (tab_index, tab) in tabs.iter_mut().enumerate() {
                                 let id = Id::new((tree_index, tab_index, "tab"));
                                 let is_being_dragged = ui.memory().is_being_dragged(id);
@@ -286,27 +292,31 @@ impl DockArea{
                                     }
                                     if state.drag_start.is_some() {
                                         if let Some(pos) = ui.input().pointer.hover_pos() {
-                                            if response.rect.contains(pos){
+                                            if response.rect.contains(pos) {
                                                 tab_hover_rect = Some((response.rect, tab_index));
                                             }
                                         }
                                     }
                                 } else {
-                                    let response =
-                                        style.tab_title(
-                                            ui, 
-                                            label,  
-                                            is_active && Some(tree_index) == focused, 
-                                            is_active, 
-                                            is_being_dragged, 
-                                            id);
-                                    
-                                    let sense = if response.1 { Sense::click() } else { Sense::click_and_drag() };
-                                    
-                                    if tab.force_close(){
+                                    let response = style.tab_title(
+                                        ui,
+                                        label,
+                                        is_active && Some(tree_index) == focused,
+                                        is_active,
+                                        is_being_dragged,
+                                        id,
+                                    );
+
+                                    let sense = if response.1 {
+                                        Sense::click()
+                                    } else {
+                                        Sense::click_and_drag()
+                                    };
+
+                                    if tab.force_close() {
                                         to_remove.push((tree_index, tab_index));
-                                    }else if response.2{
-                                        if tab.on_close(){
+                                    } else if response.2 {
+                                        if tab.on_close() {
                                             to_remove.push((tree_index, tab_index));
                                         }
                                     }
@@ -314,10 +324,10 @@ impl DockArea{
                                     if response.drag_started() {
                                         state.drag_start = response.hover_pos();
                                     }
-                                    
+
                                     if state.drag_start.is_some() {
                                         if let Some(pos) = ui.input().pointer.hover_pos() {
-                                            if response.rect.contains(pos){
+                                            if response.rect.contains(pos) {
                                                 tab_hover_rect = Some((response.rect, tab_index));
                                             }
                                         }
@@ -335,9 +345,9 @@ impl DockArea{
 
                         *viewport = rect;
 
-                        if ui.input().pointer.any_click(){
-                            if let Some(pos) = ui.input().pointer.hover_pos(){
-                                if rect.contains(pos){
+                        if ui.input().pointer.any_click() {
+                            if let Some(pos) = ui.input().pointer.hover_pos() {
+                                if rect.contains(pos) {
                                     new_focused = Some(tree_index);
                                 }
                             }
@@ -365,28 +375,28 @@ impl DockArea{
         }
         let mut emptied = 0;
         let mut last = (NodeIndex(usize::MAX), usize::MAX);
-        for remove in to_remove.iter().rev(){
-            if let Node::Leaf{ tabs, active, .. } = &mut tree[remove.0]{
+        for remove in to_remove.iter().rev() {
+            if let Node::Leaf { tabs, active, .. } = &mut tree[remove.0] {
                 tabs.remove(remove.1);
-                if remove.1 <= *active{
+                if remove.1 <= *active {
                     *active = active.checked_sub(1).unwrap_or(0);
                 }
-                if tabs.is_empty(){
+                if tabs.is_empty() {
                     emptied += 1;
                 }
-                if last.0 == remove.0{
+                if last.0 == remove.0 {
                     assert!(last.1 > remove.1)
                 }
                 last = *remove;
-            }else{
+            } else {
                 panic!();
             }
         }
-        for _ in 0..emptied{
+        for _ in 0..emptied {
             tree.remove_empty_leaf()
         }
-        
-        if let Some(focused) = new_focused{
+
+        if let Some(focused) = new_focused {
             tree.set_focused(focused);
         }
 
@@ -416,9 +426,9 @@ impl DockArea{
                     if let Some(target) = target {
                         tree.split(dst, target, 0.5, Node::leaf(tab));
                     } else {
-                        if let Some(index) = tap_pos{
+                        if let Some(index) = tap_pos {
                             tree[dst].insert_tab(index, tab);
-                        }else{
+                        } else {
                             tree[dst].append_tab(tab);
                         }
                         tree.set_focused(dst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,16 +26,17 @@
 //!     })
 //!     .build();
 //! let mut tree = Tree::new(vec![tab1, tab2]);
+//! let mut dock = Dock::from_tree(tree);
 //! ```
 //!
 //! Then you can show the tree.
 //!
 //! ```rust
 //! # egui::__run_test_ui(|ui| {
-//! # let mut tree = egui_dock::Tree::new(vec![]);
+//! # let mut dock = egui_dock::DockArea::new_empty();
 //! let style = egui_dock::Style::default();
 //! let id = ui.id();
-//! egui_dock::show(ui, id, &style, &mut tree);
+//! dock.show(ui, id, &style);
 //! # });
 //! ```
 
@@ -140,7 +141,7 @@ impl DockArea{
     }
 
     pub fn push_to_active_leaf(&mut self, tab: impl Tab + 'static){
-        self.tree.push_to_active_leaf(Box::new(tab))
+        self.tree.push_to_focused_leaf(Box::new(tab))
     }
 
     /// Shows the docking hierarchy inside a `Ui`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ struct HoverData {
 impl HoverData {
     fn resolve(&self) -> (Option<Split>, Rect, Option<usize>) {
         if let Some(tab) = self.tab{
-            return (None, tab.0, Option::Some(tab.1));
+            return (None, tab.0, Some(tab.1));
         }
         if let Some(tabs) = self.tabs {
             return (None, tabs, None);
@@ -221,7 +221,7 @@ impl DockArea{
 
                     let full_response = ui.allocate_rect(rect, Sense::hover());
                     let tabs_response = ui.allocate_rect(tabbar, Sense::hover());
-                    let mut tab_hover_rect = Option::None;
+                    let mut tab_hover_rect = None;
 
                     // tabs
                     ui.scope(|ui| {
@@ -256,7 +256,7 @@ impl DockArea{
                                                 ui,
                                                 label.clone(),
                                                 is_active,
-                                                is_active && Option::Some(tree_index) == focused,
+                                                is_active && Some(tree_index) == focused,
                                                 is_being_dragged,
                                                 id,
                                             )
@@ -282,12 +282,12 @@ impl DockArea{
 
                                     if response.clicked() {
                                         *active = tab_index;
-                                        new_focused = Option::Some(tree_index);
+                                        new_focused = Some(tree_index);
                                     }
                                     if state.drag_start.is_some() {
-                                        if let Option::Some(pos) = ui.input().pointer.hover_pos() {
+                                        if let Some(pos) = ui.input().pointer.hover_pos() {
                                             if response.rect.contains(pos){
-                                                tab_hover_rect = Option::Some((response.rect, tab_index));
+                                                tab_hover_rect = Some((response.rect, tab_index));
                                             }
                                         }
                                     }
@@ -296,7 +296,7 @@ impl DockArea{
                                         style.tab_title(
                                             ui, 
                                             label,  
-                                            is_active && Option::Some(tree_index) == focused, 
+                                            is_active && Some(tree_index) == focused, 
                                             is_active, 
                                             is_being_dragged, 
                                             id);
@@ -319,9 +319,9 @@ impl DockArea{
                                     }
                                     
                                     if state.drag_start.is_some() {
-                                        if let Option::Some(pos) = ui.input().pointer.hover_pos() {
+                                        if let Some(pos) = ui.input().pointer.hover_pos() {
                                             if response.rect.contains(pos){
-                                                tab_hover_rect = Option::Some((response.rect, tab_index));
+                                                tab_hover_rect = Some((response.rect, tab_index));
                                             }
                                         }
                                     }
@@ -339,9 +339,9 @@ impl DockArea{
                         *viewport = rect;
 
                         if ui.input().pointer.any_click(){
-                            if let Option::Some(pos) = ui.input().pointer.hover_pos(){
+                            if let Some(pos) = ui.input().pointer.hover_pos(){
                                 if rect.contains(pos){
-                                    new_focused = Option::Some(tree_index);
+                                    new_focused = Some(tree_index);
                                 }
                             }
                         }
@@ -389,7 +389,7 @@ impl DockArea{
             tree.remove_empty_leaf()
         }
         
-        if let Option::Some(focused) = new_focused{
+        if let Some(focused) = new_focused{
             tree.set_focused(focused);
         }
 
@@ -419,7 +419,7 @@ impl DockArea{
                     if let Some(target) = target {
                         tree.split(dst, target, 0.5, Node::leaf(tab));
                     } else {
-                        if let Option::Some(index) = tap_pos{
+                        if let Some(index) = tap_pos{
                             tree[dst].insert_tab(index, tab);
                         }else{
                             tree[dst].append_tab(tab);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,285 +115,340 @@ impl State {
     }
 }
 
-/// Shows the docking hierarchy inside a `Ui`.
-pub fn show(ui: &mut Ui, id: Id, style: &Style, tree: &mut Tree) {
-    let mut state = State::load(ui.ctx(), id);
-    let mut rect = ui.max_rect();
+#[derive(Default)]
+pub struct DockArea{
+    tree: Tree
+}
 
-    if let Some(margin) = style.padding {
-        rect.min += margin.left_top();
-        rect.max -= margin.right_bottom();
-        ui.painter().rect(
-            rect,
-            margin.top,
-            style.separator_color,
-            Stroke::new(margin.top, style.border_color),
-        );
+impl DockArea{
+
+    pub fn from_tree(tree: Tree) -> Self{
+        Self { tree }
     }
-    
-    if tree.is_empty(){
-        ui.allocate_rect(rect, Sense::hover());
-        return;
+    pub fn from_tabs(tabs: Vec<Box<dyn Tab>>) -> Self{
+        Self { tree: Tree::new(tabs) }
+    }
+    pub fn from_tab(tab: Box<dyn Tab>) -> Self{
+        Self { tree: Tree::new(vec![tab]) }
+    }
+    pub fn new_empty() -> Self{
+        Self { tree: Tree::default() }
     }
 
-    tree[NodeIndex::root()].set_rect(rect);
+    pub fn is_empty(&self) -> bool{
+        self.tree.is_empty()
+    }
 
-    let mut drag_data = None;
-    let mut hover_data = None;
+    pub fn push_to_active_leaf(&mut self, tab: impl Tab + 'static){
+        self.tree.push_to_active_leaf(Box::new(tab))
+    }
 
-    let pixels_per_point = ui.ctx().pixels_per_point();
-    let px = pixels_per_point.recip();
+    /// Shows the docking hierarchy inside a `Ui`.
+    pub fn show(&mut self, ui: &mut Ui, id: Id, style: &Style) {
+        let tree = &mut self.tree;
+        let mut state = State::load(ui.ctx(), id);
+        let mut rect = ui.max_rect();
 
-    let focused = tree.focused_leaf();
-
-    let mut removed = false;
-    let mut new_focused = None;
-
-    for tree_index in 0..tree.len() {
-        let tree_index = NodeIndex(tree_index);
-        
-        match &mut tree[tree_index] {
-            Node::None => (),
-            Node::Horizontal { fraction, rect } => {
-                let rect = expand_to_pixel(*rect, pixels_per_point);
-
-                let (left, separator, right) = style.hsplit(ui, fraction, rect);
-
-                ui.painter().rect_filled(separator, Rounding::none(), style.separator_color);
-
-                tree[tree_index.left()].set_rect(left);
-                tree[tree_index.right()].set_rect(right);
-            }
-            Node::Vertical { fraction, rect } => {
-                let rect = expand_to_pixel(*rect, pixels_per_point);
-
-                let (bottom, separator, top) = style.vsplit(ui, fraction, rect);
-
-                ui.painter().rect_filled(separator, Rounding::none(), style.separator_color);
-
-                tree[tree_index.left()].set_rect(bottom);
-                tree[tree_index.right()].set_rect(top);
-            }
-            Node::Leaf {
+        if let Some(margin) = style.padding {
+            rect.min += margin.left_top();
+            rect.max -= margin.right_bottom();
+            ui.painter().rect(
                 rect,
-                tabs,
-                active,
-                viewport,
-            } => {
-                let rect = *rect;
-                ui.set_clip_rect(rect);
+                margin.top,
+                style.separator_color,
+                Stroke::new(margin.top, style.border_color),
+            );
+        }
+        
+        if tree.is_empty(){
+            ui.allocate_rect(rect, Sense::hover());
+            return;
+        }
 
-                let height_topbar = 24.0;
+        tree[NodeIndex::root()].set_rect(rect);
 
-                let bottom_y = rect.min.y + height_topbar;
-                let tabbar = rect.intersect(Rect::everything_above(bottom_y));
+        let mut drag_data = None;
+        let mut hover_data = None;
 
-                let full_response = ui.allocate_rect(rect, Sense::hover());
-                let tabs_response = ui.allocate_rect(tabbar, Sense::hover());
-                let mut tab_hover_rect = Option::None;
+        let pixels_per_point = ui.ctx().pixels_per_point();
+        let px = pixels_per_point.recip();
 
-                let mut to_remove = None;
-                // tabs
-                ui.scope(|ui| {
-                    ui.painter().rect_filled(
-                        tabbar,
-                        style.tab_rounding,
-                        style.tab_bar_background_color,
-                    );
+        let focused = tree.focused_leaf();
 
-                    let a = pos2(tabbar.min.x, tabbar.max.y - px);
-                    let b = pos2(tabbar.max.x, tabbar.max.y - px);
-                    ui.painter()
-                        .line_segment([a, b], (px, style.tab_outline_color));
+        //let mut removed = false;
+        let mut to_remove = Vec::new();
+        let mut new_focused = None;
 
-                    let mut ui = ui.child_ui(tabbar, Default::default());
-                    ui.spacing_mut().item_spacing = vec2(0.0, 0.0);
+        for tree_index in 0..tree.len() {
+            let tree_index = NodeIndex(tree_index);
+            
+            match &mut tree[tree_index] {
+                Node::None => (),
+                Node::Horizontal { fraction, rect } => {
+                    let rect = expand_to_pixel(*rect, pixels_per_point);
 
-                    ui.horizontal(|ui| {
-                        
-                        for (tab_index, tab) in tabs.iter_mut().enumerate() {
-                            let id = Id::new((tree_index, tab_index, "tab"));
-                            let is_being_dragged = ui.memory().is_being_dragged(id);
+                    let (left, separator, right) = style.hsplit(ui, fraction, rect);
 
-                            let is_active = *active == tab_index || is_being_dragged;
-                            let label = tab.title();
+                    ui.painter().rect_filled(separator, Rounding::none(), style.separator_color);
 
-                            if is_being_dragged {
-                                let layer_id = LayerId::new(Order::Tooltip, id);
-                                let response = ui
-                                    .with_layer_id(layer_id, |ui| {
+                    tree[tree_index.left()].set_rect(left);
+                    tree[tree_index.right()].set_rect(right);
+                }
+                Node::Vertical { fraction, rect } => {
+                    let rect = expand_to_pixel(*rect, pixels_per_point);
+
+                    let (bottom, separator, top) = style.vsplit(ui, fraction, rect);
+
+                    ui.painter().rect_filled(separator, Rounding::none(), style.separator_color);
+
+                    tree[tree_index.left()].set_rect(bottom);
+                    tree[tree_index.right()].set_rect(top);
+                }
+                Node::Leaf {
+                    rect,
+                    tabs,
+                    active,
+                    viewport,
+                } => {
+                    let rect = *rect;
+                    ui.set_clip_rect(rect);
+
+                    let height_topbar = 24.0;
+
+                    let bottom_y = rect.min.y + height_topbar;
+                    let tabbar = rect.intersect(Rect::everything_above(bottom_y));
+
+                    let full_response = ui.allocate_rect(rect, Sense::hover());
+                    let tabs_response = ui.allocate_rect(tabbar, Sense::hover());
+                    let mut tab_hover_rect = Option::None;
+
+                    //let mut to_remove = None;
+                    // tabs
+                    ui.scope(|ui| {
+                        ui.painter().rect_filled(
+                            tabbar,
+                            style.tab_rounding,
+                            style.tab_bar_background_color,
+                        );
+
+                        let a = pos2(tabbar.min.x, tabbar.max.y - px);
+                        let b = pos2(tabbar.max.x, tabbar.max.y - px);
+                        ui.painter()
+                            .line_segment([a, b], (px, style.tab_outline_color));
+
+                        let mut ui = ui.child_ui(tabbar, Default::default());
+                        ui.spacing_mut().item_spacing = vec2(0.0, 0.0);
+
+                        ui.horizontal(|ui| {
+                            
+                            for (tab_index, tab) in tabs.iter_mut().enumerate() {
+                                let id = Id::new((tree_index, tab_index, "tab"));
+                                let is_being_dragged = ui.memory().is_being_dragged(id);
+
+                                let is_active = *active == tab_index || is_being_dragged;
+                                let label = tab.title();
+
+                                if is_being_dragged {
+                                    let layer_id = LayerId::new(Order::Tooltip, id);
+                                    let response = ui
+                                        .with_layer_id(layer_id, |ui| {
+                                            style.tab_title(
+                                                ui,
+                                                label.clone(),
+                                                is_active,
+                                                is_active && Option::Some(tree_index) == focused,
+                                                is_being_dragged,
+                                                id,
+                                            )
+                                        })
+                                        .response;
+
+                                    let sense = egui::Sense::click_and_drag();
+                                    let response = ui
+                                        .interact(response.rect, id, sense)
+                                        .on_hover_cursor(CursorIcon::Grabbing);
+
+                                    if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+                                        let center = response.rect.center();
+                                        let start = state.drag_start.unwrap_or(center);
+
+                                        let delta = pointer_pos - start;
+                                        if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
+                                            ui.ctx().translate_layer(layer_id, delta);
+
+                                            drag_data = Some((tree_index, tab_index));
+                                        }
+                                    }
+
+                                    if response.clicked() {
+                                        *active = tab_index;
+                                        new_focused = Option::Some(tree_index);
+                                    }
+                                    if state.drag_start.is_some() {
+                                        if let Option::Some(pos) = ui.input().pointer.hover_pos() {
+                                            if response.rect.contains(pos){
+                                                tab_hover_rect = Option::Some((response.rect, tab_index));
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    let response =
                                         style.tab_title(
-                                            ui,
-                                            label.clone(),
-                                            is_active,
-                                            is_active && Option::Some(tree_index) == focused,
-                                            is_being_dragged,
-                                            id,
-                                        )
-                                    })
-                                    .response;
-
-                                let sense = egui::Sense::click_and_drag();
-                                let response = ui
-                                    .interact(response.rect, id, sense)
-                                    .on_hover_cursor(CursorIcon::Grabbing);
-
-                                if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
-                                    let center = response.rect.center();
-                                    let start = state.drag_start.unwrap_or(center);
-
-                                    let delta = pointer_pos - start;
-                                    if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
-                                        ui.ctx().translate_layer(layer_id, delta);
-
-                                        drag_data = Some((tree_index, tab_index));
+                                            ui, 
+                                            label,  
+                                            is_active && Option::Some(tree_index) == focused, 
+                                            is_active, 
+                                            is_being_dragged, 
+                                            id);
+                                    let sense;
+                                    if response.1{
+                                        sense = Sense::click();
+                                    }else{
+                                        sense = Sense::click_and_drag();
+                                    }
+                                    if tab.force_close(){
+                                        to_remove.push((tree_index, tab_index));
+                                    }else if response.2{
+                                        if tab.on_close(){
+                                            to_remove.push((tree_index, tab_index));
+                                        }
+                                    }
+                                    let response = ui.interact(response.0.rect, id, sense);
+                                    if response.drag_started() {
+                                        state.drag_start = response.hover_pos();
+                                    }
+                                    
+                                    if state.drag_start.is_some() {
+                                        if let Option::Some(pos) = ui.input().pointer.hover_pos() {
+                                            if response.rect.contains(pos){
+                                                tab_hover_rect = Option::Some((response.rect, tab_index));
+                                            }
+                                        }
                                     }
                                 }
+                            }
+                        });
+                    });
 
-                                if response.clicked() {
-                                    *active = tab_index;
+                    // tab body
+                    if let Some(tab) = tabs.get_mut(*active) {
+                        let top_y = rect.min.y + height_topbar;
+                        let rect = rect.intersect(Rect::everything_below(top_y));
+                        let rect = expand_to_pixel(rect, pixels_per_point);
+
+                        *viewport = rect;
+
+                        if ui.input().pointer.any_click(){
+                            if let Option::Some(pos) = ui.input().pointer.hover_pos(){
+                                if rect.contains(pos){
                                     new_focused = Option::Some(tree_index);
                                 }
-                                if state.drag_start.is_some() {
-                                    if let Option::Some(pos) = ui.input().pointer.hover_pos() {
-                                        if response.rect.contains(pos){
-                                            tab_hover_rect = Option::Some((response.rect, tab_index));
-                                        }
-                                    }
-                                }
-                            } else {
-                                let response =
-                                    style.tab_title(
-                                        ui, 
-                                        label,  
-                                        is_active && Option::Some(tree_index) == focused, 
-                                        is_active, 
-                                        is_being_dragged, 
-                                        id);
-                                let sense;
-                                if response.1{
-                                    sense = Sense::click();
-                                }else{
-                                    sense = Sense::click_and_drag();
-                                }
-                                if response.2{
-                                    to_remove = Option::Some(tab_index);
-                                }
-                                let response = ui.interact(response.0.rect, id, sense);
-                                if response.drag_started() {
-                                    state.drag_start = response.hover_pos();
-                                }
-                                
-                                if state.drag_start.is_some() {
-                                    if let Option::Some(pos) = ui.input().pointer.hover_pos() {
-                                        if response.rect.contains(pos){
-                                            tab_hover_rect = Option::Some((response.rect, tab_index));
-                                        }
-                                    }
-                                }
                             }
                         }
-                    });
-                });
 
-                // tab body
-                if let Some(tab) = tabs.get_mut(*active) {
-                    let top_y = rect.min.y + height_topbar;
-                    let rect = rect.intersect(Rect::everything_below(top_y));
-                    let rect = expand_to_pixel(rect, pixels_per_point);
+                        ui.painter()
+                            .rect_filled(rect, 0.0, style.tab_background_color);
 
-                    *viewport = rect;
-
-                    if ui.input().pointer.any_click(){
-                        if let Option::Some(pos) = ui.input().pointer.hover_pos(){
-                            if rect.contains(pos){
-                                new_focused = Option::Some(tree_index);
-                            }
-                        }
+                        let mut ui = ui.child_ui(rect, Default::default());
+                        tab.ui(&mut ui);
                     }
 
-                    ui.painter()
-                        .rect_filled(rect, 0.0, style.tab_background_color);
-
-                    let mut ui = ui.child_ui(rect, Default::default());
-                    tab.ui(&mut ui);
-                }
-
-                let is_being_dragged = ui.memory().is_anything_being_dragged();
-                if is_being_dragged && full_response.hovered() {
-                    hover_data = ui.input().pointer.hover_pos().map(|pointer| HoverData {
-                        rect,
-                        dst: tree_index,
-                        tabs: tabs_response.hovered().then_some(tabs_response.rect),
-                        tab: tab_hover_rect,
-                        pointer,
-                    });
-                }
-
-                if let Option::Some(to_remove) = to_remove{
-                    if tabs[to_remove].close(){
-                        tabs.remove(to_remove);
-                        if to_remove <= *active{
-                            *active = active.checked_sub(1).unwrap_or(0);
-                        }
-                        removed = true;
+                    let is_being_dragged = ui.memory().is_anything_being_dragged();
+                    if is_being_dragged && full_response.hovered() {
+                        hover_data = ui.input().pointer.hover_pos().map(|pointer| HoverData {
+                            rect,
+                            dst: tree_index,
+                            tabs: tabs_response.hovered().then_some(tabs_response.rect),
+                            tab: tab_hover_rect,
+                            pointer,
+                        });
                     }
+
+                    // if let Option::Some(to_remove) = to_remove{
+                    //     if tabs[to_remove].on_close(){
+                    //         tabs.remove(to_remove);
+                    //         if to_remove <= *active{
+                    //             *active = active.checked_sub(1).unwrap_or(0);
+                    //         }
+                    //         removed = true;
+                    //     }
+                    // }
                 }
             }
         }
-    }
-    if removed{
-        tree.remove_empty_leaf();
-    }
-    if let Option::Some(focused) = new_focused{
-        tree.set_focused(focused);
-    }
-
-    if let (Some((src, tab_index)), Some(hover)) = (drag_data, hover_data) {
-        let dst = hover.dst;
-
-        if tree[src].is_leaf() && tree[dst].is_leaf() {
-            let (target, helper, tap_pos) = hover.resolve();
-
-            let id = Id::new("helper");
-            let layer_id = LayerId::new(Order::Foreground, id);
-            let painter = ui.ctx().layer_painter(layer_id);
-
-            if src != dst || tree[dst].tabs_count() > 1 {
-                painter.rect_filled(helper, 0.0, style.selection_color);
+        let mut emptied = 0;
+        let mut last = (NodeIndex(usize::MAX), usize::MAX);
+        for remove in to_remove.iter().rev(){
+            if let Node::Leaf{ tabs, active, .. } = &mut tree[remove.0]{
+                tabs.remove(remove.1);
+                if remove.1 <= *active{
+                    *active = active.checked_sub(1).unwrap_or(0);
+                }
+                if tabs.is_empty(){
+                    emptied += 1;
+                }
+                if last.0 == remove.0{
+                    assert!(last.1 > remove.1)
+                }
+                last = *remove;
+            }else{
+                panic!();
             }
+        }
+        for _ in 0..emptied{
+            tree.remove_empty_leaf()
+        }
+        
+        if let Option::Some(focused) = new_focused{
+            tree.set_focused(focused);
+        }
 
-            if ui.input().pointer.any_released() {
-                if let Node::Leaf { active, .. } = &mut tree[src] {
-                    if *active >= tab_index {
-                        *active = active.saturating_sub(1);
-                    }
+        if let (Some((src, tab_index)), Some(hover)) = (drag_data, hover_data) {
+            let dst = hover.dst;
+
+            if tree[src].is_leaf() && tree[dst].is_leaf() {
+                let (target, helper, tap_pos) = hover.resolve();
+
+                let id = Id::new("helper");
+                let layer_id = LayerId::new(Order::Foreground, id);
+                let painter = ui.ctx().layer_painter(layer_id);
+
+                if src != dst || tree[dst].tabs_count() > 1 {
+                    painter.rect_filled(helper, 0.0, style.selection_color);
                 }
 
-                let tab = tree[src].remove_tab(tab_index).unwrap();
-
-                if let Some(target) = target {
-                    tree.split(dst, target, 0.5, Node::leaf(tab));
-                } else {
-                    if let Option::Some(index) = tap_pos{
-                        tree[dst].insert_tab(index, tab);
-                    }else{
-                        tree[dst].append_tab(tab);
+                if ui.input().pointer.any_released() {
+                    if let Node::Leaf { active, .. } = &mut tree[src] {
+                        if *active >= tab_index {
+                            *active = active.saturating_sub(1);
+                        }
                     }
-                    tree.set_focused(dst);
-                }
 
-                tree.remove_empty_leaf();
-                for node in &mut tree.iter_mut() {
-                    if let Node::Leaf { tabs, active, .. } = node {
-                        if *active >= tabs.len() {
-                            *active = 0;
+                    let tab = tree[src].remove_tab(tab_index).unwrap();
+
+                    if let Some(target) = target {
+                        tree.split(dst, target, 0.5, Node::leaf(tab));
+                    } else {
+                        if let Option::Some(index) = tap_pos{
+                            tree[dst].insert_tab(index, tab);
+                        }else{
+                            tree[dst].append_tab(tab);
+                        }
+                        tree.set_focused(dst);
+                    }
+
+                    tree.remove_empty_leaf();
+                    for node in &mut tree.iter_mut() {
+                        if let Node::Leaf { tabs, active, .. } = node {
+                            if *active >= tabs.len() {
+                                *active = 0;
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    state.store(ui.ctx(), id);
+        state.store(ui.ctx(), id);
+    }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -230,10 +230,10 @@ impl Style {
             _ => (),
         }
         
-
         let pos = Align2::LEFT_TOP
             .anchor_rect(rect.shrink2(vec2(8.0, 5.0)))
             .min;
+            
 
         ui.painter().galley(pos, galley.galley);
         

--- a/src/style.rs
+++ b/src/style.rs
@@ -199,7 +199,7 @@ impl Style {
             pos.x += offset.x + text_size.x + x_text_gap + x_size.x / 2.0;
             pos.y += rect.size().y / 2.0;
             x_rect = Rect::from_center_size(pos, x_size);
-            x_res = Option::Some(ui.interact(x_rect, id, Sense::click()));
+            x_res = Some(ui.interact(x_rect, id, Sense::click()));
         }else{
             x_rect = Rect::NOTHING;
             x_res = None;

--- a/src/style.rs
+++ b/src/style.rs
@@ -131,8 +131,6 @@ impl Style {
             .allocate_rect(separator, Sense::click_and_drag())
             .on_hover_cursor(CursorIcon::ResizeVertical);
 
-        //ui.painter().line_segment([response.rect.center_top(), response.rect.center_bottom()], Stroke::new(self.separator_width, self.separator_color));
-
         {
             let delta = response.drag_delta().y;
             let range = rect.max.y - rect.min.y;
@@ -349,6 +347,37 @@ impl StyleBuilder {
     #[inline(always)]
     pub fn with_tab_background_color(mut self, tab_background: Color32) -> Self {
         self.style.tab_background_color = tab_background;
+        self
+    }
+
+    /// Sets `close_tab_color` for the close tab button color.
+    #[inline(always)]
+    pub fn with_close_tab_color(mut self, close_tab_color: Color32) -> Self {
+        self.style.close_tab_color = close_tab_color;
+        self
+    }
+
+    /// Sets `close_tab_active_color` for the active close tab button color.
+    #[inline(always)]
+    pub fn with_close_tab_active_color_color(mut self, close_tab_active_color: Color32) -> Self {
+        self.style.close_tab_active_color = close_tab_active_color;
+        self
+    }
+
+    /// Sets `close_tab_background_color` for the background close tab button color.
+    #[inline(always)]
+    pub fn with_close_tab_background_color_color(
+        mut self,
+        close_tab_background_color: Color32,
+    ) -> Self {
+        self.style.close_tab_background_color = close_tab_background_color;
+        self
+    }
+
+    /// Shows / Hides the tab close buttons.
+    #[inline(always)]
+    pub fn show_close_buttons(mut self, show_close_buttons: bool) -> Self {
+        self.style.show_close_buttons = show_close_buttons;
         self
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -70,7 +70,6 @@ impl Style {
             tab_outline_color: style.visuals.widgets.active.bg_fill,
             tab_background_color: style.visuals.window_fill(),
 
-
             close_tab_background_color: style.visuals.widgets.active.bg_fill,
             close_tab_color: style.visuals.text_color(),
             close_tab_active_color: style.visuals.strong_text_color(),
@@ -131,9 +130,9 @@ impl Style {
         let response = ui
             .allocate_rect(separator, Sense::click_and_drag())
             .on_hover_cursor(CursorIcon::ResizeVertical);
-        
+
         //ui.painter().line_segment([response.rect.center_top(), response.rect.center_bottom()], Stroke::new(self.separator_width, self.separator_color));
-        
+
         {
             let delta = response.drag_delta().y;
             let range = rect.max.y - rect.min.y;
@@ -177,17 +176,16 @@ impl Style {
         let galley = label.into_galley(ui, None, 14.0, TextStyle::Button);
 
         let x_text_gap = 5.0;
-        let x_size = Vec2::new(galley.size().y / 1.3, galley.size().y/ 1.3);
+        let x_size = Vec2::new(galley.size().y / 1.3, galley.size().y / 1.3);
 
         let offset = vec2(8.0, 0.0);
         let text_size = galley.size();
 
         let mut desired_size = text_size + offset * 2.0;
-        if self.show_close_buttons{
+        if self.show_close_buttons {
             desired_size.x += x_size.x + x_text_gap;
         }
         desired_size.y = 24.0;
-
 
         let (rect, response) = ui.allocate_at_least(desired_size, Sense::hover());
         let response = response.on_hover_cursor(CursorIcon::PointingHand);
@@ -226,17 +224,20 @@ impl Style {
             }
             _ => (),
         }
-        
+
         let pos = Align2::LEFT_TOP
             .anchor_rect(rect.shrink2(vec2(8.0, 5.0)))
             .min;
-            
 
         ui.painter().galley(pos, galley.galley);
-        
-        if (active || response.hovered()) && self.show_close_buttons{
-            if x_res.as_ref().unwrap().hovered(){
-                ui.painter().rect_filled(x_rect, Rounding::same(2.0), self.close_tab_background_color);
+
+        if (active || response.hovered()) && self.show_close_buttons {
+            if x_res.as_ref().unwrap().hovered() {
+                ui.painter().rect_filled(
+                    x_rect,
+                    Rounding::same(2.0),
+                    self.close_tab_background_color,
+                );
             }
             let x_rect = x_rect.shrink(1.75);
 
@@ -245,14 +246,19 @@ impl Style {
             } else {
                 self.close_tab_color
             };
-            ui.painter().line_segment([x_rect.left_top(), x_rect.right_bottom()], Stroke::new(1.0, color));
-            ui.painter().line_segment([x_rect.right_top(), x_rect.left_bottom()], Stroke::new(1.0, color));
-            
+            ui.painter().line_segment(
+                [x_rect.left_top(), x_rect.right_bottom()],
+                Stroke::new(1.0, color),
+            );
+            ui.painter().line_segment(
+                [x_rect.right_top(), x_rect.left_bottom()],
+                Stroke::new(1.0, color),
+            );
         }
 
-        match x_res{
+        match x_res {
             Some(some) => (response, some.hovered(), some.clicked()),
-            None =>  (response, false, false),
+            None => (response, false, false),
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -57,7 +57,8 @@ impl Style {
     /// Derives relevant fields from `egui::Style` and sets the remaining fields to their default values.
     ///
     /// Fields overwritten by [`egui::Style`] are: `selection`, `tab_bar_background_color`, `tab_text`,
-    /// `tab_outline_color`, `separator_color`, `border_color`, and `tab_background_color`.
+    /// `tab_outline_color`, `separator_color`, `border_color`, and `tab_background_color`,
+    /// `close_tab_background_color`, `close_tab_color`, `close_tab_active_color`,
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             selection_color: style.visuals.selection.bg_fill.linear_multiply(0.5),

--- a/src/style.rs
+++ b/src/style.rs
@@ -192,19 +192,15 @@ impl Style {
         let (rect, response) = ui.allocate_at_least(desired_size, Sense::hover());
         let response = response.on_hover_cursor(CursorIcon::PointingHand);
 
-        let x_rect;
-        let x_res;
-        if (active || response.hovered()) && self.show_close_buttons{
+        let (x_rect, x_res) = if (active || response.hovered()) && self.show_close_buttons {
             let mut pos = rect.left_top();
             pos.x += offset.x + text_size.x + x_text_gap + x_size.x / 2.0;
             pos.y += rect.size().y / 2.0;
-            x_rect = Rect::from_center_size(pos, x_size);
-            x_res = Some(ui.interact(x_rect, id, Sense::click()));
-        }else{
-            x_rect = Rect::NOTHING;
-            x_res = None;
-        }
-
+            let x_rect = Rect::from_center_size(pos, x_size);
+            (x_rect, Some(ui.interact(x_rect, id, Sense::click())))
+        } else {
+            (Rect::NOTHING, None)
+        };
         match (active, is_being_dragged) {
             (true, false) => {
                 let mut tab = rect;
@@ -244,13 +240,11 @@ impl Style {
             }
             let x_rect = x_rect.shrink(1.75);
 
-            let color;
-            if x_res.as_ref().unwrap().interact_pointer_pos().is_some()
-                || focused{
-                color = self.close_tab_active_color;
-            }else{
-                color = self.close_tab_color
-            }
+            let color = if focused || x_res.as_ref().unwrap().interact_pointer_pos().is_some() {
+                self.close_tab_active_color
+            } else {
+                self.close_tab_color
+            };
             ui.painter().line_segment([x_rect.left_top(), x_rect.right_bottom()], Stroke::new(1.0, color));
             ui.painter().line_segment([x_rect.right_top(), x_rect.left_bottom()], Stroke::new(1.0, color));
             

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -17,7 +17,7 @@ pub trait Tab{
     /// This is called when the close button is pressed
     /// returning false will cancel closing the tab
     fn on_close(&mut self) -> bool{
-        false
+        true
     }
     /// This is called every frame
     /// return true and the tab will close 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -14,20 +14,20 @@ pub struct TabBuilder {
 }
 
 /// Dockable tab that can be used in `Tree`s.
-pub trait Tab{
-    ///Actual tab content
+pub trait Tab {
+    /// Actual tab content
     fn ui(&mut self, ui: &mut egui::Ui);
-    ///The title to be displayed
+    /// The title to be displayed
     fn title(&mut self) -> egui::WidgetText;
     /// This is called when the close button is pressed
     /// returning false will cancel closing the tab
-    fn on_close(&mut self) -> bool{
+    fn on_close(&mut self) -> bool {
         true
     }
     /// This is called every frame
-    /// return true and the tab will close 
+    /// return true and the tab will close
     /// using this to close the tab will NOT call the on_close function!
-    fn force_close(&mut self) -> bool{
+    fn force_close(&mut self) -> bool {
         false
     }
 }
@@ -39,10 +39,12 @@ pub struct BuiltTab {
     on_close: Option<OnClose>,
     force_close: Option<ForceClose>,
 }
-impl Tab for BuiltTab{
+
+impl Tab for BuiltTab {
     fn title(&mut self) -> egui::WidgetText {
         self.title.clone()
     }
+
     fn ui(&mut self, ui: &mut egui::Ui) {
         ScrollArea::both()
             .id_source(self.title.text().to_string() + " - egui_dock::Tab")
@@ -58,14 +60,14 @@ impl Tab for BuiltTab{
     }
 
     fn on_close(&mut self) -> bool {
-        match &mut self.on_close{
+        match &mut self.on_close {
             Some(on_close) => on_close(),
             None => true,
         }
     }
 
     fn force_close(&mut self) -> bool {
-        match &mut self.force_close{
+        match &mut self.force_close {
             Some(force_close) => force_close(),
             None => false,
         }
@@ -116,14 +118,14 @@ impl TabBuilder {
         self.add_content = Some(Box::new(add_content));
         self
     }
-    
+
     /// Sets the function that runs when the close button is pressed
     /// return true to close and false to block the close
     pub fn on_close(mut self, on_close: impl FnMut() -> bool + 'static) -> Self {
         self.on_close = Some(Box::new(on_close));
         self
     }
-    
+
     /// Sets the function that checks if the tab should be closed every frame
     /// return false to keep open and true to close the tab
     /// returning true will NOT call the on_close function (if any)
@@ -132,4 +134,3 @@ impl TabBuilder {
         self
     }
 }
-

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -19,14 +19,21 @@ pub trait Tab {
     fn ui(&mut self, ui: &mut egui::Ui);
     /// The title to be displayed
     fn title(&mut self) -> egui::WidgetText;
-    /// This is called when the close button is pressed
-    /// returning false will cancel closing the tab
+
+    /// This is called when the tabs close button is pressed
+    ///
+    /// Returns weather or not the tab should close immediately
+    ///
+    /// NOTE if returning false `ui` will still be called once more if this tab is active
     fn on_close(&mut self) -> bool {
         true
     }
-    /// This is called every frame
-    /// return true and the tab will close
-    /// using this to close the tab will NOT call the on_close function!
+
+    /// This is called every frame after `ui` is called (if the tab is active)
+    ///
+    /// Returns wether or not the tab should be forced to close
+    ///
+    /// In the event this function returns true the tab will be removed without calling `on_close`
     fn force_close(&mut self) -> bool {
         false
     }
@@ -119,16 +126,21 @@ impl TabBuilder {
         self
     }
 
-    /// Sets the function that runs when the close button is pressed
-    /// return true to close and false to block the close
+    /// Sets the function that is called when the close button is pressed
+    ///
+    /// If no function is set the default behavior is to always return true
+    ///
+    /// See [Tab](crate::tab::Tab) `on_close` for more detail
     pub fn on_close(mut self, on_close: impl FnMut() -> bool + 'static) -> Self {
         self.on_close = Some(Box::new(on_close));
         self
     }
 
-    /// Sets the function that checks if the tab should be closed every frame
-    /// return false to keep open and true to close the tab
-    /// returning true will NOT call the on_close function (if any)
+    /// Sets the function that is called every frame to determine if the tab should close
+    ///
+    /// If no function is set the default behavior is to always return false
+    ///
+    /// See [Tab](crate::tab::Tab) `force_close` for more detail
     pub fn force_close(mut self, force_close: impl FnMut() -> bool + 'static) -> Self {
         self.force_close = Some(Box::new(force_close));
         self

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -10,10 +10,20 @@ pub struct TabBuilder {
 }
 
 pub trait Tab{
+    ///Actual tab content
     fn ui(&mut self, ui: &mut egui::Ui);
+    ///The title to be displayed
     fn title(&mut self) -> egui::WidgetText;
-    fn close(&mut self) -> bool{
-        true
+    /// This is called when the close button is pressed
+    /// returning false will cancel closing the tab
+    fn on_close(&mut self) -> bool{
+        false
+    }
+    /// This is called every frame
+    /// return true and the tab will close 
+    /// using this to close the tab will NOT call the on_close function!
+    fn force_close(&mut self) -> bool{
+        false
     }
 }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -15,25 +15,26 @@ pub struct TabBuilder {
 
 /// Dockable tab that can be used in `Tree`s.
 pub trait Tab {
-    /// Actual tab content
-    fn ui(&mut self, ui: &mut egui::Ui);
-    /// The title to be displayed
-    fn title(&mut self) -> egui::WidgetText;
+    /// Actual tab content.
+    fn ui(&mut self, ui: &mut Ui);
 
-    /// This is called when the tabs close button is pressed
+    /// The title to be displayed.
+    fn title(&mut self) -> WidgetText;
+
+    /// This is called when the tabs close button is pressed.
     ///
-    /// Returns weather or not the tab should close immediately
+    /// Returns `true` if the tab should close immediately, `false` otherwise.
     ///
-    /// NOTE if returning false `ui` will still be called once more if this tab is active
+    /// NOTE if returning false `ui` will still be called once more if this tab is active.
     fn on_close(&mut self) -> bool {
         true
     }
 
-    /// This is called every frame after `ui` is called (if the tab is active)
+    /// This is called every frame after `ui` is called (if the tab is active).
     ///
-    /// Returns wether or not the tab should be forced to close
+    /// Returns `true` if the tab should be forced to close, `false` otherwise.
     ///
-    /// In the event this function returns true the tab will be removed without calling `on_close`
+    /// In the event this function returns true the tab will be removed without calling `on_close`.
     fn force_close(&mut self) -> bool {
         false
     }
@@ -48,11 +49,7 @@ pub struct BuiltTab {
 }
 
 impl Tab for BuiltTab {
-    fn title(&mut self) -> egui::WidgetText {
-        self.title.clone()
-    }
-
-    fn ui(&mut self, ui: &mut egui::Ui) {
+    fn ui(&mut self, ui: &mut Ui) {
         ScrollArea::both()
             .id_source(self.title.text().to_string() + " - egui_dock::Tab")
             .show(ui, |ui| {
@@ -64,6 +61,10 @@ impl Tab for BuiltTab {
                         (self.add_content)(ui);
                     });
             });
+    }
+
+    fn title(&mut self) -> WidgetText {
+        self.title.clone()
     }
 
     fn on_close(&mut self) -> bool {
@@ -126,9 +127,10 @@ impl TabBuilder {
         self
     }
 
-    /// Sets the function that is called when the close button is pressed
+    /// Sets the function that is called when the close button is pressed.
+    /// The function should return `true` if the tab should close immediately, `false` otherwise.
     ///
-    /// If no function is set the default behavior is to always return true
+    /// If no function is set the default behavior is to always return true.
     ///
     /// See [Tab](crate::tab::Tab) `on_close` for more detail
     pub fn on_close(mut self, on_close: impl FnMut() -> bool + 'static) -> Self {
@@ -136,9 +138,10 @@ impl TabBuilder {
         self
     }
 
-    /// Sets the function that is called every frame to determine if the tab should close
+    /// Sets the function that is called every frame to determine if the tab should close.
+    /// The function should return `true` if the tab should be forced to close, `false` otherwise.
     ///
-    /// If no function is set the default behavior is to always return false
+    /// If no function is set the default behavior is to always return false.
     ///
     /// See [Tab](crate::tab::Tab) `force_close` for more detail
     pub fn force_close(mut self, force_close: impl FnMut() -> bool + 'static) -> Self {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -377,7 +377,7 @@ impl Tree {
         self[index[0]] = old;
         self[index[1]] = new;
 
-        self.focused_node = Option::Some(index[1]);
+        self.focused_node = Some(index[1]);
 
         index
     }
@@ -408,8 +408,8 @@ impl Tree {
             let left = top.left();
             let right = top.right();
             match (tree.tree.get(left.0), tree.tree.get(right.0)){
-                (Some(&Node::Leaf{..}), _) => Option::Some(left),
-                (_, Some(&Node::Leaf{..})) => Option::Some(left),
+                (Some(&Node::Leaf{..}), _) => Some(left),
+                (_, Some(&Node::Leaf{..})) => Some(left),
                 
                 (Some(Node::Horizontal{..} | Node::Vertical{..}), Some(Node::Horizontal{..} | Node::Vertical{..})) => {
                     match first_leaf(tree, left){
@@ -427,21 +427,21 @@ impl Tree {
             }
         }
 
-        if Option::Some(node) == self.focused_node{
-            self.focused_node = Option::None;
+        if Some(node) == self.focused_node{
+            self.focused_node = None;
             let mut node = node;
-            while let Option::Some(parent) = node.parent(){
+            while let Some(parent) = node.parent(){
                 let next = if node.is_left(){
                     parent.right()
                 }else{
                     parent.left()
                 };
-                if let Option::Some(Node::Leaf{..}) = self.tree.get(next.0){
-                    self.focused_node = Option::Some(next);
+                if let Some(Node::Leaf{..}) = self.tree.get(next.0){
+                    self.focused_node = Some(next);
                     break;
                 }
-                if let Option::Some(node) = first_leaf(&self, next){
-                    self.focused_node = Option::Some(node);
+                if let Some(node) = first_leaf(&self, next){
+                    self.focused_node = Some(node);
                     break;
                 }
                 node = parent;
@@ -462,8 +462,8 @@ impl Tree {
                     if src >= self.tree.len() {
                         break 'left_end;
                     }
-                    if Option::Some(NodeIndex(src)) == self.focused_node{
-                        self.focused_node = Option::Some(NodeIndex(dst));
+                    if Some(NodeIndex(src)) == self.focused_node{
+                        self.focused_node = Some(NodeIndex(dst));
                     }
                     self.tree[dst] = std::mem::replace(&mut self.tree[src], Node::None);
                 }
@@ -477,8 +477,8 @@ impl Tree {
                     if src >= self.tree.len() {
                         break 'right_end;
                     }
-                    if Option::Some(NodeIndex(src)) == self.focused_node{
-                        self.focused_node = Option::Some(NodeIndex(dst));
+                    if Some(NodeIndex(src)) == self.focused_node{
+                        self.focused_node = Some(NodeIndex(dst));
                     }
                     self.tree[dst] = std::mem::replace(&mut self.tree[src], Node::None);
                 }
@@ -493,13 +493,13 @@ impl Tree {
             match node{
                 Node::Leaf { tabs, active, ..} => {
                     tabs.push(tab);
-                    self.focused_node = Option::Some(NodeIndex(index));
+                    self.focused_node = Some(NodeIndex(index));
                     *active = tabs.len() - 1;
                     return;
                 }, 
                 Node::None => {
                     *node = Node::leaf(tab);
-                    self.focused_node = Option::Some(NodeIndex(index));
+                    self.focused_node = Some(NodeIndex(index));
                     return;
                 },
                 _ => {}
@@ -515,8 +515,8 @@ impl Tree {
 
     ///Updates the focused leaf
     pub fn set_focused(&mut self, node: NodeIndex){
-        if let Option::Some(Node::Leaf{..}) = self.tree.get(node.0){
-            self.focused_node = Option::Some(node);
+        if let Some(Node::Leaf{..}) = self.tree.get(node.0){
+            self.focused_node = Some(node);
         }else{
            self.focused_node = None; 
         }
@@ -530,17 +530,17 @@ impl Tree {
             Some(node) => {
                 if self.tree.is_empty(){
                     self.tree.push(Node::leaf(tab));
-                    self.focused_node = Option::Some(NodeIndex::root());
+                    self.focused_node = Some(NodeIndex::root());
                 }else{
                     match &mut self[node]{
                         Node::None => {
                             self[node] = Node::leaf(tab);
-                            self.focused_node = Option::Some(node);
+                            self.focused_node = Some(node);
                         },
                         Node::Leaf { tabs, active, ..} => {
                             tabs.push(tab);
                             *active = tabs.len() - 1;
-                            self.focused_node = Option::Some(node);
+                            self.focused_node = Some(node);
                         },
                         _ => {
                             self.push_to_first_leaf(tab);
@@ -551,7 +551,7 @@ impl Tree {
             None => {
                 if self.tree.is_empty(){
                     self.tree.push(Node::leaf(tab));
-                    self.focused_node = Option::Some(NodeIndex::root());
+                    self.focused_node = Some(NodeIndex::root());
                 }else{
                     self.push_to_first_leaf(tab);
                 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,7 @@
-use crate::Tab;
+
 use egui::*;
 
+pub type Tab = Box<dyn crate::Tab>;
 pub type Tabs = Vec<Tab>;
 
 /// Represents an abstract node of a `Tree`.
@@ -80,7 +81,28 @@ impl Node {
     #[track_caller]
     pub fn append_tab(&mut self, tab: Tab) {
         match self {
-            Node::Leaf { tabs, .. } => tabs.push(tab),
+            Node::Leaf { tabs, active, .. } => {
+                tabs.push(tab);
+                *active = tabs.len() - 1;
+            },
+            _ => unreachable!(),
+        }
+        
+    }
+
+    /// Adds a `tab` to the node.
+    ///
+    /// # Panics
+    /// Panics if the new capacity of `tabs` exceeds isize::MAX bytes.
+    /// index > tabs_count()
+    #[track_caller]
+    pub fn insert_tab(&mut self, index: usize, tab: Tab) {
+        match self {
+            Node::Leaf { tabs, active, .. } => {
+                tabs.insert(index, tab);
+                *active = index;
+
+            },
             _ => unreachable!(),
         }
     }
@@ -185,6 +207,7 @@ pub enum Split {
 #[derive(Default)]
 pub struct Tree {
     tree: Vec<Node>,
+    focused_node: Option<NodeIndex>,
 }
 
 impl std::ops::Index<NodeIndex> for Tree {
@@ -208,7 +231,7 @@ impl Tree {
     #[inline(always)]
     pub fn new(tabs: Tabs) -> Self {
         let root = Node::leaf_with(tabs);
-        Self { tree: vec![root] }
+        Self { tree: vec![root], focused_node: None }
     }
 
     /// Returns the viewport `Rect` and the `Tab` inside the first leaf node, or `None` of no leaf exists in the `Tree`.
@@ -354,6 +377,8 @@ impl Tree {
         self[index[0]] = old;
         self[index[1]] = new;
 
+        self.focused_node = Option::Some(index[1]);
+
         index
     }
 
@@ -370,10 +395,62 @@ impl Tree {
             None => return,
         };
 
-        let parent = node.parent().unwrap();
+        let parent = match node.parent(){
+            Some(val) => val,
+            None => {
+                self.tree.clear();
+                return;
+            },
+        };
+
+
+        fn first_leaf(tree: &Tree, top: NodeIndex) -> Option<NodeIndex>{
+            let left = top.left();
+            let right = top.right();
+            match (tree.tree.get(left.0), tree.tree.get(right.0)){
+                (Some(&Node::Leaf{..}), _) => Option::Some(left),
+                (_, Some(&Node::Leaf{..})) => Option::Some(left),
+                
+                (Some(Node::Horizontal{..} | Node::Vertical{..}), Some(Node::Horizontal{..} | Node::Vertical{..})) => {
+                    match first_leaf(tree, left){
+                        ret @ Some(_) => ret,
+                        None => first_leaf(tree, right),
+                    }
+                },
+                (Some(Node::Horizontal{..} | Node::Vertical{..}), _) => first_leaf(tree, left),
+                (_, Some(Node::Horizontal{..} | Node::Vertical{..})) => first_leaf(tree, right),
+                
+                (None, None) 
+                | (Some(&Node::None), None)
+                | (None, Some(&Node::None))
+                | (Some(&Node::None), Some(&Node::None)) => None,
+            }
+        }
+
+        if Option::Some(node) == self.focused_node{
+            self.focused_node = Option::None;
+            let mut node = node;
+            while let Option::Some(parent) = node.parent(){
+                let next = if node.is_left(){
+                    parent.right()
+                }else{
+                    parent.left()
+                };
+                if let Option::Some(Node::Leaf{..}) = self.tree.get(next.0){
+                    self.focused_node = Option::Some(next);
+                    break;
+                }
+                if let Option::Some(node) = first_leaf(&self, next){
+                    self.focused_node = Option::Some(node);
+                    break;
+                }
+                node = parent;
+            }
+        }
 
         self[parent] = Node::None;
         self[node] = Node::None;
+
 
         let mut level = 0;
 
@@ -384,6 +461,9 @@ impl Tree {
                 for (dst, src) in dst.zip(src) {
                     if src >= self.tree.len() {
                         break 'left_end;
+                    }
+                    if Option::Some(NodeIndex(src)) == self.focused_node{
+                        self.focused_node = Option::Some(NodeIndex(dst));
                     }
                     self.tree[dst] = std::mem::replace(&mut self.tree[src], Node::None);
                 }
@@ -397,10 +477,78 @@ impl Tree {
                     if src >= self.tree.len() {
                         break 'right_end;
                     }
+                    if Option::Some(NodeIndex(src)) == self.focused_node{
+                        self.focused_node = Option::Some(NodeIndex(dst));
+                    }
                     self.tree[dst] = std::mem::replace(&mut self.tree[src], Node::None);
                 }
                 level += 1;
             }
+        }
+    }
+
+    pub fn push_to_first_leaf(&mut self, tab: Tab){
+        for (index, node) in &mut self.tree.iter_mut().enumerate(){
+            match node{
+                Node::Leaf { tabs, active, ..} => {
+                    tabs.push(tab);
+                    self.focused_node = Option::Some(NodeIndex(index));
+                    *active = tabs.len() - 1;
+                    return;
+                }, 
+                Node::None => {
+                    *node = Node::leaf(tab);
+                    self.focused_node = Option::Some(NodeIndex(index));
+                    return;
+                },
+                _ => {}
+            }
+        }
+        panic!();
+    }
+
+    pub fn focused_leaf(&self) -> Option<NodeIndex>{
+        self.focused_node
+    }
+    pub fn set_focused(&mut self, node: NodeIndex){
+        if let Option::Some(Node::Leaf{..}) = self.tree.get(node.0){
+            self.focused_node = Option::Some(node);
+        }else{
+           self.focused_node = None; 
+        }
+    }
+
+    pub fn push_to_active_leaf(&mut self, tab: Tab){
+        match self.focused_node{
+            Some(node) => {
+                if self.tree.is_empty(){
+                    self.tree.push(Node::leaf(tab));
+                    self.focused_node = Option::Some(NodeIndex::root());
+                }else{
+                    match &mut self[node]{
+                        Node::None => {
+                            self[node] = Node::leaf(tab);
+                            self.focused_node = Option::Some(node);
+                        },
+                        Node::Leaf { tabs, active, ..} => {
+                            tabs.push(tab);
+                            *active = tabs.len() - 1;
+                            self.focused_node = Option::Some(node);
+                        },
+                        _ => {
+                            self.push_to_first_leaf(tab);
+                        }
+                    }
+                }
+            },
+            None => {
+                if self.tree.is_empty(){
+                    self.tree.push(Node::leaf(tab));
+                    self.focused_node = Option::Some(NodeIndex::root());
+                }else{
+                    self.push_to_first_leaf(tab);
+                }
+            },
         }
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -511,23 +511,27 @@ impl Tree {
         panic!();
     }
 
-    ///Currently focused leaf
+    /// Currently focused leaf
     pub fn focused_leaf(&self) -> Option<NodeIndex> {
         self.focused_node
     }
 
-    ///Updates the focused leaf
-    pub fn set_focused(&mut self, node: NodeIndex) {
-        if let Some(Node::Leaf { .. }) = self.tree.get(node.0) {
-            self.focused_node = Some(node);
+    /// Sets the currently focused leaf to `node_index`
+    ///
+    /// If the node at `node_index` isn't `Node::Leaf`
+    pub fn set_focused(&mut self, node_index: NodeIndex) {
+        if let Some(Node::Leaf { .. }) = self.tree.get(node_index.0) {
+            self.focused_node = Some(node_index);
         } else {
             self.focused_node = None;
         }
     }
 
-    /// Pushes the new tab to the currently focused tab.
-    /// if there is none this function pushes the tab to the first leaf it finds
-    /// or if there isnt any creates one
+    /// Pushes `tab` to the currently focused leaf.
+    ///
+    /// If no leaf is focused it will be pushed to the first available leaf.
+    ///
+    /// If no leaf is available then a new leaf will be created.
     pub fn push_to_focused_leaf(&mut self, tab: Tab) {
         match self.focused_node {
             Some(node) => {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -487,6 +487,7 @@ impl Tree {
         }
     }
 
+    /// Push a tab to the first leaf it finds or creates a leaf if an empty spot is encountered
     pub fn push_to_first_leaf(&mut self, tab: Tab){
         for (index, node) in &mut self.tree.iter_mut().enumerate(){
             match node{
@@ -507,9 +508,12 @@ impl Tree {
         panic!();
     }
 
+    ///Currently focused leaf
     pub fn focused_leaf(&self) -> Option<NodeIndex>{
         self.focused_node
     }
+
+    ///Updates the focused leaf
     pub fn set_focused(&mut self, node: NodeIndex){
         if let Option::Some(Node::Leaf{..}) = self.tree.get(node.0){
             self.focused_node = Option::Some(node);
@@ -518,7 +522,10 @@ impl Tree {
         }
     }
 
-    pub fn push_to_active_leaf(&mut self, tab: Tab){
+    /// Pushes the new tab to the currently focused tab.
+    /// if there is none this function pushes the tab to the first leaf it finds
+    /// or if there isnt any creates one
+    pub fn push_to_focused_leaf(&mut self, tab: Tab){
         match self.focused_node{
             Some(node) => {
                 if self.tree.is_empty(){

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -444,7 +444,7 @@ impl Tree {
                     self.focused_node = Some(next);
                     break;
                 }
-                if let Some(node) = first_leaf(&self, next) {
+                if let Some(node) = first_leaf(self, next) {
                     self.focused_node = Some(node);
                     break;
                 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -490,7 +490,7 @@ impl Tree {
         }
     }
 
-    /// Push a tab to the first leaf it finds or creates a leaf if an empty spot is encountered
+    /// Push a tab to the first leaf it finds or creates a leaf if an empty spot is encountered.
     pub fn push_to_first_leaf(&mut self, tab: Tab) {
         for (index, node) in &mut self.tree.iter_mut().enumerate() {
             match node {
@@ -511,14 +511,12 @@ impl Tree {
         panic!();
     }
 
-    /// Currently focused leaf
+    /// Currently focused leaf.
     pub fn focused_leaf(&self) -> Option<NodeIndex> {
         self.focused_node
     }
 
-    /// Sets the currently focused leaf to `node_index`
-    ///
-    /// If the node at `node_index` isn't `Node::Leaf`
+    /// Sets the currently focused leaf to `node_index` if the node at `node_index` isn't `Node::Leaf`.
     pub fn set_focused(&mut self, node_index: NodeIndex) {
         if let Some(Node::Leaf { .. }) = self.tree.get(node_index.0) {
             self.focused_node = Some(node_index);


### PR DESCRIPTION
Added the ability for tabs to be closed.
There are two ways a tab can be closed. either a user presses the close button and the `on_close` function returns true. or if the tab returns true from its `force_close` function that is called every frame.

The docking area will also now keep track of the currently "focused" leaf. This allows for tabs to be appended with `push_to_active_leaf`. if there is no currently focused leaf the function will add the tab to the first leaf it finds or crate a new leaf.

when tabs are dragged onto a new leaf they will be set as the active tab.
tabs can now also be reordered by dragging over existing tabs. dropping while over an existing tab will insert the new tab into its index pushing tabs to the right of it over (also making that index the active index).

You can now also specify functions on_close and force_close for the `TabBuilder`. if `on_close` isn't added it always will return true and if `force_close` isn't added it always returns false.

The theme of the close button can also be customized in the `Style` struct.
`close_tab_color` is the color of the inactive x.
`close_tab_active_color` is the color of the active x (the active tab on the currently focused leaf).
`close_tab_background_color` background color of the close button.

The close button can also be disabled with `show_close_buttons`
with `show_close_buttons` disabled `on_close` will never be called but `force_close` will still be called every frame.