### PR TITLE
Add #![warn(missing_docs)] flag to lib and small doc tweaks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 //! # `egui_dock`: docking support for `egui`
 //!
 //! Credit goes to @lain-dono for implementing the actual library.
@@ -152,6 +154,7 @@ impl State {
 
 /// How we view a tab when its in a [`Tree`].
 pub trait TabViewer {
+    /// The type of tab in which you can store state to be drawn in your tabs.
     type Tab;
 
     /// Actual tab content.
@@ -221,6 +224,7 @@ pub struct DockArea<'tree, Tab> {
 }
 
 impl<'tree, Tab> DockArea<'tree, Tab> {
+    /// Creates a new [DockArea] from the provided [`Tree`].
     #[inline(always)]
     pub fn new(tree: &'tree mut Tree<Tab>) -> DockArea<'tree, Tab> {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl State {
 
 // ----------------------------------------------------------------------------
 
-/// How we view a tab when its in a [`Tree`].
+/// How to display a tab inside a [`Tree`].
 pub trait TabViewer {
     /// The type of tab in which you can store state to be drawn in your tabs.
     type Tab;
@@ -214,9 +214,7 @@ pub trait TabViewer {
 
 // ----------------------------------------------------------------------------
 
-/// Stores the layout and position of all its tabs
-///
-/// Keeps track of the currently focused leaf and currently active tabs
+/// Displays a [`Tree`] in `egui`.
 pub struct DockArea<'tree, Tab> {
     id: Id,
     tree: &'tree mut Tree<Tab>,

--- a/src/style.rs
+++ b/src/style.rs
@@ -4,13 +4,17 @@ use egui::{style::Margin, *};
 /// Left or right alignment for tab add button.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[allow(missing_docs)]
 pub enum TabAddAlign {
     Left,
     Right,
 }
 
 /// Specifies the look and feel of egui_dock.
+///
+/// See [`StyleBuilder`] for fields details.
 #[derive(Clone, Debug)]
+#[allow(missing_docs)]
 pub struct Style {
     pub dock_area_padding: Option<Margin>,
     pub default_inner_margin: Margin,
@@ -473,6 +477,7 @@ impl Style {
     }
 }
 
+/// Builds a [`Style`] with custom configuration values.
 #[derive(Default)]
 pub struct StyleBuilder {
     style: Style,
@@ -480,6 +485,7 @@ pub struct StyleBuilder {
 
 impl StyleBuilder {
     #[inline(always)]
+    /// Creates a new [StyleBuilder].
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -15,7 +15,7 @@ impl From<usize> for TabIndex {
 
 // ----------------------------------------------------------------------------
 
-/// Represents an abstract node of a `Tree`.
+/// Represents an abstract node of a [`Tree`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Node<Tab> {
@@ -186,7 +186,7 @@ impl<Tab> Node<Tab> {
 
 // ----------------------------------------------------------------------------
 
-/// Wrapper around indices to the collection of nodes inside a `Tree`.
+/// Wrapper around indices to the collection of nodes inside a [`Tree`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NodeIndex(pub usize);
@@ -284,7 +284,15 @@ pub enum Split {
 
 // ----------------------------------------------------------------------------
 
-/// Binary tree representing the relationships between `Node`s.
+/// Binary tree representing the relationships between [`Node`]s.
+///
+/// # Implementation details
+///
+/// The binary tree is stored in a [`Vec`] indexed by [`NodeIndex`].
+/// The root is always at index *0*.
+/// For a given node *n*:
+///  - left child of *n* will be at index *n * 2 + 1*.
+///  - right child of *n* will be at index *n * 2 + 2*.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tree<Tab> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -36,9 +36,21 @@ pub enum Node<Tab> {
         active: TabIndex,
     },
     /// Parent node in the vertical orientation
-    Vertical { rect: Rect, fraction: f32 },
+    Vertical {
+        /// The rectangle in which all children of this node are drawn.
+        rect: Rect,
+
+        /// The fraction taken by the top child of this node.
+        fraction: f32,
+    },
     /// Parent node in the horizontal orientation
-    Horizontal { rect: Rect, fraction: f32 },
+    Horizontal {
+        /// The rectangle in which all children of this node are drawn.
+        rect: Rect,
+
+        /// The fraction taken by the left child of this node.
+        fraction: f32,
+    },
 }
 
 impl<Tab> Node<Tab> {
@@ -162,6 +174,7 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Gets the number of tabs in the node.
     #[inline]
     pub fn tabs_count(&self) -> usize {
         match self {
@@ -261,6 +274,7 @@ impl NodeIndex {
 
 /// Direction in which a new node is created relatively to the parent node at which the split occurs.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[allow(missing_docs)]
 pub enum Split {
     Left,
     Right,


### PR DESCRIPTION
I added `#![warn(missing_docs)]` so that we do not forget to document new elements in the future.