### PR TITLE
Change `DockArea` api to look a bit more like other egui containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - It is now possible to close tabs with a close button that can be shown/hidden through `Style`
 - When dragging tabs onto the tab bar if the tab will be inserted a highlighted region will show where the tab will end up if dropped.
 - The dock will keep track of the currently focused leaf.
-- Using `push_to_active_leaf` will push the given tab to the currently active leaf.
+- Using `Tree::push_to_focused_leaf` will push the given tab to the currently active leaf.
 - `StyleBuilder` for the `Style`
 - New fields in `Style:` `separator_color`, `border_color`, and `border_size` (last two for the cases when used `Margin`)
 - `TabBuilder` for the `BuiltTab`
@@ -21,7 +21,6 @@
 ## Breaking changes
 
 - Ui code of the dock has been moved into `DockArea` and is displayed with `DockArea::show`
-- `Tree` cannot be directly accessed through `DockArea`
 - Renamed `Style::border_size` to `Style::border_width`
 - Renamed `Style::separator_size` to `Style::separator_width`
 - Removed `Style::tab_text_color` as you can now set the tab text color of a tab by passing `RichText` for its title

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This fork aims to provide documentation and further development if necessary.
 
 ## Usage
 
-First, construct the initial dock:
+First, construct the initial tree :
 
 ```rust
 use egui::{Color32, RichText, style::Margin};
-use egui_dock::{TabBuilder, Tree, DockArea};
+use egui_dock::{TabBuilder, Tree, NodeIndex};
 
 let tab1 = TabBuilder::default()
     .title(RichText::new("Tab 1").color(Color32::BLUE))
@@ -34,15 +34,15 @@ let tab2 = TabBuilder::default()
     })
     .build();
 
-let mut dock = DockArea::from_tabs(vec![tab1, tab2]);
+let mut tree = Tree::new(vec![tab1]);
+
+tree.split_left(NodeIndex::root(), 0.20, vec![tab2]);
 ```
 
 Then, you can show the dock.
 
 ```rust
-let style = egui_dock::Style::default();
-let id = ui.id();
-dock.show(ui, id, &style);
+DockArea::new(&mut tree).show(ctx);
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This fork aims to provide documentation and further development if necessary.
 
 ## Usage
 
-First, construct the initial tree :
+First, construct the initial tree:
 
 ```rust
 use egui::{Color32, RichText, style::Margin};

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,11 +1,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, NativeOptions};
-use egui::color_picker::{color_picker_color32, Alpha};
-use egui::{Color32, Id, LayerId, RichText, Slider, Ui};
-use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
 use std::cell::RefCell;
 use std::rc::Rc;
+
+use eframe::{egui, NativeOptions};
+use egui::color_picker::{color_picker_color32, Alpha};
+use egui::{Color32, RichText, Slider};
+
+use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
 
 fn main() {
     let options = NativeOptions::default();
@@ -25,7 +27,7 @@ struct MyContext {
 struct MyApp {
     _context: Rc<RefCell<MyContext>>,
     style: Rc<RefCell<Style>>,
-    dock: DockArea,
+    tree: Tree,
 }
 
 impl Default for MyApp {
@@ -171,21 +173,14 @@ impl Default for MyApp {
         Self {
             style,
             _context: context,
-            dock: DockArea::from_tree(tree),
+            tree,
         }
     }
 }
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        let style = self.style.borrow().clone();
-
-        let id = Id::new("some hashable string");
-        let layer_id = LayerId::background();
-        let max_rect = ctx.available_rect();
-        let clip_rect = ctx.available_rect();
-
-        let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
-        self.dock.show(&mut ui, id, &style)
+        let style = { self.style.borrow().clone() };
+        DockArea::new(&mut self.tree).style(style).show(ctx);
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -180,7 +180,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        let style = { self.style.borrow().clone() };
+        let style = self.style.borrow().clone();
         DockArea::new(&mut self.tree).style(style).show(ctx);
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::{egui, NativeOptions};
-use egui::{Id, LayerId, Ui};
+
 use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
 
 fn main() {
@@ -14,8 +14,7 @@ fn main() {
 }
 
 struct MyApp {
-    style: Style,
-    dock: DockArea,
+    tree: Tree,
 }
 
 impl Default for MyApp {
@@ -58,23 +57,14 @@ impl Default for MyApp {
         let [_, _] = tree.split_below(a, 0.7, vec![tab4]);
         let [_, _] = tree.split_below(b, 0.5, vec![tab5]);
 
-        Self {
-            style: Style::default(),
-            dock: DockArea::from_tree(tree),
-        }
+        Self { tree }
     }
 }
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        self.style = Style::from_egui(ctx.style().as_ref());
-
-        let id = Id::new("some hashable string");
-        let layer_id = LayerId::background();
-        let max_rect = ctx.available_rect();
-        let clip_rect = ctx.available_rect();
-
-        let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
-        self.dock.show(&mut ui, id, &self.style)
+        DockArea::new(&mut self.tree)
+            .style(Style::from_egui(ctx.style().as_ref()))
+            .show(ctx);
     }
 }


### PR DESCRIPTION
Changes : 
- Does not own Tree
- Does not need to be stored
- Use a builder style API to change the id, the style and show with ctx or inside an ui