### PR TITLE
added hover shows tab name when style enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 - New option `expand_tabs` in `Style` causes tab titles to expand to fill the width of their tab bars.
 - Added `context_menu` into `TabViewer` ([#46](https://github.com/Adanos020/egui_dock/pull/46)).        
-- The `ScrollArea` inside a Tab is now Optional via `Style` ([#49](https://github.com/Adanos020/egui_dock/pull/49)).
+- The `ScrollArea` inside a tab is now optional via `Style` ([#49](https://github.com/Adanos020/egui_dock/pull/49)).
 - `Tree::tabs`: an iterator over the tabs in a tree ([#53](https://github.com/Adanos020/egui_dock/pull/53)).
+- `Style` now includes an option to show the hoverd tab's name ([#56](https://github.com/Adanos020/egui_dock/pull/56)) 
 
 ## 0.2.1 - 2022-09-09
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -120,6 +120,7 @@ impl MyContext {
         ui.collapsing("Tabs", |ui| {
             ui.separator();
 
+            ui.checkbox(&mut style.tab_hover_name, "Show tab name when hoverd over them");
             ui.checkbox(&mut style.tabs_are_draggable, "Tabs are draggable");
             ui.checkbox(&mut style.expand_tabs, "Expand tabs");
             ui.checkbox(&mut style.show_context_menu, "Show context_menu");

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -120,7 +120,10 @@ impl MyContext {
         ui.collapsing("Tabs", |ui| {
             ui.separator();
 
-            ui.checkbox(&mut style.tab_hover_name, "Show tab name when hoverd over them");
+            ui.checkbox(
+                &mut style.tab_hover_name,
+                "Show tab name when hoverd over them",
+            );
             ui.checkbox(&mut style.tabs_are_draggable, "Tabs are draggable");
             ui.checkbox(&mut style.expand_tabs, "Expand tabs");
             ui.checkbox(&mut style.show_context_menu, "Show context_menu");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,6 +405,12 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                     Sense::click_and_drag()
                                 };
 
+                                if style.tab_hover_name {
+                                    response.0.clone().on_hover_ui(|ui| {
+                                        ui.label(tab_viewer.title(tab));
+                                    });
+                                }
+
                                 if style.show_context_menu {
                                     response.0.clone().context_menu(|ui| {
                                         tab_viewer.context_menu(ui, tab);

--- a/src/style.rs
+++ b/src/style.rs
@@ -33,6 +33,7 @@ pub struct Style {
     pub show_close_buttons: bool,
     pub show_context_menu: bool,
     pub tab_include_scrollarea: bool,
+    pub tab_hover_name: bool,
 }
 
 impl Default for Style {
@@ -66,6 +67,7 @@ impl Default for Style {
             expand_tabs: false,
             show_context_menu: true,
             tab_include_scrollarea: true,
+            tab_hover_name: false,
         }
     }
 }
@@ -480,6 +482,13 @@ impl StyleBuilder {
     #[inline(always)]
     pub fn with_tab_scroll_area(mut self, tab_include_scrollarea: bool) -> Self {
         self.style.tab_include_scrollarea = tab_include_scrollarea;
+        self
+    }
+
+    /// Wheter tabs show their name when hoverd over them.
+    #[inline(always)]
+    pub fn show_name_when_hovered(mut self, tab_hover_name: bool) -> Self {
+        self.style.tab_hover_name = tab_hover_name;
         self
     }
 


### PR DESCRIPTION
Might be useful when #42 is implemented and names aren't fully visible meanwhile it's default is set to false 