### PR TITLE
make tabs scrollable when there are too many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `tab_context_menus`
   - `scroll_area_in_tabs`
   - `show_tab_name_on_hover`
+- Make tabs scrollable when they overflow ([#116](https://github.com/Adanos020/egui_dock/pull/116))
 
 ### Breaking changes
 - Removed `remove_empty_leaf` which was used for internal usage and should not be needed by users ([#115](https://github.com/Adanos020/egui_dock/pull/107))

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -34,6 +34,9 @@ pub enum Node<Tab> {
 
         /// The opened tab.
         active: TabIndex,
+
+        /// Scroll amount of the tab bar.
+        scroll: f32,
     },
     /// Parent node in the vertical orientation
     Vertical {
@@ -62,6 +65,7 @@ impl<Tab> Node<Tab> {
             viewport: Rect::NOTHING,
             tabs: vec![tab],
             active: TabIndex(0),
+            scroll: 0.0,
         }
     }
 
@@ -73,6 +77,7 @@ impl<Tab> Node<Tab> {
             viewport: Rect::NOTHING,
             tabs,
             active: TabIndex(0),
+            scroll: 0.0,
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use egui::{Pos2, Rect};
+use egui::{Pos2, Rect, Vec2};
 
 #[inline(always)]
 pub fn expand_to_pixel(mut rect: Rect, ppi: f32) -> Rect {
@@ -17,4 +17,11 @@ pub fn map_to_pixel_pos(mut pos: Pos2, ppi: f32, map: fn(f32) -> f32) -> Pos2 {
 #[inline(always)]
 pub fn map_to_pixel(point: f32, ppi: f32, map: fn(f32) -> f32) -> f32 {
     map(point * ppi) / ppi
+}
+
+pub fn rect_set_size_centered(rect: &mut Rect, size: Vec2) {
+    let center = rect.center();
+    rect.set_width(size.x);
+    rect.set_height(size.y);
+    rect.set_center(center);
 }


### PR DESCRIPTION
Attempt to fix #42 by making tab bar scroll-able (with mouse wheel) when tabs overflow.

This is very much work in progress as it does not handle expand tab option and likely won't work on touch devices.