### PR TITLE
Fix style editor in hello example

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use eframe::{egui, NativeOptions};
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    CentralPanel, Color32, Frame, Slider, TopBottomPanel, Ui, WidgetText,
+    CentralPanel, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
 use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
@@ -317,9 +317,11 @@ impl eframe::App for MyApp {
             // to set inner margins to 0.
             .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
             .show(ctx, |ui| {
-                // Customize DockArea style.
-                let mut style = egui_dock::Style::from_egui(&ctx.style());
-                style.selection_color = Color32::BLUE;
+                let style = self
+                    .context
+                    .style
+                    .get_or_insert(Style::from_egui(ui.style()))
+                    .clone();
 
                 DockArea::new(&mut self.tree)
                     .style(style)


### PR DESCRIPTION
Reverts a part of the changes made to the hello example in #102

It seems the line that was setting the style on the MyContext struct was inadvertently removed causing the style editor tab to panic when shown, since style was None and it unwraps it. 

I also removed the line from that PR that manually set the `selection_color` to BLUE as it's already a semi-transparent blue by default and it seems better to showcase the default values. If there was a reason for this lmk, it just seemed like it was just mistakenly left in since there wasn't any discussion about it.