### PR TITLE
inner_margin in Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - The `ScrollArea` inside a tab is now optional via `Style`. ([#49](https://github.com/Adanos020/egui_dock/pull/49))
 - `Tree::tabs`: an iterator over the tabs in a tree. ([#53](https://github.com/Adanos020/egui_dock/pull/53))
 - `Style` now includes an option to show the hoverd tab's name. ([#56](https://github.com/Adanos020/egui_dock/pull/56))
+- `Style` now includes an option to change default inner_margin. ([#67](https://github.com/Adanos020/egui_dock/pull/67))
+
+### Breaking changes
+- Renamed `TabViewer::inner_margin` to `TabViewer::inner_margin_override`. ([#67](https://github.com/Adanos020/egui_dock/pull/67))
 
 ### Deprecated (will be deleted in the next release)
 - `dynamic_tab::TabContent`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,8 +190,8 @@ pub trait TabViewer {
     }
 
     /// Sets the margins between tab's borders and its contents.
-    fn inner_margin(&self) -> Margin {
-        Margin::same(4.0)
+    fn inner_margin_override(&self, style: &Style) -> Margin {
+        style.default_inner_margin
     }
 
     /// Whether the tab will be cleared with the color specified in [`Style::tab_background_color`]
@@ -520,18 +520,17 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                         .with((tab_viewer.title(tab).text(), "egui_dock::Tab")),
                                 )
                                 .show(ui, |ui| {
-                                    Frame::none().inner_margin(tab_viewer.inner_margin()).show(
-                                        ui,
-                                        |ui| {
+                                    Frame::none()
+                                        .inner_margin(tab_viewer.inner_margin_override(&style))
+                                        .show(ui, |ui| {
                                             let available_rect = ui.available_rect_before_wrap();
                                             ui.expand_to_include_rect(available_rect);
                                             tab_viewer.ui(ui, tab);
-                                        },
-                                    );
+                                        });
                                 });
                         } else {
                             Frame::none()
-                                .inner_margin(tab_viewer.inner_margin())
+                                .inner_margin(tab_viewer.inner_margin_override(&style))
                                 .show(ui, |ui| {
                                     tab_viewer.ui(ui, tab);
                                 });

--- a/src/style.rs
+++ b/src/style.rs
@@ -13,6 +13,7 @@ pub enum TabAddAlign {
 #[derive(Clone)]
 pub struct Style {
     pub dock_area_padding: Option<Margin>,
+    pub default_inner_margin: Margin,
 
     pub border_color: Color32,
     pub border_width: f32,
@@ -56,6 +57,7 @@ impl Default for Style {
     fn default() -> Self {
         Self {
             dock_area_padding: None,
+            default_inner_margin: Margin::same(4.0),
 
             border_color: Color32::BLACK,
             border_width: Default::default(),


### PR DESCRIPTION
Fixes(?) https://github.com/Adanos020/egui_dock/issues/64
It seems that this is enough for the inner_margin setting to work in the examples.

There are a few more places (Tab, TabBuilder), but they are marked #[deprecated] 