### PR TITLE
Fix combining 'expand tabs' and 'show add tab button'

### DIFF
--- a/examples/tab_add.rs
+++ b/examples/tab_add.rs
@@ -58,6 +58,7 @@ impl eframe::App for MyApp {
             .style(
                 StyleBuilder::from_egui(ctx.style().as_ref())
                     .show_add_buttons(true)
+                    .expand_tabs(true)
                     .build(),
             )
             .show(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,11 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     let b = pos2(tabbar.max.x, tabbar.max.y - px);
                     ui.painter()
                         .line_segment([a, b], (px, style.tab_outline_color));
-                    let expanded_width = (tabbar.max.x - tabbar.min.x) / (tabs.len() as f32);
+                    let mut available_width = tabbar.max.x - tabbar.min.x;
+                    if style.show_add_buttons {
+                        available_width -= Style::TAB_PLUS_SIZE;
+                    }
+                    let expanded_width = available_width / (tabs.len() as f32);
 
                     let mut ui = ui.child_ui(tabbar, Default::default());
                     ui.spacing_mut().item_spacing = vec2(0.0, 0.0);

--- a/src/style.rs
+++ b/src/style.rs
@@ -216,8 +216,10 @@ impl Style {
         )
     }
 
+    pub(crate) const TAB_PLUS_SIZE: f32 = 24.0;
+
     pub(crate) fn tab_plus(&self, ui: &mut Ui) -> Response {
-        let desired_size = Vec2::splat(24.0);
+        let desired_size = Vec2::splat(Self::TAB_PLUS_SIZE);
 
         let mut rect = ui.available_rect_before_wrap();
 


### PR DESCRIPTION
Currently if you enable expand-tabs and also show-add-tab-button the tabs expand into the space for the button, which also means their close button overlaps the add button. We discussed this a bit in #44 but because #45 was merged before #43 it didn't include the fix, which I've made here.

I added expand-tabs to the `tab_add` example so that it's easier to see how it works:

![image](https://user-images.githubusercontent.com/47219/200442128-6c4ddec5-b695-4b5c-af9e-4a08f0137ee6.png)
