### PR TITLE
Refactor: TabViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - `TabBuilder` for the `BuiltTab`
 - Support for all implementations of `Into<WidgetText>` in tab titles
 - Style editor in the `hello` example
-- Added `Tree::find_tab`
+- Added `Tree::find_tab`, `TabViewer`, `DynamicTabViewer`, `DynamicTree`
+- Added a `text_editor` example
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@
 - `TabBuilder` for the `BuiltTab`
 - Support for all implementations of `Into<WidgetText>` in tab titles
 - Style editor in the `hello` example
+- Added `Tree::find_tab`
 
 ## Changed
 
 - If a tab is dropped onto the tab bar it will be inserted into the index that it is dropped onto.
 - Now when you drag a tab it has an outline along the entire length of the edges of it
 - Bumped MSRV to `1.62`
+- `Tree` is now generic over how you want to represent a tab
 
 ## Breaking changes
 
@@ -25,6 +27,7 @@
 - Renamed `Style::separator_size` to `Style::separator_width`
 - Removed `Style::tab_text_color` as you can now set the tab text color of a tab by passing `RichText` for its title
 - Removed the requirement of creating your own Context type
+- Renamed `Tree::set_focused` to `Tree::set_focused_node`
 
 ## Fixed
 

--- a/README.md
+++ b/README.md
@@ -12,39 +12,6 @@ This fork aims to provide documentation and further development if necessary.
 
 ![demo](images/demo.gif "Demo")
 
-## Usage
-
-First, construct the initial tree:
-
-```rust
-use egui::{Color32, RichText, style::Margin};
-use egui_dock::{TabBuilder, Tree, NodeIndex};
-
-let tab1 = TabBuilder::default()
-    .title(RichText::new("Tab 1").color(Color32::BLUE))
-    .content(|ui| {
-        ui.label("Tab 1");
-    })
-    .build();
-let tab2 = TabBuilder::default()
-    .title("Tab 2")
-    .inner_margin(Margin::same(4.0))
-    .content(|ui| {
-        ui.label("Tab 2");
-    })
-    .build();
-
-let mut tree = Tree::new(vec![tab1]);
-
-tree.split_left(NodeIndex::root(), 0.20, vec![tab2]);
-```
-
-Then, you can show the dock.
-
-```rust
-DockArea::new(&mut tree).show(ctx);
-```
-
 ## Contribution
 
 Feel free to open issues and pull requests.

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -183,6 +183,6 @@ impl eframe::App for MyApp {
         let style = self.style.borrow().clone();
         DockArea::new(&mut self.tree)
             .style(style)
-            .show(ctx, &mut egui_dock::TabViewer {});
+            .show(ctx, &mut egui_dock::DynamicTabViewer {});
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,7 +7,7 @@ use eframe::{egui, NativeOptions};
 use egui::color_picker::{color_picker_color32, Alpha};
 use egui::{Color32, RichText, Slider};
 
-use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
+use egui_dock::{DockArea, DynamicTree, NodeIndex, Style, TabBuilder};
 
 fn main() {
     let options = NativeOptions::default();
@@ -27,7 +27,7 @@ struct MyContext {
 struct MyApp {
     _context: Rc<RefCell<MyContext>>,
     style: Rc<RefCell<Style>>,
-    tree: Tree,
+    tree: DynamicTree,
 }
 
 impl Default for MyApp {
@@ -164,7 +164,7 @@ impl Default for MyApp {
             })
             .build();
 
-        let mut tree = Tree::new(vec![node_tree, style_editor]);
+        let mut tree = DynamicTree::new(vec![node_tree, style_editor]);
 
         let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![inspector]);
         let [_, _] = tree.split_below(a, 0.7, vec![files, assets]);
@@ -181,6 +181,8 @@ impl Default for MyApp {
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         let style = self.style.borrow().clone();
-        DockArea::new(&mut self.tree).style(style).show(ctx);
+        DockArea::new(&mut self.tree)
+            .style(style)
+            .show(ctx, &mut egui_dock::TabViewer {});
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 use eframe::{egui, NativeOptions};
 
-use egui_dock::{DockArea, NodeIndex, Style, TabBuilder, Tree};
+use egui_dock::{DockArea, NodeIndex, Style, Tree};
 
 fn main() {
     let options = NativeOptions::default();
@@ -13,49 +13,32 @@ fn main() {
     );
 }
 
+struct TabViewer {}
+
+impl egui_dock::TabViewer for TabViewer {
+    type Tab = String;
+
+    fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+        ui.label(format!("Content of {tab}"));
+    }
+
+    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+        (&*tab).into()
+    }
+}
+
 struct MyApp {
-    tree: Tree,
+    tree: Tree<String>,
 }
 
 impl Default for MyApp {
     fn default() -> Self {
-        let tab1 = TabBuilder::default()
-            .title("Tab 1")
-            .content(|ui| {
-                ui.label("Tab 1");
-            })
-            .build();
-        let tab2 = TabBuilder::default()
-            .title("Tab 2")
-            .content(|ui| {
-                ui.label("Tab 2");
-            })
-            .build();
-        let tab3 = TabBuilder::default()
-            .title("Tab 3")
-            .content(|ui| {
-                ui.label("Tab 3");
-            })
-            .build();
-        let tab4 = TabBuilder::default()
-            .title("Tab 4")
-            .content(|ui| {
-                ui.label("Tab 4");
-            })
-            .build();
-        let tab5 = TabBuilder::default()
-            .title("Tab 5")
-            .content(|ui| {
-                ui.label("Tab 5");
-            })
-            .build();
-
-        let mut tree = Tree::new(vec![tab1, tab2]);
+        let mut tree = Tree::new(vec!["tab1".to_owned(), "tab2".to_owned()]);
 
         // You can modify the tree before constructing the dock
-        let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![tab3]);
-        let [_, _] = tree.split_below(a, 0.7, vec![tab4]);
-        let [_, _] = tree.split_below(b, 0.5, vec![tab5]);
+        let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec!["tab3".to_owned()]);
+        let [_, _] = tree.split_below(a, 0.7, vec!["tab4".to_owned()]);
+        let [_, _] = tree.split_below(b, 0.5, vec!["tab5".to_owned()]);
 
         Self { tree }
     }
