### PR TITLE
Make TabIndex publically accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,16 +62,14 @@
 use egui::style::Margin;
 use egui::*;
 
-use tree::TabIndex;
-use utils::*;
-
 #[allow(deprecated)]
 pub use crate::{
     dynamic_tab::{DynamicTabViewer, DynamicTree, Tab, TabBuilder},
     style::{Style, StyleBuilder},
-    tree::{Node, NodeIndex, Split, Tree},
+    tree::{Node, NodeIndex, Split, TabIndex, Tree},
 };
 pub use egui;
+use utils::*;
 
 mod dynamic_tab;
 mod style;


### PR DESCRIPTION
The `TabIndex` is used within the public interface of the crate, however the type itself was not pub.

I also had to change the order of imports a bit because `utils::*` seems to include the type somehow.
That resulted in the type still being inaccessible and the explicit pub use of TabIndex being marked as an "unused import".