### PR TITLE
More customaizable tabs

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -188,12 +188,28 @@ impl MyContext {
             ui.separator();
 
             egui::Grid::new("tabs_colors").show(ui, |ui| {
-                ui.label("Title text color unfocused:");
+                ui.label("Title text color, inactive and unfocused:");
                 color_edit_button_srgba(ui, &mut style.tab_text_color_unfocused, Alpha::OnlyBlend);
                 ui.end_row();
 
-                ui.label("Title text color focused:");
+                ui.label("Title text color, inactive and focused:");
                 color_edit_button_srgba(ui, &mut style.tab_text_color_focused, Alpha::OnlyBlend);
+                ui.end_row();
+
+                ui.label("Title text color, active and unfocused:");
+                color_edit_button_srgba(
+                    ui,
+                    &mut style.tab_text_color_active_unfocused,
+                    Alpha::OnlyBlend,
+                );
+                ui.end_row();
+
+                ui.label("Title text color, active and focused:");
+                color_edit_button_srgba(
+                    ui,
+                    &mut style.tab_text_color_active_focused,
+                    Alpha::OnlyBlend,
+                );
                 ui.end_row();
 
                 ui.label("Close button color unfocused:");

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -143,7 +143,7 @@ impl MyContext {
 
             ui.checkbox(
                 &mut style.tab_hover_name,
-                "Show tab name when hoverd over them",
+                "Show tab name when hovered over them",
             );
             ui.checkbox(&mut style.tabs_are_draggable, "Tabs are draggable");
             ui.checkbox(&mut style.expand_tabs, "Expand tabs");
@@ -216,8 +216,15 @@ impl MyContext {
                 color_edit_button_srgba(ui, &mut style.tab_bar_background_color, Alpha::OnlyBlend);
                 ui.end_row();
 
-                ui.label("Outline color:");
+                ui.label("Outline color:")
+                    .on_hover_text("The outline around the active tab name.");
                 color_edit_button_srgba(ui, &mut style.tab_outline_color, Alpha::OnlyBlend);
+                ui.end_row();
+
+                ui.label("Horizontal line color:").on_hover_text(
+                    "The line separating the tab name area from the tab content area",
+                );
+                color_edit_button_srgba(ui, &mut style.hline_color, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Background color:");

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -4,14 +4,17 @@ use std::collections::HashSet;
 
 use eframe::{egui, NativeOptions};
 use egui::{
-    color_picker::{color_picker_color32, Alpha},
+    color_picker::{color_edit_button_srgba, Alpha},
     CentralPanel, Id, LayerId, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
 use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
 
 fn main() {
-    let options = NativeOptions::default();
+    let options = NativeOptions {
+        initial_window_size: Some(egui::vec2(1024.0, 1024.0)),
+        ..Default::default()
+    };
     eframe::run_native(
         "My egui App",
         options,
@@ -92,43 +95,47 @@ impl MyContext {
         let style = self.style.as_mut().unwrap();
 
         ui.collapsing("Border", |ui| {
-            ui.separator();
+            egui::Grid::new("border").show(ui, |ui| {
+                ui.label("Width:");
+                ui.add(Slider::new(&mut style.border_width, 1.0..=50.0));
+                ui.end_row();
 
-            ui.label("Width");
-            ui.add(Slider::new(&mut style.border_width, 1.0..=50.0));
-
-            ui.separator();
-
-            ui.label("Color");
-            color_picker_color32(ui, &mut style.border_color, Alpha::OnlyBlend);
+                ui.label("Color:");
+                color_edit_button_srgba(ui, &mut style.border_color, Alpha::OnlyBlend);
+                ui.end_row();
+            });
         });
 
         ui.collapsing("Selection", |ui| {
-            ui.separator();
-
-            ui.label("Color");
-            color_picker_color32(ui, &mut style.selection_color, Alpha::OnlyBlend);
+            egui::Grid::new("selection").show(ui, |ui| {
+                ui.label("Color:");
+                color_edit_button_srgba(ui, &mut style.selection_color, Alpha::OnlyBlend);
+                ui.end_row();
+            });
         });
 
         ui.collapsing("Separator", |ui| {
-            ui.separator();
+            egui::Grid::new("separator").show(ui, |ui| {
+                ui.label("Width:");
+                ui.add(Slider::new(&mut style.separator_width, 1.0..=50.0));
+                ui.end_row();
 
-            ui.label("Width");
-            ui.add(Slider::new(&mut style.separator_width, 1.0..=50.0));
+                ui.label("Offset limit:");
+                ui.add(Slider::new(&mut style.separator_extra, 1.0..=300.0));
+                ui.end_row();
 
-            ui.label("Offset limit");
-            ui.add(Slider::new(&mut style.separator_extra, 1.0..=300.0));
+                ui.label("Idle color:");
+                color_edit_button_srgba(ui, &mut style.separator_color_idle, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.separator();
+                ui.label("Hovered color:");
+                color_edit_button_srgba(ui, &mut style.separator_color_hovered, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.label("Idle color");
-            color_picker_color32(ui, &mut style.separator_color_idle, Alpha::OnlyBlend);
-
-            ui.label("Hovered color");
-            color_picker_color32(ui, &mut style.separator_color_hovered, Alpha::OnlyBlend);
-
-            ui.label("Dragged color");
-            color_picker_color32(ui, &mut style.separator_color_dragged, Alpha::OnlyBlend);
+                ui.label("Dragged color:");
+                color_edit_button_srgba(ui, &mut style.separator_color_dragged, Alpha::OnlyBlend);
+                ui.end_row();
+            });
         });
 
         ui.collapsing("Tabs", |ui| {
@@ -176,45 +183,47 @@ impl MyContext {
 
             ui.separator();
 
-            ui.label("Title text color unfocused");
-            color_picker_color32(ui, &mut style.tab_text_color_unfocused, Alpha::OnlyBlend);
-
-            ui.label("Title text color focused");
-            color_picker_color32(ui, &mut style.tab_text_color_focused, Alpha::OnlyBlend);
-
-            ui.separator();
-
             ui.checkbox(&mut style.show_close_buttons, "Allow closing tabs");
 
             ui.separator();
 
-            ui.label("Close button color unfocused");
-            color_picker_color32(ui, &mut style.close_tab_color, Alpha::OnlyBlend);
+            egui::Grid::new("tabs_colors").show(ui, |ui| {
+                ui.label("Title text color unfocused:");
+                color_edit_button_srgba(ui, &mut style.tab_text_color_unfocused, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.separator();
+                ui.label("Title text color focused:");
+                color_edit_button_srgba(ui, &mut style.tab_text_color_focused, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.label("Close button color focused");
-            color_picker_color32(ui, &mut style.close_tab_active_color, Alpha::OnlyBlend);
+                ui.label("Close button color unfocused:");
+                color_edit_button_srgba(ui, &mut style.close_tab_color, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.separator();
+                ui.label("Close button color focused:");
+                color_edit_button_srgba(ui, &mut style.close_tab_active_color, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.label("Close button background color");
-            color_picker_color32(ui, &mut style.close_tab_background_color, Alpha::OnlyBlend);
+                ui.label("Close button background color:");
+                color_edit_button_srgba(
+                    ui,
+                    &mut style.close_tab_background_color,
+                    Alpha::OnlyBlend,
+                );
+                ui.end_row();
 
-            ui.separator();
+                ui.label("Bar background color:");
+                color_edit_button_srgba(ui, &mut style.tab_bar_background_color, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.label("Bar background color");
-            color_picker_color32(ui, &mut style.tab_bar_background_color, Alpha::OnlyBlend);
+                ui.label("Outline color:");
+                color_edit_button_srgba(ui, &mut style.tab_outline_color, Alpha::OnlyBlend);
+                ui.end_row();
 
-            ui.separator();
-
-            ui.label("Outline color");
-            color_picker_color32(ui, &mut style.tab_outline_color, Alpha::OnlyBlend);
-
-            ui.separator();
-
-            ui.label("Background color");
-            color_picker_color32(ui, &mut style.tab_background_color, Alpha::OnlyBlend);
+                ui.label("Background color:");
+                color_edit_button_srgba(ui, &mut style.tab_background_color, Alpha::OnlyBlend);
+                ui.end_row();
+            });
         });
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -154,6 +154,11 @@ impl MyContext {
                 "Include ScrollArea inside of tabs",
             );
 
+            ui.checkbox(
+                &mut style.hline_below_active_tab_name,
+                "Show a line below the active tab name",
+            );
+
             ui.separator();
 
             ui.horizontal(|ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,14 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     let mut ui = ui.child_ui(tabbar, Default::default());
                     ui.spacing_mut().item_spacing = vec2(0.0, 0.0);
 
+                    if !style.hline_below_active_tab_name {
+                        ui.painter().hline(
+                            tabbar.x_range(),
+                            tabbar.max.y - px,
+                            (px, style.hline_color),
+                        );
+                    }
+
                     ui.horizontal(|ui| {
                         for (tab_index, tab) in tabs.iter_mut().enumerate() {
                             let id = self.id.with((node_index, tab_index, "tab"));
@@ -500,8 +508,13 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     });
                 });
 
-                ui.painter()
-                    .hline(tabbar.x_range(), tabbar.max.y - px, (px, style.hline_color));
+                if style.hline_below_active_tab_name {
+                    ui.painter().hline(
+                        tabbar.x_range(),
+                        tabbar.max.y - px,
+                        (px, style.hline_color),
+                    );
+                }
 
                 // tab body
                 if let Some(tab) = tabs.get_mut(active.0) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                             let response = if is_being_dragged {
                                 let layer_id = LayerId::new(Order::Tooltip, id);
-                                let response = ui
+                                let mut response = ui
                                     .with_layer_id(layer_id, |ui| {
                                         style.tab_title(
                                             ui,
@@ -395,7 +395,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                     .response;
 
                                 let sense = Sense::click_and_drag();
-                                let response = ui.interact(response.rect, id, sense);
+                                response = ui.interact(response.rect, id, sense);
 
                                 if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
                                     let center = response.rect.center();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@
 //! ```
 
 use egui::{
-    pos2, style::Margin, vec2, Context, CursorIcon, Frame, Id, LayerId, Order, Pos2, Rect,
-    Rounding, ScrollArea, Sense, Stroke, Ui, WidgetText,
+    style::Margin, vec2, Context, CursorIcon, Frame, Id, LayerId, Order, Pos2, Rect, Rounding,
+    ScrollArea, Sense, Stroke, Ui, WidgetText,
 };
 
 pub use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,10 +347,6 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         style.tab_bar_background_color,
                     );
 
-                    let a = pos2(tabbar.min.x, tabbar.max.y - px);
-                    let b = pos2(tabbar.max.x, tabbar.max.y - px);
-                    ui.painter()
-                        .line_segment([a, b], (px, style.tab_outline_color));
                     let mut available_width = tabbar.max.x - tabbar.min.x;
                     if style.show_add_buttons {
                         available_width -= Style::TAB_PLUS_SIZE;
@@ -503,6 +499,9 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         };
                     });
                 });
+
+                ui.painter()
+                    .hline(tabbar.x_range(), tabbar.max.y - px, (px, style.hline_color));
 
                 // tab body
                 if let Some(tab) = tabs.get_mut(active.0) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                                 response
                             } else {
-                                let response = style.tab_title(
+                                let (mut response, close_response) = style.tab_title(
                                     ui,
                                     label,
                                     is_active && Some(node_index) == focused,
@@ -435,20 +435,25 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                     expanded_width,
                                 );
 
-                                let sense = if response.1 {
+                                let (close_hovered, close_clicked) = match close_response {
+                                    Some(res) => (res.hovered(), res.clicked()),
+                                    None => (false, false),
+                                };
+
+                                let sense = if close_hovered {
                                     Sense::click()
                                 } else {
                                     Sense::click_and_drag()
                                 };
 
                                 if style.tab_hover_name {
-                                    response.0.clone().on_hover_ui(|ui| {
+                                    response = response.on_hover_ui(|ui| {
                                         ui.label(tab_viewer.title(tab));
                                     });
                                 }
 
                                 if style.show_context_menu {
-                                    response.0.clone().context_menu(|ui| {
+                                    response = response.context_menu(|ui| {
                                         tab_viewer.context_menu(ui, tab);
                                         if style.show_close_buttons && ui.button("Close").clicked()
                                         {
@@ -462,7 +467,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                     });
                                 }
 
-                                if response.2 {
+                                if close_clicked {
                                     if tab_viewer.on_close(tab) {
                                         to_remove.push((node_index, tab_index));
                                     } else {
@@ -470,7 +475,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                                         new_focused = Some(node_index);
                                     }
                                 }
-                                let response = ui.interact(response.0.rect, id, sense);
+                                let response = ui.interact(response.rect, id, sense);
                                 if response.drag_started() {
                                     state.drag_start = response.hover_pos();
                                 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -36,6 +36,12 @@ pub struct Style {
 
     /// The line separating the tab name area from the tab content area
     pub hline_color: Color32,
+
+    /// If `true`, show the hline below the active tabs name.
+    /// If `false`, show the active tab as merged with the tab ui area.
+    /// Default: `false`.
+    pub hline_below_active_tab_name: bool,
+
     pub tab_rounding: Rounding,
     pub tab_background_color: Color32,
 
@@ -85,6 +91,7 @@ impl Default for Style {
 
             tab_outline_color: Color32::BLACK,
             hline_color: Color32::BLACK,
+            hline_below_active_tab_name: false,
             tab_rounding: Default::default(),
             tab_background_color: Color32::WHITE,
 
@@ -368,9 +375,16 @@ impl Style {
                     Stroke::new(1.0, self.tab_outline_color),
                 );
             } else {
-                let stroke = egui::Stroke::new(1.0, self.tab_outline_color);
+                let stroke = Stroke::new(1.0, self.tab_outline_color);
                 ui.painter()
                     .rect(rect, rounding, self.tab_background_color, stroke);
+
+                // Make the tab name area connect with the tab ui area:
+                ui.painter().hline(
+                    rect.x_range(),
+                    rect.bottom(),
+                    Stroke::new(2.0, self.tab_background_color),
+                );
             }
         }
 
@@ -546,6 +560,17 @@ impl StyleBuilder {
     #[inline(always)]
     pub fn with_hline_color(mut self, hline_color: Color32) -> Self {
         self.style.hline_color = hline_color;
+        self
+    }
+
+    /// Sets [`Self::hline_below_active_tab_name`].
+    ///
+    /// If `true`, show the hline below the active tabs name.
+    /// If `false`, show the active tab as merged with the tab ui area.
+    /// Default: `false`.
+    #[inline(always)]
+    pub fn with_hline_below_active_tab_name(mut self, hline_below_active_tab_name: bool) -> Self {
+        self.style.hline_below_active_tab_name = hline_below_active_tab_name;
         self
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -41,6 +41,8 @@ pub struct Style {
 
     pub tab_text_color_unfocused: Color32,
     pub tab_text_color_focused: Color32,
+    pub tab_text_color_active_unfocused: Color32,
+    pub tab_text_color_active_focused: Color32,
 
     pub tabs_are_draggable: bool,
     pub expand_tabs: bool,
@@ -88,6 +90,8 @@ impl Default for Style {
 
             tab_text_color_unfocused: Color32::DARK_GRAY,
             tab_text_color_focused: Color32::BLACK,
+            tab_text_color_active_unfocused: Color32::DARK_GRAY,
+            tab_text_color_active_focused: Color32::BLACK,
 
             close_tab_color: Color32::WHITE,
             close_tab_active_color: Color32::WHITE,
@@ -121,6 +125,8 @@ impl Style {
     /// - [`Self::tab_background_color`]
     /// - [`Self::tab_text_color_unfocused`]
     /// - [`Self::tab_text_color_focused`]
+    /// - [`Self::tab_text_color_active_unfocused`]
+    /// - [`Self::tab_text_color_active_focused`]
     /// - [`Self::separator_color_idle`]
     /// - [`Self::separator_color_hovered`]
     /// - [`Self::separator_color_dragged`]
@@ -142,6 +148,8 @@ impl Style {
 
             tab_text_color_unfocused: style.visuals.text_color(),
             tab_text_color_focused: style.visuals.strong_text_color(),
+            tab_text_color_active_unfocused: style.visuals.text_color(),
+            tab_text_color_active_focused: style.visuals.strong_text_color(),
 
             separator_color_idle: style.visuals.widgets.noninteractive.bg_stroke.color,
             separator_color_hovered: style.visuals.widgets.hovered.bg_stroke.color,
@@ -378,11 +386,15 @@ impl Style {
 
         let override_text_color = if galley.galley_has_color {
             None // respect the color the user has chosen
-        } else if focused {
-            Some(self.tab_text_color_focused)
         } else {
-            Some(self.tab_text_color_unfocused)
+            Some(match (active, focused) {
+                (false, false) => self.tab_text_color_unfocused,
+                (false, true) => self.tab_text_color_focused,
+                (true, false) => self.tab_text_color_active_unfocused,
+                (true, true) => self.tab_text_color_active_focused,
+            })
         };
+
         ui.painter().add(epaint::TextShape {
             pos: text_pos,
             galley: galley.galley,
@@ -627,17 +639,37 @@ impl StyleBuilder {
         self
     }
 
-    /// Color of tab title when the tab is unfocused.
+    /// Color of tab title when an inactive tab is unfocused.
     #[inline(always)]
     pub fn with_tab_text_color_unfocused(mut self, tab_text_color_unfocused: Color32) -> Self {
         self.style.tab_text_color_unfocused = tab_text_color_unfocused;
         self
     }
 
-    /// Color of tab title when the tab is focused.
+    /// Color of tab title when an inactive tab is focused.
     #[inline(always)]
     pub fn with_tab_text_color_focused(mut self, tab_text_color_focused: Color32) -> Self {
         self.style.tab_text_color_focused = tab_text_color_focused;
+        self
+    }
+
+    /// Color of tab title when an active tab is unfocused.
+    #[inline(always)]
+    pub fn with_tab_text_color_active_unfocused(
+        mut self,
+        tab_text_color_active_unfocused: Color32,
+    ) -> Self {
+        self.style.tab_text_color_active_unfocused = tab_text_color_active_unfocused;
+        self
+    }
+
+    /// Color of tab title when an active tab is focused.
+    #[inline(always)]
+    pub fn with_tab_text_color_active_focused(
+        mut self,
+        tab_text_color_active_focused: Color32,
+    ) -> Self {
+        self.style.tab_text_color_active_focused = tab_text_color_active_focused;
         self
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -554,7 +554,7 @@ impl StyleBuilder {
         self
     }
 
-    /// Sets [`Self::hline_color`], the line separating the tab name area from the tab content area.
+    /// Sets [`Style::hline_color`], the line separating the tab name area from the tab content area.
     ///
     /// By `Default` it's [`Color32::BLACK`].
     #[inline(always)]
@@ -563,7 +563,7 @@ impl StyleBuilder {
         self
     }
 
-    /// Sets [`Self::hline_below_active_tab_name`].
+    /// Sets [`Style::hline_below_active_tab_name`].
     ///
     /// If `true`, show the hline below the active tabs name.
     /// If `false`, show the active tab as merged with the tab ui area.

--- a/src/style.rs
+++ b/src/style.rs
@@ -21,6 +21,7 @@ pub struct Style {
 
     pub selection_color: Color32,
 
+    // The resizable separator:
     pub separator_width: f32,
     pub separator_extra: f32,
     pub separator_color_idle: Color32,
@@ -30,7 +31,11 @@ pub struct Style {
     pub tab_bar_background_color: Color32,
     pub tab_bar_height: f32,
 
+    /// The outline around the active tab name.
     pub tab_outline_color: Color32,
+
+    /// The line separating the tab name area from the tab content area
+    pub hline_color: Color32,
     pub tab_rounding: Rounding,
     pub tab_background_color: Color32,
 
@@ -77,6 +82,7 @@ impl Default for Style {
             tab_bar_height: 24.0,
 
             tab_outline_color: Color32::BLACK,
+            hline_color: Color32::BLACK,
             tab_rounding: Default::default(),
             tab_background_color: Color32::WHITE,
 
@@ -111,6 +117,7 @@ impl Style {
     /// - [`Self::selection_color`]
     /// - [`Self::tab_bar_background_color`]
     /// - [`Self::tab_outline_color`]
+    /// - [`Self::hline_color`]
     /// - [`Self::tab_background_color`]
     /// - [`Self::tab_text_color_unfocused`]
     /// - [`Self::tab_text_color_focused`]
@@ -130,6 +137,7 @@ impl Style {
 
             tab_bar_background_color: style.visuals.faint_bg_color,
             tab_outline_color: style.visuals.widgets.active.bg_fill,
+            hline_color: style.visuals.widgets.active.bg_fill,
             tab_background_color: style.visuals.window_fill(),
 
             tab_text_color_unfocused: style.visuals.text_color(),
@@ -358,7 +366,7 @@ impl Style {
             }
         }
 
-        let pos = if self.expand_tabs {
+        let text_pos = if self.expand_tabs {
             let mut pos = Align2::CENTER_CENTER.pos_in_rect(&rect.shrink2(vec2(8.0, 5.0)));
             pos -= galley.size() / 2.0;
             pos
@@ -376,7 +384,7 @@ impl Style {
             Some(self.tab_text_color_unfocused)
         };
         ui.painter().add(epaint::TextShape {
-            pos,
+            pos: text_pos,
             galley: galley.galley,
             underline: Stroke::NONE,
             override_text_color,
@@ -517,6 +525,15 @@ impl StyleBuilder {
     #[inline(always)]
     pub fn with_tab_outline_color(mut self, tab_outline_color: Color32) -> Self {
         self.style.tab_outline_color = tab_outline_color;
+        self
+    }
+
+    /// Sets [`Self::hline_color`], the line separating the tab name area from the tab content area.
+    ///
+    /// By `Default` it's [`Color32::BLACK`].
+    #[inline(always)]
+    pub fn with_hline_color(mut self, hline_color: Color32) -> Self {
+        self.style.hline_color = hline_color;
         self
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -307,7 +307,6 @@ impl Style {
         id: Id,
         expanded_width: f32,
     ) -> (Response, bool, bool) {
-        let px = ui.ctx().pixels_per_point().recip();
         let rounding = self.tab_rounding;
 
         let galley = label.into_galley(ui, None, f32::INFINITY, TextStyle::Button);
@@ -346,23 +345,13 @@ impl Style {
         };
         match (active, is_being_dragged) {
             (true, false) => {
-                let mut tab = rect;
-                tab.min.x -= px;
-                tab.max.x += px;
+                let stroke = egui::Stroke::new(1.0, self.tab_outline_color);
                 ui.painter()
-                    .rect_filled(tab, rounding, self.tab_outline_color);
-
-                tab.min.x += px;
-                tab.max.x -= px;
-                tab.min.y += px;
-                ui.painter()
-                    .rect_filled(tab, rounding, self.tab_background_color);
+                    .rect(rect, rounding, self.tab_background_color, stroke);
             }
             (true, true) => {
-                let tab = rect;
-
                 ui.painter().rect_stroke(
-                    tab,
+                    rect,
                     self.tab_rounding,
                     Stroke::new(1.0, self.tab_outline_color),
                 );
@@ -664,7 +653,7 @@ impl StyleBuilder {
         self
     }
 
-    /// Wheter tabs show their name when hoverd over them.
+    /// Whether tabs show their name when hovered over them.
     #[inline(always)]
     pub fn show_name_when_hovered(mut self, tab_hover_name: bool) -> Self {
         self.style.tab_hover_name = tab_hover_name;

--- a/src/style.rs
+++ b/src/style.rs
@@ -352,7 +352,7 @@ impl Style {
         };
 
         let (rect, mut response) = ui.allocate_at_least(desired_size, Sense::hover());
-        if !ui.memory().is_anything_being_dragged() && is_being_dragged {
+        if !ui.memory().is_anything_being_dragged() {
             response = response.on_hover_cursor(CursorIcon::Grab);
         }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,6 +15,7 @@ pub struct Style {
     pub dock_area_padding: Option<Margin>,
     pub default_inner_margin: Margin,
 
+    // TODO: this should be `egui::Stroke`.
     pub border_color: Color32,
     pub border_width: f32,
 
@@ -293,7 +294,8 @@ impl Style {
         response
     }
 
-    /// `active` means "the tab that is opened in the parent panel".
+    /// * `active` means "the tab that is opened in the parent panel".
+    /// * `focused` means "the tab that was last interacted with".
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn tab_title(
         &self,

--- a/src/style.rs
+++ b/src/style.rs
@@ -319,6 +319,8 @@ impl Style {
 
     /// * `active` means "the tab that is opened in the parent panel".
     /// * `focused` means "the tab that was last interacted with".
+    ///
+    /// Returns the main button response plus the response of the close button, if any.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn tab_title(
         &self,
@@ -329,7 +331,7 @@ impl Style {
         is_being_dragged: bool,
         id: Id,
         expanded_width: f32,
-    ) -> (Response, bool, bool) {
+    ) -> (Response, Option<Response>) {
         let rounding = self.tab_rounding;
 
         let galley = label.into_galley(ui, None, f32::INFINITY, TextStyle::Button);
@@ -354,18 +356,19 @@ impl Style {
             response = response.on_hover_cursor(CursorIcon::Grab);
         }
 
-        let (x_rect, x_res) = if (active || response.hovered()) && self.show_close_buttons {
-            let mut pos = rect.right_top();
-            pos.x -= offset.x + x_size.x / 2.0;
-            pos.y += rect.size().y / 2.0;
-            let x_rect = Rect::from_center_size(pos, x_size);
-            let response = ui
-                .interact(x_rect, id, Sense::click())
-                .on_hover_cursor(CursorIcon::PointingHand);
-            (x_rect, Some(response))
-        } else {
-            (Rect::NOTHING, None)
-        };
+        let (close_rect, close_response) =
+            if (active || response.hovered()) && self.show_close_buttons {
+                let mut pos = rect.right_top();
+                pos.x -= offset.x + x_size.x / 2.0;
+                pos.y += rect.size().y / 2.0;
+                let x_rect = Rect::from_center_size(pos, x_size);
+                let response = ui
+                    .interact(x_rect, id, Sense::click())
+                    .on_hover_cursor(CursorIcon::PointingHand);
+                (x_rect, Some(response))
+            } else {
+                (Rect::NOTHING, None)
+            };
 
         if active {
             if is_being_dragged {
@@ -418,16 +421,22 @@ impl Style {
         });
 
         if (active || response.hovered()) && self.show_close_buttons {
-            if x_res.as_ref().unwrap().hovered() {
+            if close_response.as_ref().unwrap().hovered() {
                 ui.painter().rect_filled(
-                    x_rect,
+                    close_rect,
                     Rounding::same(2.0),
                     self.close_tab_background_color,
                 );
             }
-            let x_rect = x_rect.shrink(1.75);
+            let x_rect = close_rect.shrink(1.75);
 
-            let color = if focused || x_res.as_ref().unwrap().interact_pointer_pos().is_some() {
+            let color = if focused
+                || close_response
+                    .as_ref()
+                    .unwrap()
+                    .interact_pointer_pos()
+                    .is_some()
+            {
                 self.close_tab_active_color
             } else {
                 self.close_tab_color
@@ -442,10 +451,11 @@ impl Style {
             );
         }
 
-        match x_res {
-            Some(some) => (response, some.hovered(), some.clicked()),
-            None => (response, false, false),
-        }
+        (response, close_response)
+        // match close_response {
+        //     Some(some) => (response, some.hovered(), some.clicked()),
+        //     None => (response, false, false),
+        // }
     }
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -343,20 +343,19 @@ impl Style {
         } else {
             (Rect::NOTHING, None)
         };
-        match (active, is_being_dragged) {
-            (true, false) => {
-                let stroke = egui::Stroke::new(1.0, self.tab_outline_color);
-                ui.painter()
-                    .rect(rect, rounding, self.tab_background_color, stroke);
-            }
-            (true, true) => {
+
+        if active {
+            if is_being_dragged {
                 ui.painter().rect_stroke(
                     rect,
                     self.tab_rounding,
                     Stroke::new(1.0, self.tab_outline_color),
                 );
+            } else {
+                let stroke = egui::Stroke::new(1.0, self.tab_outline_color);
+                ui.painter()
+                    .rect(rect, rounding, self.tab_background_color, stroke);
             }
-            _ => (),
         }
 
         let pos = if self.expand_tabs {


### PR DESCRIPTION
A default style is barely different, but this PR makes it a lot more customizable

Before:
![image](https://user-images.githubusercontent.com/1148717/216016519-8acfa7b2-42dd-4159-bec5-fe51025ca9fb.png)


After:
![image](https://user-images.githubusercontent.com/1148717/216018456-15c495ed-8c29-4df3-b698-2ff0cfe1a408.png)


Oh, and the style editor in the `hello` example looks much nicer:

![Screen Shot 2023-02-01 at 11 33 36](https://user-images.githubusercontent.com/1148717/216019214-e8fb0909-6899-4292-93fe-95d72598638c.png)