@@ -65,6 +48,6 @@ impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         DockArea::new(&mut self.tree)
             .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx);
+            .show(ctx, &mut TabViewer {});
     }
 }

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -1,0 +1,86 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use std::collections::BTreeMap;
+
+use eframe::{egui, NativeOptions};
+
+/// We identify tabs by the title of the file we are editing.
+type Title = String;
+
+fn main() {
+    let options = NativeOptions::default();
+    eframe::run_native(
+        "Text editor examples",
+        options,
+        Box::new(|_cc| Box::new(MyApp::default())),
+    );
+}
+
+struct Buffers {
+    buffers: BTreeMap<Title, String>,
+}
+
+impl egui_dock::TabViewer for Buffers {
+    type Tab = Title;
+
+    fn ui(&mut self, ui: &mut egui::Ui, title: &mut Title) {
+        let text = self.buffers.entry(title.clone()).or_default();
+        egui::TextEdit::multiline(text)
+            .desired_width(f32::INFINITY)
+            .show(ui);
+    }
+
+    fn title(&mut self, title: &mut Title) -> egui::WidgetText {
+        egui::WidgetText::from(&*title)
+    }
+}
+
+struct MyApp {
+    buffers: Buffers,
+    tree: egui_dock::Tree<String>,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        let mut buffers = BTreeMap::default();
+        buffers.insert(
+            "CHANGELOG.md".to_owned(),
+            include_str!("../CHANGELOG.md").to_owned(),
+        );
+        buffers.insert("LICENSE".to_owned(), include_str!("../LICENSE").to_owned());
+        buffers.insert(
+            "README.md".to_owned(),
+            include_str!("../README.md").to_owned(),
+        );
+
+        let tree = egui_dock::Tree::new(vec!["README.md".to_owned(), "CHANGELOG.md".to_owned()]);
+
+        Self {
+            buffers: Buffers { buffers },
+            tree,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left("documents").show(ctx, |ui| {
+            for title in self.buffers.buffers.keys() {
+                let tab_location = self.tree.find_tab(title);
+                let is_open = tab_location.is_some();
+                if ui.selectable_label(is_open, title).clicked() {
+                    if let Some((node_index, tab_index)) = tab_location {
+                        self.tree.set_active_tab(node_index, tab_index);
+                    } else {
+                        // Open the file for editing:
+                        self.tree.push_to_focused_leaf(title.clone());
+                    }
+                }
+            }
+        });
+
+        egui_dock::DockArea::new(&mut self.tree)
+            .style(egui_dock::Style::from_egui(ctx.style().as_ref()))
+            .show(ctx, &mut self.buffers);
+    }
+}

