### PR TITLE
Add option to expand tabs to fill tab bar

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -104,6 +104,7 @@ impl MyContext {
             ui.separator();
 
             ui.checkbox(&mut style.tabs_are_draggable, "Tabs are draggable");
+            ui.checkbox(&mut style.expand_tabs, "Expand tabs");
 
             ui.separator();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     let b = pos2(tabbar.max.x, tabbar.max.y - px);
                     ui.painter()
                         .line_segment([a, b], (px, style.tab_outline_color));
+                    let expanded_width = (tabbar.max.x - tabbar.min.x) / (tabs.len() as f32);
 
                     let mut ui = ui.child_ui(tabbar, Default::default());
                     ui.spacing_mut().item_spacing = vec2(0.0, 0.0);
@@ -345,6 +346,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                             is_active && Some(node_index) == focused,
                                             is_being_dragged,
                                             id,
+                                            expanded_width,
                                         )
                                     })
                                     .response;
@@ -389,6 +391,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                     is_active,
                                     is_being_dragged,
                                     id,
+                                    expanded_width,
                                 );
 
                                 let sense = if response.1 {

--- a/src/style.rs
+++ b/src/style.rs
@@ -25,6 +25,7 @@ pub struct Style {
     pub tab_text_color_focused: Color32,
 
     pub tabs_are_draggable: bool,
+    pub expand_tabs: bool,
 
     pub close_tab_color: Color32,
     pub close_tab_active_color: Color32,
@@ -60,6 +61,7 @@ impl Default for Style {
             show_close_buttons: true,
 
             tabs_are_draggable: true,
+            expand_tabs: false,
         }
     }
 }
@@ -181,6 +183,7 @@ impl Style {
     }
 
     /// `active` means "the tab that is opened in the parent panel".
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn tab_title(
         &self,
         ui: &mut Ui,
@@ -189,30 +192,31 @@ impl Style {
         active: bool,
         is_being_dragged: bool,
         id: Id,
+        expanded_width: f32,
     ) -> (Response, bool, bool) {
         let px = ui.ctx().pixels_per_point().recip();
         let rounding = self.tab_rounding;
 
         let galley = label.into_galley(ui, None, f32::INFINITY, TextStyle::Button);
 
-        let x_text_gap = 5.0;
         let x_size = Vec2::new(galley.size().y / 1.3, galley.size().y / 1.3);
 
         let offset = vec2(8.0, 0.0);
-        let text_size = galley.size();
 
-        let mut desired_size = text_size + offset * 2.0;
-        if self.show_close_buttons {
-            desired_size.x += x_size.x + x_text_gap;
-        }
-        desired_size.y = 24.0;
+        let desired_size = if self.expand_tabs {
+            vec2(expanded_width, 24.0)
+        } else if self.show_close_buttons {
+            vec2(galley.size().x + offset.x * 2.0 + x_size.x + 5.0, 24.0)
+        } else {
+            vec2(galley.size().x + offset.x * 2.0, 24.0)
+        };
 
         let (rect, response) = ui.allocate_at_least(desired_size, Sense::hover());
         let response = response.on_hover_cursor(CursorIcon::PointingHand);
 
         let (x_rect, x_res) = if (active || response.hovered()) && self.show_close_buttons {
-            let mut pos = rect.left_top();
-            pos.x += offset.x + text_size.x + x_text_gap + x_size.x / 2.0;
+            let mut pos = rect.right_top();
+            pos.x -= offset.x + x_size.x / 2.0;
             pos.y += rect.size().y / 2.0;
             let x_rect = Rect::from_center_size(pos, x_size);
             (x_rect, Some(ui.interact(x_rect, id, Sense::click())))
@@ -245,9 +249,15 @@ impl Style {
             _ => (),
         }
 
-        let pos = Align2::LEFT_TOP
-            .anchor_rect(rect.shrink2(vec2(8.0, 5.0)))
-            .min;
+        let pos = if self.expand_tabs {
+            let mut pos = Align2::CENTER_TOP.pos_in_rect(&rect.shrink2(vec2(8.0, 5.0)));
+            pos.x -= galley.size().x / 2.0;
+            pos
+        } else {
+            Align2::LEFT_TOP
+                .anchor_rect(rect.shrink2(vec2(8.0, 5.0)))
+                .min
+        };
 
         let override_text_color = if galley.galley_has_color {
             None // respect the color the user has chosen


### PR DESCRIPTION
Closes #44.

I added an option to Style and added a checkbox to the `hello` example to demonstrate its use.

For #43, the calculation of `expanded_width` in `lib.rs` will need tweaking to subtract the width of the add-tab button from the available width, which should be painless. If that gets merged first I can update this PR as appropriate.

![image](https://user-images.githubusercontent.com/47219/193158328-0068cfc1-daf0-4189-85b5-dffed862373d.png)
