### PR TITLE
Improve Node management 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+# Added
+- Added `Tree::move_tab` method that allow moving a tab from one node to the other.
+
 ### Breaking changes
 - Remove `remove_empty_leaf` which was used for internal usage and should not be needed by users.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking changes
+- Remove `remove_empty_leaf` which was used for internal usage and should not be needed by users.
+
 ### Fixed
 - Make splitter drag behave like egui `DragValue` ([#103](https://github.com/Adanos020/egui_dock/pull/103))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Make splitter drag behave like egui `DragValue` ([#103](https://github.com/Adanos020/egui_dock/pull/103))
+
 ## 0.4.0 - 2023-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.0 - 2023-02-09
+
 ### Added
 - Added `TabViewer::on_tab_button` ([#93](https://github.com/Adanos020/egui_dock/pull/93)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 # Added
-- Added `Tree::move_tab` method that allow moving a tab from one node to the other.
+- Added `Tree::move_tab` method that allows moving a tab from one node to the other.
 
 ### Breaking changes
 - Remove `remove_empty_leaf` which was used for internal usage and should not be needed by users.

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use eframe::{egui, NativeOptions};
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    CentralPanel, Color32, Frame, Slider, TopBottomPanel, Ui, WidgetText,
+    CentralPanel, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
 use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
@@ -317,9 +317,11 @@ impl eframe::App for MyApp {
             // to set inner margins to 0.
             .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
             .show(ctx, |ui| {
-                // Customize DockArea style.
-                let mut style = egui_dock::Style::from_egui(&ctx.style());
-                style.selection_color = Color32::BLUE;
+                let style = self
+                    .context
+                    .style
+                    .get_or_insert(Style::from_egui(ui.style()))
+                    .clone();
 
                 DockArea::new(&mut self.tree)
                     .style(style)

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use eframe::{egui, NativeOptions};
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    CentralPanel, Id, LayerId, Slider, TopBottomPanel, Ui, WidgetText,
+    CentralPanel, Color32, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
 use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
@@ -312,21 +312,18 @@ impl eframe::App for MyApp {
             })
         });
 
-        CentralPanel::default().show(ctx, |_ui| {
-            let layer_id = LayerId::background();
-            let max_rect = ctx.available_rect();
-            let clip_rect = ctx.available_rect();
-            let id = Id::new("egui_dock::DockArea");
-            let mut ui = Ui::new(ctx.clone(), layer_id, id, max_rect, clip_rect);
+        CentralPanel::default()
+            // When displaying a DockArea in another UI, it looks better
+            // to set inner margins to 0.
+            .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
+            .show(ctx, |ui| {
+                // Customize DockArea style.
+                let mut style = egui_dock::Style::from_egui(&ctx.style());
+                style.selection_color = Color32::BLUE;
 
-            let style = self
-                .context
-                .style
-                .get_or_insert(Style::from_egui(&ui.ctx().style()))
-                .clone();
-            DockArea::new(&mut self.tree)
-                .style(style)
-                .show_inside(&mut ui, &mut self.context);
-        });
+                DockArea::new(&mut self.tree)
+                    .style(style)
+                    .show_inside(ui, &mut self.context);
+            });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             .unwrap_or_else(|| Style::from_egui(ui.style().as_ref()));
 
         let mut state = State::load(ui.ctx(), self.id);
-        let mut rect = ui.max_rect();
+        let mut rect = ui.available_rect_before_wrap();
 
         if let Some(margin) = style.dock_area_padding {
             rect.min += margin.left_top();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,8 @@
 #![forbid(unsafe_code)]
 
 use egui::{
-    style::Margin, vec2, Context, CursorIcon, Frame, Id, LayerId, Order, Pos2, Rect, Rounding,
-    ScrollArea, Sense, Stroke, Ui, WidgetText,
+    style::Margin, vec2, CentralPanel, Context, CursorIcon, Frame, Id, LayerId, Order, Pos2, Rect,
+    Rounding, ScrollArea, Sense, Stroke, Ui, WidgetText,
 };
 
 pub use crate::{
@@ -244,18 +244,43 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         self
     }
 
-    /// Shows the docking area.
+    /// Show the `DockArea` at the top level.
+    ///
+    /// This is the same as doing:
+    /// ```
+    /// # use egui_dock::{DockArea, Tree};
+    /// # use egui::{CentralPanel, Frame};
+    /// # struct TabViewer {}
+    /// # impl egui_dock::TabViewer for TabViewer {
+    /// #     type Tab = String;
+    /// #     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {}
+    /// #     fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText { (&*tab).into() }
+    /// # }
+    /// # let mut tree: Tree<String> = Tree::new(vec![]);
+    /// # let mut tab_viewer = TabViewer {};
+    /// # egui::__run_test_ctx(|ctx| {
+    /// CentralPanel::default()
+    ///     .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
+    ///     .show(ctx, |ui| {
+    ///         DockArea::new(&mut tree).show_inside(ui, &mut tab_viewer);
+    ///     });
+    /// # });
+    /// ```
+    /// So you can't use the [`CentralPanel::show`] when using `DockArea`'s one.
+    ///
+    /// See also [`show_inside`](Self::show_inside).
     #[inline]
     pub fn show(self, ctx: &Context, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
-        let layer_id = LayerId::background();
-        let max_rect = ctx.available_rect();
-        let clip_rect = ctx.available_rect();
-
-        let mut ui = Ui::new(ctx.clone(), layer_id, self.id, max_rect, clip_rect);
-        self.show_inside(&mut ui, tab_viewer);
+        CentralPanel::default()
+            .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
+            .show(ctx, |ui| {
+                self.show_inside(ui, tab_viewer);
+            });
     }
 
-    /// Shows the docking hierarchy inside a `Ui`.
+    /// Shows the docking hierarchy inside a [`Ui`].
+    ///
+    /// See also [`show`](Self::show).
     pub fn show_inside(self, ui: &mut Ui, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
         let style = self
             .style

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,42 +105,39 @@ impl HoverData {
 
         let center = rect.center();
         let pts = [
-            center.distance(pointer),
-            rect.left_center().distance(pointer),
-            rect.right_center().distance(pointer),
-            rect.center_top().distance(pointer),
-            rect.center_bottom().distance(pointer),
-        ];
-
-        let position = pts
-            .into_iter()
-            .enumerate()
-            .min_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs))
-            .map(|(idx, _)| idx)
-            .unwrap();
-
-        let (tab_dst, other) = match position {
-            0 => (TabDestination::Append, Rect::EVERYTHING),
-            1 => (
+            (
+                center.distance(pointer),
+                TabDestination::Append,
+                Rect::EVERYTHING,
+            ),
+            (
+                rect.left_center().distance(pointer),
                 TabDestination::Split(Split::Left),
                 Rect::everything_left_of(center.x),
             ),
-            2 => (
+            (
+                rect.right_center().distance(pointer),
                 TabDestination::Split(Split::Right),
                 Rect::everything_right_of(center.x),
             ),
-            3 => (
+            (
+                rect.center_top().distance(pointer),
                 TabDestination::Split(Split::Above),
                 Rect::everything_above(center.y),
             ),
-            4 => (
+            (
+                rect.center_bottom().distance(pointer),
                 TabDestination::Split(Split::Below),
                 Rect::everything_below(center.y),
             ),
-            _ => unreachable!(),
-        };
+        ];
 
-        (rect.intersect(other), tab_dst)
+        let (_, tab_dst, overlay) = pts
+            .into_iter()
+            .min_by(|(lhs, ..), (rhs, ..)| lhs.total_cmp(rhs))
+            .unwrap();
+
+        (rect.intersect(overlay), tab_dst)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 //! # `egui_dock`: docking support for `egui`
 //!
 //! Credit goes to @lain-dono for implementing the actual library.
@@ -150,8 +152,9 @@ impl State {
 
 // ----------------------------------------------------------------------------
 
-/// How we view a tab when its in a [`Tree`].
+/// How to display a tab inside a [`Tree`].
 pub trait TabViewer {
+    /// The type of tab in which you can store state to be drawn in your tabs.
     type Tab;
 
     /// Actual tab content.
@@ -211,9 +214,7 @@ pub trait TabViewer {
 
 // ----------------------------------------------------------------------------
 
-/// Stores the layout and position of all its tabs
-///
-/// Keeps track of the currently focused leaf and currently active tabs
+/// Displays a [`Tree`] in `egui`.
 pub struct DockArea<'tree, Tab> {
     id: Id,
     tree: &'tree mut Tree<Tab>,
@@ -221,6 +222,7 @@ pub struct DockArea<'tree, Tab> {
 }
 
 impl<'tree, Tab> DockArea<'tree, Tab> {
+    /// Creates a new [DockArea] from the provided [`Tree`].
     #[inline(always)]
     pub fn new(tree: &'tree mut Tree<Tab>) -> DockArea<'tree, Tab> {
         Self {

--- a/src/style.rs
+++ b/src/style.rs
@@ -192,15 +192,21 @@ impl Style {
 
         let response = ui
             .allocate_rect(separator, Sense::click_and_drag())
-            .on_hover_cursor(CursorIcon::ResizeHorizontal);
+            .on_hover_and_drag_cursor(CursorIcon::ResizeHorizontal);
 
-        {
+        if let Some(pos) = response.interact_pointer_pos() {
+            let x = pos.x;
             let delta = response.drag_delta().x;
-            let range = rect.max.x - rect.min.x;
-            let min = (self.separator_extra / range).min(1.0);
-            let max = 1.0 - min;
-            let (min, max) = (min.min(max), max.max(min));
-            *fraction = (*fraction + delta / range).clamp(min, max);
+
+            if (delta > 0. && x > midpoint && x < rect.max.x)
+                || (delta < 0. && x < midpoint && x > rect.min.x)
+            {
+                let range = rect.max.x - rect.min.x;
+                let min = (self.separator_extra / range).min(1.0);
+                let max = 1.0 - min;
+                let (min, max) = (min.min(max), max.max(min));
+                *fraction = (*fraction + delta / range).clamp(min, max);
+            }
         }
 
         let midpoint = rect.min.x + rect.width() * *fraction;
@@ -239,15 +245,22 @@ impl Style {
 
         let response = ui
             .allocate_rect(separator, Sense::click_and_drag())
-            .on_hover_cursor(CursorIcon::ResizeVertical);
+            .on_hover_and_drag_cursor(CursorIcon::ResizeVertical);
 
-        {
+        if let Some(pos) = response.interact_pointer_pos() {
+            let y = pos.y;
             let delta = response.drag_delta().y;
-            let range = rect.max.y - rect.min.y;
-            let min = (self.separator_extra / range).min(1.0);
-            let max = 1.0 - min;
-            let (min, max) = (min.min(max), max.max(min));
-            *fraction = (*fraction + delta / range).clamp(min, max);
+
+            if (delta > 0. && y > midpoint && y < rect.max.y)
+                || (delta < 0. && y < midpoint && y > rect.min.y)
+            {
+                let delta = response.drag_delta().y;
+                let range = rect.max.y - rect.min.y;
+                let min = (self.separator_extra / range).min(1.0);
+                let max = 1.0 - min;
+                let (min, max) = (min.min(max), max.max(min));
+                *fraction = (*fraction + delta / range).clamp(min, max);
+            }
         }
 
         let midpoint = rect.min.y + rect.height() * *fraction;

--- a/src/style.rs
+++ b/src/style.rs
@@ -4,13 +4,17 @@ use egui::{style::Margin, *};
 /// Left or right alignment for tab add button.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[allow(missing_docs)]
 pub enum TabAddAlign {
     Left,
     Right,
 }
 
 /// Specifies the look and feel of egui_dock.
+///
+/// See [`StyleBuilder`] for fields details.
 #[derive(Clone, Debug)]
+#[allow(missing_docs)]
 pub struct Style {
     pub dock_area_padding: Option<Margin>,
     pub default_inner_margin: Margin,
@@ -473,6 +477,7 @@ impl Style {
     }
 }
 
+/// Builds a [`Style`] with custom configuration values.
 #[derive(Default)]
 pub struct StyleBuilder {
     style: Style,
@@ -480,6 +485,7 @@ pub struct StyleBuilder {
 
 impl StyleBuilder {
     #[inline(always)]
+    /// Creates a new [StyleBuilder].
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -15,7 +15,7 @@ impl From<usize> for TabIndex {
 
 // ----------------------------------------------------------------------------
 
-/// Represents an abstract node of a `Tree`.
+/// Represents an abstract node of a [`Tree`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Node<Tab> {
@@ -36,9 +36,21 @@ pub enum Node<Tab> {
         active: TabIndex,
     },
     /// Parent node in the vertical orientation
-    Vertical { rect: Rect, fraction: f32 },
+    Vertical {
+        /// The rectangle in which all children of this node are drawn.
+        rect: Rect,
+
+        /// The fraction taken by the top child of this node.
+        fraction: f32,
+    },
     /// Parent node in the horizontal orientation
-    Horizontal { rect: Rect, fraction: f32 },
+    Horizontal {
+        /// The rectangle in which all children of this node are drawn.
+        rect: Rect,
+
+        /// The fraction taken by the left child of this node.
+        fraction: f32,
+    },
 }
 
 impl<Tab> Node<Tab> {
@@ -162,6 +174,7 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Gets the number of tabs in the node.
     #[inline]
     pub fn tabs_count(&self) -> usize {
         match self {
@@ -173,7 +186,7 @@ impl<Tab> Node<Tab> {
 
 // ----------------------------------------------------------------------------
 
-/// Wrapper around indices to the collection of nodes inside a `Tree`.
+/// Wrapper around indices to the collection of nodes inside a [`Tree`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct NodeIndex(pub usize);
@@ -261,6 +274,7 @@ impl NodeIndex {
 
 /// Direction in which a new node is created relatively to the parent node at which the split occurs.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[allow(missing_docs)]
 pub enum Split {
     Left,
     Right,
@@ -270,7 +284,15 @@ pub enum Split {
 
 // ----------------------------------------------------------------------------
 
-/// Binary tree representing the relationships between `Node`s.
+/// Binary tree representing the relationships between [`Node`]s.
+///
+/// # Implementation details
+///
+/// The binary tree is stored in a [`Vec`] indexed by [`NodeIndex`].
+/// The root is always at index *0*.
+/// For a given node *n*:
+///  - left child of *n* will be at index *n * 2 + 1*.
+///  - right child of *n* will be at index *n * 2 + 2*.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tree<Tab> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -170,13 +170,11 @@ impl<Tab> Node<Tab> {
     pub fn remove_tab(&mut self, tab_index: TabIndex) -> Option<Tab> {
         match self {
             Node::Leaf { tabs, active, .. } => {
-                let tab = tabs.remove(tab_index.0);
-
                 if tab_index <= *active {
                     active.0 = active.0.saturating_sub(1);
                 }
 
-                Some(tab)
+                Some(tabs.remove(tab_index.0))
             }
             _ => None,
         }


### PR DESCRIPTION
Looking into `Tree` structure, I found the method `remove_empty_leaf` which:
 - Didn't seem like something useful for external users
 - Was always used in contexts where we knew the actual `NodeIndex` that could be removed, causing a useless linear search.
 
So I removed the function and replaced it with the more useful `remove_leaf` function.
I also removed a bit of duplicated code regarding tab removal.

To simplify a bit the `DockArea::show_inside` I extracted the tab moving logic inside the `Tree` structure as the `Tree::move_tab` function.