### PR TITLE
StyleBuilder::from_egui, multiple dock IDs, Tree::find_active_focused

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     let mut ui = ui.child_ui(rect, Default::default());
                     ui.push_id(node_index, |ui| {
                         ScrollArea::both()
-                            .id_source(self.id.with((tab_viewer.title(tab).text(), "egui_dock::Tab")))
+                            .id_source(
+                                self.id
+                                    .with((tab_viewer.title(tab).text(), "egui_dock::Tab")),
+                            )
                             .show(ui, |ui| {
                                 Frame::none().inner_margin(tab_viewer.inner_margin()).show(
                                     ui,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                     ui.horizontal(|ui| {
                         for (tab_index, tab) in tabs.iter_mut().enumerate() {
-                            let id = Id::new((node_index, tab_index, "tab"));
+                            let id = self.id.with((node_index, tab_index, "tab"));
                             let tab_index = TabIndex(tab_index);
                             let is_being_dragged =
                                 ui.memory().is_being_dragged(id) && style.tabs_are_draggable;
@@ -447,7 +447,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     let mut ui = ui.child_ui(rect, Default::default());
                     ui.push_id(node_index, |ui| {
                         ScrollArea::both()
-                            .id_source(Id::new((tab_viewer.title(tab).text(), "egui_dock::Tab")))
+                            .id_source(self.id.with((tab_viewer.title(tab).text(), "egui_dock::Tab")))
                             .show(ui, |ui| {
                                 Frame::none().inner_margin(tab_viewer.inner_margin()).show(
                                     ui,

--- a/src/style.rs
+++ b/src/style.rs
@@ -309,16 +309,7 @@ impl StyleBuilder {
 
     /// Derives relevant fields from `egui::Style` and sets the remaining fields to their default values.
     ///
-    /// Fields overwritten by [`egui::Style`] are:
-    /// - `selection_color`
-    /// - `tab_bar_background_color`
-    /// - `tab_outline_color`
-    /// - `tab_background_color`
-    /// - `separator_color`
-    /// - `border_color`
-    /// - `close_tab_background_color`
-    /// - `close_tab_color`
-    /// - `close_tab_active_color`
+    /// See also: [Style::from_egui].
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             style: Style::from_egui(style),

--- a/src/style.rs
+++ b/src/style.rs
@@ -307,6 +307,24 @@ impl StyleBuilder {
         Self::default()
     }
 
+    /// Derives relevant fields from `egui::Style` and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - `selection_color`
+    /// - `tab_bar_background_color`
+    /// - `tab_outline_color`
+    /// - `tab_background_color`
+    /// - `separator_color`
+    /// - `border_color`
+    /// - `close_tab_background_color`
+    /// - `close_tab_color`
+    /// - `close_tab_active_color`
+    pub fn from_egui(style: &egui::Style) -> Self {
+        Self {
+            style: Style::from_egui(style),
+        }
+    }
+
     /// Sets `padding` to indent from the edges of the window. By `Default` it's `None`.
     #[inline(always)]
     pub fn with_padding(mut self, padding: Margin) -> Self {

--- a/src/style.rs
+++ b/src/style.rs
@@ -309,7 +309,7 @@ impl StyleBuilder {
 
     /// Derives relevant fields from `egui::Style` and sets the remaining fields to their default values.
     ///
-    /// See also: [Style::from_egui].
+    /// See also: [`Style::from_egui`].
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             style: Style::from_egui(style),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -302,6 +302,21 @@ impl<Tab> Tree<Tab> {
         })
     }
 
+    /// Returns the viewport `Rect` and the `Tab` inside the focused leaf node or `None` if it does not exist.
+    pub fn find_active_focused(&mut self) -> Option<(Rect, &mut Tab)> {
+        if let Some(Node::Leaf {
+            tabs,
+            active,
+            viewport,
+            ..
+        }) = self.focused_node.and_then(|idx| self.tree.get_mut(idx.0))
+        {
+            tabs.get_mut(active.0).map(|tab| (*viewport, tab))
+        } else {
+            None
+        }
+    }
+
     /// Returns the number of nodes in the `Tree`.
     #[inline(always)]
     pub fn len(&self) -> usize {


### PR DESCRIPTION
<img width="957" alt="image" src="https://user-images.githubusercontent.com/10081540/191049695-289284f0-fc16-4251-94e8-6484828469d7.png">


Currently I am making extensive use of `egui_dock` in my application, but I found that it was missing several features that would have improved my quality of life vastly. This is a PR with 3 of such improvements:
* `StyleBuilder::from_egui` - Initializes the inner `Style` of `StyleBuilder` through `Style::from_egui`.
* Having multiple Docks, even with different `id`s caused clashes in the id space (even if I used `ui.push_id`). This change makes the  id sources of several elements factor in the Dock's own `id` to prevent clashes.
  * Pictured above is two separate docks :)
* `Tree::find_active_focused` - The tree exposed `find_active`, but it did not expose the same funcitonality when there are potentially multiple splits. This change introduces `find_active_focused` to do exactly that.

They are small enough that I put them in a single PR, but let me know if you would like me to split them.