--- a/examples/traits.rs
+++ b/examples/traits.rs
@@ -71,7 +71,7 @@ impl eframe::App for MyApp {
                         .push_to_focused_leaf(Box::new(Editor::new("New Text".into())));
                 }
             });
-        DockArea::new(&mut self.tree).show(ctx, &mut egui_dock::TabViewer {});
+        DockArea::new(&mut self.tree).show(ctx, &mut egui_dock::DynamicTabViewer {});
     }
 }
 

--- a/examples/traits.rs
+++ b/examples/traits.rs
@@ -6,7 +6,7 @@ use egui::{
     Window,
 };
 
-use egui_dock::{DockArea, NodeIndex, TabBuilder, TabTrait, Tree};
+use egui_dock::{DockArea, DynamicTree, NodeIndex, Tab, TabBuilder};
 
 fn main() {
     let options = NativeOptions::default();
@@ -18,7 +18,7 @@ fn main() {
 }
 
 struct MyApp {
-    tree: Tree,
+    tree: DynamicTree,
 }
 
 impl Default for MyApp {
@@ -50,7 +50,7 @@ impl Default for MyApp {
             })
             .build();
 
-        let mut tree = Tree::new(vec![tab1, tab2]);
+        let mut tree = DynamicTree::new(vec![tab1, tab2]);
 
         // You can modify the tree before constructing the dock
         let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec![tab3]);
@@ -71,7 +71,7 @@ impl eframe::App for MyApp {
                         .push_to_focused_leaf(Box::new(Editor::new("New Text".into())));
                 }
             });
-        DockArea::new(&mut self.tree).show(ctx);
+        DockArea::new(&mut self.tree).show(ctx, &mut egui_dock::TabViewer {});
     }
 }
 
@@ -100,7 +100,7 @@ impl Editor {
     }
 }
 
