### PR TITLE
Added ability to remove tab (using logic from render)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Style` now includes an option to show the hoverd tab's name. ([#56](https://github.com/Adanos020/egui_dock/pull/56))
 - `Style` now includes an option to change default inner_margin. ([#67](https://github.com/Adanos020/egui_dock/pull/67))
 - The split separator now highlights on hover ([#68](https://github.com/Adanos020/egui_dock/pull/68))
+- Tabs can now be removed with `Tree::remove_tab` ([#70](https://github.com/Adanos020/egui_dock/pull/70))
 
 ### Breaking changes
 - Renamed `TabViewer::inner_margin` to `TabViewer::inner_margin_override`. ([#67](https://github.com/Adanos020/egui_dock/pull/67))

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,12 +1,14 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use std::collections::HashSet;
+
 use eframe::{egui, NativeOptions};
 use egui::{
     color_picker::{color_picker_color32, Alpha},
-    Id, LayerId, Slider, Ui, WidgetText,
+    CentralPanel, Id, LayerId, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
-use egui_dock::{DockArea, NodeIndex, Style, TabViewer, Tree};
+use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
 
 fn main() {
     let options = NativeOptions::default();
@@ -21,6 +23,7 @@ struct MyContext {
     pub title: String,
     pub age: u32,
     pub style: Option<Style>,
+    open_tabs: HashSet<String>,
 }
 
 struct MyApp {
@@ -53,6 +56,11 @@ impl TabViewer for MyContext {
 
     fn title(&mut self, tab: &mut Self::Tab) -> WidgetText {
         tab.as_str().into()
+    }
+
+    fn on_close(&mut self, tab: &mut Self::Tab) -> bool {
+        self.open_tabs.remove(tab);
+        true
     }
 }
 
@@ -205,12 +213,6 @@ impl MyContext {
 
 impl Default for MyApp {
     fn default() -> Self {
-        let context = MyContext {
-            title: "Hello".to_string(),
-            age: 24,
-            style: None,
-        };
-
         let mut tree = Tree::new(vec!["Simple Demo".to_owned(), "Style Editor".to_owned()]);
         let [a, b] = tree.split_left(NodeIndex::root(), 0.3, vec!["Inspector".to_owned()]);
         let [_, _] = tree.split_below(
@@ -220,25 +222,69 @@ impl Default for MyApp {
         );
         let [_, _] = tree.split_below(b, 0.5, vec!["Hierarchy".to_owned()]);
 
+        let mut open_tabs = HashSet::new();
+
+        for node in tree.iter() {
+            match node {
+                Node::Leaf { tabs, .. } => {
+                    for tab in tabs {
+                        open_tabs.insert(tab.clone());
+                    }
+                }
+                _ => (),
+            }
+        }
+        let context = MyContext {
+            title: "Hello".to_string(),
+            age: 24,
+            style: None,
+            open_tabs,
+        };
+
         Self { context, tree }
     }
 }
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        let layer_id = LayerId::background();
-        let max_rect = ctx.available_rect();
-        let clip_rect = ctx.available_rect();
-        let id = Id::new("egui_dock::DockArea");
-        let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
+        TopBottomPanel::top("egui_dock::MenuBar").show(&ctx, |ui| {
+            egui::menu::bar(ui, |ui| {
+                ui.menu_button("View", |ui| {
+                    // allow certain tabs to be toggled
+                    for tab in &["File Browser", "Asset Manager"] {
+                        if ui
+                            .selectable_label(self.context.open_tabs.contains(*tab), *tab)
+                            .clicked()
+                        {
+                            if let Some(index) = self.tree.find_tab(&tab.to_string()) {
+                                self.tree.remove_tab(index);
+                                self.context.open_tabs.remove(*tab);
+                            } else {
+                                self.tree.push_to_focused_leaf(tab.to_string());
+                            }
 
-        let style = self
-            .context
-            .style
-            .get_or_insert(Style::from_egui(&ui.ctx().style()))
-            .clone();
-        DockArea::new(&mut self.tree)
-            .style(style)
-            .show_inside(&mut ui, &mut self.context);
+                            ui.close_menu();
+                        }
+                    }
+                });
+            })
+        });
+
+        CentralPanel::default().show(ctx, |_ui| {
+            let layer_id = LayerId::background();
+            let max_rect = ctx.available_rect();
+            let clip_rect = ctx.available_rect();
+            let id = Id::new("egui_dock::DockArea");
+            let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
+
+            let style = self
+                .context
+                .style
+                .get_or_insert(Style::from_egui(&ui.ctx().style()))
+                .clone();
+            DockArea::new(&mut self.tree)
+                .style(style)
+                .show_inside(&mut ui, &mut self.context);
+        });
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -225,13 +225,10 @@ impl Default for MyApp {
         let mut open_tabs = HashSet::new();
 
         for node in tree.iter() {
-            match node {
-                Node::Leaf { tabs, .. } => {
-                    for tab in tabs {
-                        open_tabs.insert(tab.clone());
-                    }
+            if let Node::Leaf { tabs, .. } = node {
+                for tab in tabs {
+                    open_tabs.insert(tab.clone());
                 }
-                _ => (),
             }
         }
         let context = MyContext {
@@ -247,7 +244,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        TopBottomPanel::top("egui_dock::MenuBar").show(&ctx, |ui| {
+        TopBottomPanel::top("egui_dock::MenuBar").show(ctx, |ui| {
             egui::menu::bar(ui, |ui| {
                 ui.menu_button("View", |ui| {
                     // allow certain tabs to be toggled

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -672,28 +672,21 @@ impl<Tab> Tree<Tab> {
     }
 
     pub fn remove_tab(&mut self, remove: (NodeIndex, TabIndex)) -> Option<Tab> {
-        let mut emptied = 0;
+        match &mut self[remove.0] {
+            Node::Leaf { tabs, active, .. } => {
+                let tab = tabs.remove(remove.1 .0);
 
-        let tab = if let Node::Leaf { tabs, active, .. } = &mut self[remove.0] {
-            let tab = tabs.remove(remove.1 .0);
+                if remove.1 <= *active {
+                    active.0 = active.0.saturating_sub(1);
+                }
+                if tabs.is_empty() {
+                    self.remove_empty_leaf();
+                }
 
-            if remove.1 <= *active {
-                active.0 = active.0.saturating_sub(1);
+                Some(tab)
             }
-            if tabs.is_empty() {
-                emptied += 1;
-            }
-
-            Some(tab)
-        } else {
-            None
-        };
-
-        for _ in 0..emptied {
-            self.remove_empty_leaf()
+            _ => None,
         }
-
-        tab
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -670,6 +670,31 @@ impl<Tab> Tree<Tab> {
             }
         }
     }
+
+    pub fn remove_tab(&mut self, remove: (NodeIndex, TabIndex)) -> Option<Tab> {
+        let mut emptied = 0;
+
+        let tab = if let Node::Leaf { tabs, active, .. } = &mut self[remove.0] {
+            let tab = tabs.remove(remove.1 .0);
+
+            if remove.1 <= *active {
+                active.0 = active.0.saturating_sub(1);
+            }
+            if tabs.is_empty() {
+                emptied += 1;
+            }
+
+            Some(tab)
+        } else {
+            None
+        };
+
+        for _ in 0..emptied {
+            self.remove_empty_leaf()
+        }
+
+        tab
+    }
 }
 
 impl<Tab> Tree<Tab>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -671,6 +671,11 @@ impl<Tab> Tree<Tab> {
         }
     }
 
+    /// Removes the tab at the given ([`NodeIndex`], [`TabIndex`]) pair.
+    ///
+    /// If the node is emptied after the tab is removed, the node will also be removed.
+    ///
+    /// Returns the removed tab if it exists, or `None` otherwise.
     pub fn remove_tab(&mut self, remove: (NodeIndex, TabIndex)) -> Option<Tab> {
         match &mut self[remove.0] {
             Node::Leaf { tabs, active, .. } => {


### PR DESCRIPTION
I wanted to be able to add/remove tabs in different parts of the gui (i.e. in a View menu). The add is already supported with push_to_focused_leaf, but the remove was not available as an API call. I was able to find it in the render logic and put it in its own function and I thought this might be useful for other people.

toggled on:
![image](https://user-images.githubusercontent.com/12837524/202838007-f9e606a6-d2a2-4b35-863e-188b4439f255.png)

toggled off:
![image](https://user-images.githubusercontent.com/12837524/202838018-df621fd9-e8de-4993-b8b8-953df01b9714.png)


Edit:
Also it wasn't something I could easily add as a utility function in my own code since `TabIndex` isn't publicly accessible. Looks like that's fixed in #60 though, so I don't need this merged if you guys think it's not something you want to add.