### PR TITLE
Fix: use the correct icon when dragging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                             let is_being_dragged =
                                 ui.memory().is_being_dragged(id) && style.tabs_are_draggable;
 
+                            if is_being_dragged {
+                                ui.output().cursor_icon = CursorIcon::Grabbing;
+                            }
+
                             let is_active = *active == tab_index || is_being_dragged;
                             let label = tab_viewer.title(tab);
 
@@ -355,9 +359,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                     .response;
 
                                 let sense = Sense::click_and_drag();
-                                let response = ui
-                                    .interact(response.rect, id, sense)
-                                    .on_hover_cursor(CursorIcon::Grabbing);
+                                let response = ui.interact(response.rect, id, sense);
 
                                 if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
                                     let center = response.rect.center();

--- a/src/style.rs
+++ b/src/style.rs
@@ -215,8 +215,10 @@ impl Style {
             vec2(galley.size().x + offset.x * 2.0, 24.0)
         };
 
-        let (rect, response) = ui.allocate_at_least(desired_size, Sense::hover());
-        let response = response.on_hover_cursor(CursorIcon::PointingHand);
+        let (rect, mut response) = ui.allocate_at_least(desired_size, Sense::hover());
+        if !ui.memory().is_anything_being_dragged() {
+            response = response.on_hover_cursor(CursorIcon::Grab);
+        }
 
         let (x_rect, x_res) = if (active || response.hovered()) && self.show_close_buttons {
             let mut pos = rect.right_top();


### PR DESCRIPTION
Previously, you would have `CursorIcon::PointingHand` when hovering a tab title. When dragging a tab, you would get `CursorIcon::Grabbing`, but if you dragged a tab so it was hovering another title, it would go back to `CursorIcon::PointingHand`.

This PR changes the hovering cursor to `CursorIcon::Grab`. Additionally, it fixes the above bug so that `CursorIcon::Grabbing` is used all the while a tab is being dragged.

![tab-cursor-fix](https://user-images.githubusercontent.com/1148717/194847897-13b6098a-cc2c-4411-9881-55f244454823.gif)
