### PR TITLE
Use available_rect_before_wrap() in DockArea::show_inside

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use eframe::{egui, NativeOptions};
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    CentralPanel, Id, LayerId, Slider, TopBottomPanel, Ui, WidgetText,
+    CentralPanel, Color32, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
 use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
@@ -312,21 +312,18 @@ impl eframe::App for MyApp {
             })
         });
 
-        CentralPanel::default().show(ctx, |_ui| {
-            let layer_id = LayerId::background();
-            let max_rect = ctx.available_rect();
-            let clip_rect = ctx.available_rect();
-            let id = Id::new("egui_dock::DockArea");
-            let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
+        CentralPanel::default()
+            // When displaying a DockArea in another UI, it looks better
+            // to set inner margins to 0.
+            .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
+            .show(ctx, |ui| {
+                // Customize DockArea style.
+                let mut style = egui_dock::Style::from_egui(&ctx.style());
+                style.selection_color = Color32::BLUE;
 
-            let style = self
-                .context
-                .style
-                .get_or_insert(Style::from_egui(&ui.ctx().style()))
-                .clone();
-            DockArea::new(&mut self.tree)
-                .style(style)
-                .show_inside(&mut ui, &mut self.context);
-        });
+                DockArea::new(&mut self.tree)
+                    .style(style)
+                    .show_inside(ui, &mut self.context);
+            });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             .unwrap_or_else(|| Style::from_egui(ui.style().as_ref()));
 
         let mut state = State::load(ui.ctx(), self.id);
-        let mut rect = ui.max_rect();
+        let mut rect = ui.available_rect_before_wrap();
 
         if let Some(margin) = style.dock_area_padding {
             rect.min += margin.left_top();


### PR DESCRIPTION
Using `max_rect()` in `DockArea::show_inside` function makes the DockArea hide any element previously added, it is specially annoying when using Panels.

With the following code:
```rust
CentralPanel::default().show(ctx, |ui| {
    TopBottomPanel::top("top_bar").show_inside(ui, |ui| {
        ui.label("MyLabel");
    });

    DockArea::new(&mut self.tree)
        .show_inside(ui, &mut self.context);
});
```

We previously had:
![image](https://user-images.githubusercontent.com/48593807/217957035-46bd9f5a-5de5-4fc8-8b3b-756c31b7d8c1.png)

And with this change we have:
![image](https://user-images.githubusercontent.com/48593807/217957130-fda3b12b-0483-46ff-9806-0ecf328f22a2.png)