-impl TabTrait for Editor {
+impl Tab for Editor {
     fn ui(&mut self, ui: &mut Ui) {
         if self.show_save {
             Window::new("Save")

--- a/examples/traits.rs
+++ b/examples/traits.rs
@@ -6,7 +6,7 @@ use egui::{
     Window,
 };
 
-use egui_dock::{DockArea, NodeIndex, Tab, TabBuilder, Tree};
+use egui_dock::{DockArea, NodeIndex, TabBuilder, TabTrait, Tree};
 
 fn main() {
     let options = NativeOptions::default();
@@ -100,7 +100,7 @@ impl Editor {
     }
 }
 
-impl Tab for Editor {
+impl TabTrait for Editor {
     fn ui(&mut self, ui: &mut Ui) {
         if self.show_save {
             Window::new("Save")

--- a/src/dynamic_tab.rs
+++ b/src/dynamic_tab.rs
@@ -132,7 +132,7 @@ impl TabBuilder {
     ///
     /// If no function is set the default behavior is to always return true.
     ///
-    /// See [Tab](crate::tab::Tab) `on_close` for more detail
+    /// See [`Tab::on_close`] for more detail
     pub fn on_close(mut self, on_close: impl FnMut() -> bool + 'static) -> Self {
         self.on_close = Some(Box::new(on_close));
         self
@@ -143,7 +143,7 @@ impl TabBuilder {
     ///
     /// If no function is set the default behavior is to always return false.
     ///
-    /// See [Tab](crate::tab::Tab) `force_close` for more detail
+    /// See [`Tab::force_close`] for more detail
     pub fn force_close(mut self, force_close: impl FnMut() -> bool + 'static) -> Self {
         self.force_close = Some(Box::new(force_close));
         self
@@ -152,10 +152,10 @@ impl TabBuilder {
 
 // ----------------------------------------------------------------------------
 
-/// A type-def for when using [`DyanicTab`] or [`TabBuilder`].
+/// A type-def for when using [`Tab`] or [`TabBuilder`].
 pub type DynamicTree = crate::Tree<Box<dyn Tab>>;
 
-/// For use with [`DockArea::show`] when using [`DynamicTree`].
+/// For use with [`crate::DockArea::show`] when using [`DynamicTree`].
 #[derive(Default)]
 pub struct DynamicTabViewer {}
 

--- a/src/dynamic_tab.rs
+++ b/src/dynamic_tab.rs
@@ -157,9 +157,9 @@ pub type DynamicTree = crate::Tree<Box<dyn Tab>>;
 
 /// For use with [`DockArea::show`] when using [`DynamicTree`].
 #[derive(Default)]
-pub struct TabViewer {}
+pub struct DynamicTabViewer {}
 
-impl crate::TabViewer for TabViewer {
+impl crate::TabViewer for DynamicTabViewer {
     type Tab = Box<dyn Tab>;
 
     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,13 +47,15 @@ pub use style::{Style, StyleBuilder};
 use tree::TabIndex;
 use utils::*;
 
-pub use self::tab::{TabBuilder, TabTrait};
+pub use self::dynamic_tab::{DynamicTree, Tab, TabBuilder, TabViewer};
 pub use self::tree::{Node, NodeIndex, Split, Tree};
 
+mod dynamic_tab;
 mod style;
-mod tab;
 mod tree;
 mod utils;
+
+// ----------------------------------------------------------------------------
 
 struct HoverData {
     rect: Rect,
@@ -120,6 +122,7 @@ impl State {
 
 // ----------------------------------------------------------------------------
 
+/// How we view a tab when its in a [`Tree`].
 pub trait TabViewer {
     type Tab;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,38 +6,56 @@
 //!
 //! ## Usage
 //!
-//! First, construct the initial tree
+//! The library is centered around the [`Tree`].
+//! It stores the layout of [`Node`]s which contains tabs.
+//!
+//! [`Tree`] is generic (`Tree<Tab>`) so you can use any data to represent a tab.
+//! You show the tabs using [`DockArea`] and specify how they are shown
+//! by implementing [`TabViewer`].
 //!
 //! ```rust
-//! use egui::{Color32, RichText, style::Margin};
-//! use egui_dock::{TabBuilder, Tree, NodeIndex};
+//! use egui_dock::{NodeIndex, Tree};
 //!
-//! let tab1 = TabBuilder::default()
-//!     .title(RichText::new("Tab 1").color(Color32::BLUE))
-//!     .content(|ui| {
-//!         ui.label("Tab 1");
-//!     })
-//!     .build();
-//! let tab2 = TabBuilder::default()
-//!     .title("Tab 2")
-//!     .inner_margin(Margin::same(4.0))
-//!     .content(|ui| {
-//!         ui.label("Tab 2");
-//!     })
-//!     .build();
+//! struct MyTabs {
+//!     tree: Tree<String>
+//! }
 //!
-//! let mut tree = Tree::new(vec![tab1]);
+//! impl MyTabs {
+//!     pub fn new() -> Self {
+//!         let tab1 = "tab1".to_string();
+//!         let tab2 = "tab2".to_string();
 //!
-//! tree.split_left(NodeIndex::root(), 0.20, vec![tab2]);
-//! ```
+//!         let mut tree = Tree::new(vec![tab1]);
+//!         tree.split_left(NodeIndex::root(), 0.20, vec![tab2]);
 //!
-//! Then, you can show the dock.
+//!         Self { tree }
+//!     }
 //!
-//! ```rust
-//! # use egui_dock::{DockArea, Tree};
+//!     fn ui(&mut self, ui: &mut egui::Ui) {
+//!         let style = egui_dock::Style::from_egui(ui.style().as_ref());
+//!         egui_dock::DockArea::new(&mut self.tree)
+//!             .style(style)
+//!             .show_inside(ui, &mut TabViewer {});
+//!     }
+//! }
+//!
+//! struct TabViewer {}
+//!
+//! impl egui_dock::TabViewer for TabViewer {
+//!     type Tab = String;
+//!
+//!     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+//!         ui.label(format!("Content of {tab}"));
+//!     }
+//!
+//!     fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+//!         (&*tab).into()
+//!     }
+//! }
+//!
+//! # let mut my_tabs = MyTabs::new();
 //! # egui::__run_test_ctx(|ctx| {
-//! # let mut tree = Tree::new(vec![]);
-//! DockArea::new(&mut tree).show(ctx);
+//! #     egui::CentralPanel::default().show(ctx, |ui| my_tabs.ui(ui));
 //! # });
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use style::{Style, StyleBuilder};
 use tree::TabIndex;
 use utils::*;
 
-pub use self::dynamic_tab::{DynamicTree, Tab, TabBuilder, TabViewer};
+pub use self::dynamic_tab::{DynamicTabViewer, DynamicTree, Tab, TabBuilder};
 pub use self::tree::{Node, NodeIndex, Split, Tree};
 
 mod dynamic_tab;

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -14,7 +14,7 @@ pub struct TabBuilder {
 }
 
 /// Dockable tab that can be used in `Tree`s.
-pub trait Tab {
+pub trait TabTrait {
     /// Actual tab content.
     fn ui(&mut self, ui: &mut Ui);
 
@@ -48,7 +48,7 @@ pub struct BuiltTab {
     force_close: Option<ForceClose>,
 }
 
-impl Tab for BuiltTab {
+impl TabTrait for BuiltTab {
     fn ui(&mut self, ui: &mut Ui) {
         ScrollArea::both()
             .id_source(self.title.text().to_string() + " - egui_dock::Tab")
@@ -99,7 +99,7 @@ impl TabBuilder {
     ///
     /// # Panics
     /// Panics if `title` or `add_contents` is unset.
-    pub fn build(self) -> Box<dyn Tab> {
+    pub fn build(self) -> Box<dyn TabTrait> {
         Box::new(BuiltTab {
             title: self.title.expect("Missing tab title"),
             inner_margin: self.inner_margin,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -623,6 +623,13 @@ impl<Tab> Tree<Tab>
 where
     Tab: PartialEq,
 {
+    /// Find the given tab.
+    ///
+    /// Returns which node the tab is in, and where in that node the tab is in.
+    ///
+    /// The returned [`NodeIndex`] will always point to a [`Node::Leaf`].
+    ///
+    /// In case there are several hits, only the first is returned.
     pub fn find_tab(&self, needle_tab: &Tab) -> Option<(NodeIndex, TabIndex)> {
         for (node_index, node) in self.tree.iter().enumerate() {
             if let Node::Leaf { tabs, .. } = node {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -224,10 +224,18 @@ pub enum Split {
 // ----------------------------------------------------------------------------
 
 /// Binary tree representing the relationships between `Node`s.
-#[derive(Default)]
 pub struct Tree<Tab> {
     tree: Vec<Node<Tab>>,
     focused_node: Option<NodeIndex>,
+}
+
+impl<Tab> Default for Tree<Tab> {
+    fn default() -> Self {
+        Self {
+            tree: Default::default(),
+            focused_node: Default::default(),
+        }
+    }
 }
 
 impl<Tab> std::ops::Index<NodeIndex> for Tree<Tab> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,18 +1,28 @@
 use egui::*;
 
-pub type Tab = Box<dyn crate::Tab>;
-pub type Tabs = Vec<Tab>;
+/// Identifies a tab within a [`Node`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct TabIndex(pub usize);
+
+impl From<usize> for TabIndex {
+    #[inline]
+    fn from(index: usize) -> Self {
+        TabIndex(index)
+    }
+}
+
+// ----------------------------------------------------------------------------
 
 /// Represents an abstract node of a `Tree`.
-pub enum Node {
+pub enum Node<Tab> {
     /// Empty node
     None,
     /// Contains the actual tabs
     Leaf {
         rect: Rect,
         viewport: Rect,
-        tabs: Tabs,
-        active: usize,
+        tabs: Vec<Tab>,
+        active: TabIndex,
     },
     /// Parent node in the vertical orientation
     Vertical { rect: Rect, fraction: f32 },
@@ -20,14 +30,14 @@ pub enum Node {
     Horizontal { rect: Rect, fraction: f32 },
 }
 
-impl Node {
+impl<Tab> Node<Tab> {
     /// Constructs a leaf node with a given `tab`.
     pub fn leaf(tab: Tab) -> Self {
         Self::Leaf {
             rect: Rect::NOTHING,
             viewport: Rect::NOTHING,
             tabs: vec![tab],
-            active: Default::default(),
+            active: TabIndex(0),
         }
     }
 
@@ -37,7 +47,7 @@ impl Node {
             rect: Rect::NOTHING,
             viewport: Rect::NOTHING,
             tabs,
-            active: 0,
+            active: TabIndex(0),
         }
     }
 
@@ -81,8 +91,8 @@ impl Node {
     pub fn append_tab(&mut self, tab: Tab) {
         match self {
             Node::Leaf { tabs, active, .. } => {
+                *active = TabIndex(tabs.len());
                 tabs.push(tab);
-                *active = tabs.len() - 1;
             }
             _ => unreachable!(),
         }
@@ -94,10 +104,10 @@ impl Node {
     /// Panics if the new capacity of `tabs` exceeds isize::MAX bytes.
     /// index > tabs_count()
     #[track_caller]
-    pub fn insert_tab(&mut self, index: usize, tab: Tab) {
+    pub fn insert_tab(&mut self, index: TabIndex, tab: Tab) {
         match self {
             Node::Leaf { tabs, active, .. } => {
-                tabs.insert(index, tab);
+                tabs.insert(index.0, tab);
                 *active = index;
             }
             _ => unreachable!(),
@@ -109,9 +119,9 @@ impl Node {
     ///
     /// # Panics
     /// Panics if `index` is out of bounds.
-    pub fn remove_tab(&mut self, index: usize) -> Option<Tab> {
+    pub fn remove_tab(&mut self, tab_index: TabIndex) -> Option<Tab> {
         match self {
-            Node::Leaf { tabs, .. } => Some(tabs.remove(index)),
+            Node::Leaf { tabs, .. } => Some(tabs.remove(tab_index.0)),
             _ => None,
         }
     }
@@ -125,9 +135,18 @@ impl Node {
     }
 }
 
+// ----------------------------------------------------------------------------
+
 /// Wrapper around indices to the collection of nodes inside a `Tree`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct NodeIndex(pub usize);
+
+impl From<usize> for NodeIndex {
+    #[inline]
+    fn from(index: usize) -> Self {
+        NodeIndex(index)
+    }
+}
 
 impl NodeIndex {
     /// Returns the index of the root node.
@@ -191,6 +210,8 @@ impl NodeIndex {
     }
 }
 
+// ----------------------------------------------------------------------------
+
 /// Direction in which a new node is created relatively to the parent node at which the split occurs.
 #[derive(Clone, Copy)]
 pub enum Split {
@@ -200,15 +221,17 @@ pub enum Split {
     Below,
 }
 
+// ----------------------------------------------------------------------------
+
 /// Binary tree representing the relationships between `Node`s.
 #[derive(Default)]
-pub struct Tree {
-    tree: Vec<Node>,
+pub struct Tree<Tab> {
+    tree: Vec<Node<Tab>>,
     focused_node: Option<NodeIndex>,
 }
 
-impl std::ops::Index<NodeIndex> for Tree {
-    type Output = Node;
+impl<Tab> std::ops::Index<NodeIndex> for Tree<Tab> {
+    type Output = Node<Tab>;
 
     #[inline(always)]
     fn index(&self, index: NodeIndex) -> &Self::Output {
@@ -216,17 +239,17 @@ impl std::ops::Index<NodeIndex> for Tree {
     }
 }
 
-impl std::ops::IndexMut<NodeIndex> for Tree {
+impl<Tab> std::ops::IndexMut<NodeIndex> for Tree<Tab> {
     #[inline(always)]
     fn index_mut(&mut self, index: NodeIndex) -> &mut Self::Output {
         &mut self.tree[index.0]
     }
 }
 
-impl Tree {
+impl<Tab> Tree<Tab> {
     /// Creates a new `Tree` with given `Vec` of `Tab`s in its root node.
     #[inline(always)]
-    pub fn new(tabs: Tabs) -> Self {
+    pub fn new(tabs: Vec<Tab>) -> Self {
         let root = Node::leaf_with(tabs);
         Self {
             tree: vec![root],
@@ -244,7 +267,7 @@ impl Tree {
                 ..
             } = node
             {
-                tabs.get_mut(*active).map(|tab| (*viewport, tab))
+                tabs.get_mut(active.0).map(|tab| (*viewport, tab))
             } else {
                 None
             }
@@ -264,12 +287,12 @@ impl Tree {
     }
 
     /// Returns `Iter` of the underlying collection of nodes.
-    pub fn iter(&self) -> std::slice::Iter<'_, Node> {
+    pub fn iter(&self) -> std::slice::Iter<'_, Node<Tab>> {
         self.tree.iter()
     }
 
     /// Returns `IterMut` of the underlying collection of nodes.
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Node> {
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Node<Tab>> {
         self.tree.iter_mut()
     }
 
@@ -287,7 +310,7 @@ impl Tree {
         parent: NodeIndex,
         split: Split,
         fraction: f32,
-        tabs: Tabs,
+        tabs: Vec<Tab>,
     ) -> [NodeIndex; 2] {
         self.split(parent, split, fraction, Node::leaf_with(tabs))
     }
@@ -301,7 +324,12 @@ impl Tree {
     /// The new node is placed above the old node.
     ///
     /// Returns the indices of the old node and the new node.
-    pub fn split_above(&mut self, parent: NodeIndex, fraction: f32, tabs: Tabs) -> [NodeIndex; 2] {
+    pub fn split_above(
+        &mut self,
+        parent: NodeIndex,
+        fraction: f32,
+        tabs: Vec<Tab>,
+    ) -> [NodeIndex; 2] {
         self.split(parent, Split::Above, fraction, Node::leaf_with(tabs))
     }
 
@@ -314,7 +342,12 @@ impl Tree {
     /// The new node is placed below the old node.
     ///
     /// Returns the indices of the old node and the new node.
-    pub fn split_below(&mut self, parent: NodeIndex, fraction: f32, tabs: Tabs) -> [NodeIndex; 2] {
+    pub fn split_below(
+        &mut self,
+        parent: NodeIndex,
+        fraction: f32,
+        tabs: Vec<Tab>,
+    ) -> [NodeIndex; 2] {
         self.split(parent, Split::Below, fraction, Node::leaf_with(tabs))
     }
 
@@ -327,7 +360,12 @@ impl Tree {
     /// The new node is placed to the left of the old node.
     ///
     /// Returns the indices of the old node and the new node.
-    pub fn split_left(&mut self, parent: NodeIndex, fraction: f32, tabs: Tabs) -> [NodeIndex; 2] {
+    pub fn split_left(
+        &mut self,
+        parent: NodeIndex,
+        fraction: f32,
+        tabs: Vec<Tab>,
+    ) -> [NodeIndex; 2] {
         self.split(parent, Split::Left, fraction, Node::leaf_with(tabs))
     }
 
@@ -340,7 +378,12 @@ impl Tree {
     /// The new node is placed to the right of the old node.
     ///
     /// Returns the indices of the old node and the new node.
-    pub fn split_right(&mut self, parent: NodeIndex, fraction: f32, tabs: Tabs) -> [NodeIndex; 2] {
+    pub fn split_right(
+        &mut self,
+        parent: NodeIndex,
+        fraction: f32,
+        tabs: Vec<Tab>,
+    ) -> [NodeIndex; 2] {
         self.split(parent, Split::Right, fraction, Node::leaf_with(tabs))
     }
 
@@ -358,7 +401,7 @@ impl Tree {
         parent: NodeIndex,
         split: Split,
         fraction: f32,
-        new: Node,
+        new: Node<Tab>,
     ) -> [NodeIndex; 2] {
         let old = self[parent].split(split, fraction);
         assert!(old.is_leaf());
@@ -382,6 +425,30 @@ impl Tree {
         index
     }
 
+    fn first_leaf(&self, top: NodeIndex) -> Option<NodeIndex> {
+        let left = top.left();
+        let right = top.right();
+        match (self.tree.get(left.0), self.tree.get(right.0)) {
+            (Some(&Node::Leaf { .. }), _) => Some(left),
+            (_, Some(&Node::Leaf { .. })) => Some(left),
+
+            (
+                Some(Node::Horizontal { .. } | Node::Vertical { .. }),
+                Some(Node::Horizontal { .. } | Node::Vertical { .. }),
+            ) => match self.first_leaf(left) {
+                ret @ Some(_) => ret,
+                None => self.first_leaf(right),
+            },
+            (Some(Node::Horizontal { .. } | Node::Vertical { .. }), _) => self.first_leaf(left),
+            (_, Some(Node::Horizontal { .. } | Node::Vertical { .. })) => self.first_leaf(right),
+
+            (None, None)
+            | (Some(&Node::None), None)
+            | (None, Some(&Node::None))
+            | (Some(&Node::None), Some(&Node::None)) => None,
+        }
+    }
+
     /// Removes the first node containing 0 tabs.
     pub fn remove_empty_leaf(&mut self) {
         let mut nodes = self.tree.iter().enumerate();
@@ -403,34 +470,6 @@ impl Tree {
             }
         };
 
-        fn first_leaf(tree: &Tree, top: NodeIndex) -> Option<NodeIndex> {
-            let left = top.left();
-            let right = top.right();
-            match (tree.tree.get(left.0), tree.tree.get(right.0)) {
-                (Some(&Node::Leaf { .. }), _) => Some(left),
-                (_, Some(&Node::Leaf { .. })) => Some(left),
-
-                (
-                    Some(Node::Horizontal { .. } | Node::Vertical { .. }),
-                    Some(Node::Horizontal { .. } | Node::Vertical { .. }),
-                ) => match first_leaf(tree, left) {
-                    ret @ Some(_) => ret,
-                    None => first_leaf(tree, right),
-                },
-                (Some(Node::Horizontal { .. } | Node::Vertical { .. }), _) => {
-                    first_leaf(tree, left)
-                }
-                (_, Some(Node::Horizontal { .. } | Node::Vertical { .. })) => {
-                    first_leaf(tree, right)
-                }
-
-                (None, None)
-                | (Some(&Node::None), None)
-                | (None, Some(&Node::None))
-                | (Some(&Node::None), Some(&Node::None)) => None,
-            }
-        }
-
         if Some(node) == self.focused_node {
             self.focused_node = None;
             let mut node = node;
@@ -444,7 +483,7 @@ impl Tree {
                     self.focused_node = Some(next);
                     break;
                 }
-                if let Some(node) = first_leaf(self, next) {
+                if let Some(node) = self.first_leaf(next) {
                     self.focused_node = Some(node);
                     break;
                 }
@@ -495,9 +534,9 @@ impl Tree {
         for (index, node) in &mut self.tree.iter_mut().enumerate() {
             match node {
                 Node::Leaf { tabs, active, .. } => {
+                    *active = TabIndex(tabs.len());
                     tabs.push(tab);
                     self.focused_node = Some(NodeIndex(index));
-                    *active = tabs.len() - 1;
                     return;
                 }
                 Node::None => {
@@ -516,12 +555,19 @@ impl Tree {
         self.focused_node
     }
 
-    /// Sets the currently focused leaf to `node_index` if the node at `node_index` isn't `Node::Leaf`.
-    pub fn set_focused(&mut self, node_index: NodeIndex) {
+    /// Sets the currently focused leaf to `node_index` if the node at `node_index` is a leaf.
+    pub fn set_focused_node(&mut self, node_index: NodeIndex) {
         if let Some(Node::Leaf { .. }) = self.tree.get(node_index.0) {
             self.focused_node = Some(node_index);
         } else {
             self.focused_node = None;
+        }
+    }
+
+    /// Sets which is the active tab within a specific node.
+    pub fn set_active_tab(&mut self, node_index: NodeIndex, tab_index: TabIndex) {
+        if let Some(Node::Leaf { active, .. }) = self.tree.get_mut(node_index.0) {
+            *active = tab_index;
         }
     }
 
@@ -543,8 +589,8 @@ impl Tree {
                             self.focused_node = Some(node);
                         }
                         Node::Leaf { tabs, active, .. } => {
+                            *active = TabIndex(tabs.len());
                             tabs.push(tab);
-                            *active = tabs.len() - 1;
                             self.focused_node = Some(node);
                         }
                         _ => {
@@ -562,5 +608,23 @@ impl Tree {
                 }
             }
         }
+    }
+}
+
+impl<Tab> Tree<Tab>
+where
+    Tab: PartialEq,
+{
+    pub fn find_tab(&self, needle_tab: &Tab) -> Option<(NodeIndex, TabIndex)> {
+        for (node_index, node) in self.tree.iter().enumerate() {
+            if let Node::Leaf { tabs, .. } = node {
+                for (tab_index, tab) in tabs.iter().enumerate() {
+                    if tab == needle_tab {
+                        return Some((node_index.into(), tab_index.into()));
+                    }
+                }
+            }
+        }
+        None
     }
 }


### PR DESCRIPTION
The current `trait Tab` implementation has some limitations:

A) We cannot serialize `Tree`:s.
B) One must create the tabs up-front with everything they need to show themselves (with `Tab::ui`).

The second point in particular impose very weird constraints on users. If a tab wants to modify some global state, it need to be initialized with a `Arc<Mutex<State>>` or similar. I don't like!

This PR is a refactor that solves both these problems (and more!?).

The approach is this: instead of storing a `Box<dyn Tab>` in `Tree`, we instead make `Tree` generic over what the user wants to identify a tab (`Tree<Tab>`). For instance, a user may identify each tab by a UUID or similar. Then we use a new `trait TabView` which actually shows the tabs, fetches their titles, handles close events, and so on.

The old `trait Tab` approach can still be implemented on top of this implementation, if one so desires.

In general, I think this is a better approach to a generic library. I'm not sure if we should even keep the old `trait Tab`, or let users define that themselves.

---

**TODO**
* [x] Figure out if we want to keep `trait Tab`, and if so if we should add some helpers to make make the use of it similar to before

---

Other changes in this PR:
* A new newtype `struct TabIndex(pub usize)` for better typesafety (and self-documenting code).
* Add `Tree::find_tab`
* Add `Tree::set_active_tab`
* Rename `Tree::set_focused` to `Tree::set_focused_node`.