### PR TITLE
Lvaroqui/avoid generating empty leaf

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
 
 env:
   CARGO_TERM_COLOR: always

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -125,27 +125,15 @@ impl MyContext {
                 ui.end_row();
 
                 ui.label("Idle color:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.separator.color_idle,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.separator.color_idle, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Hovered color:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.separator.color_hovered,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.separator.color_hovered, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Dragged color:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.separator.color_dragged,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.separator.color_dragged, Alpha::OnlyBlend);
                 ui.end_row();
             });
         });
@@ -190,19 +178,11 @@ impl MyContext {
 
             egui::Grid::new("tabs_colors").show(ui, |ui| {
                 ui.label("Title text color, inactive and unfocused:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tabs.text_color_unfocused,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.tabs.text_color_unfocused, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Title text color, inactive and focused:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tabs.text_color_focused,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.tabs.text_color_focused, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Title text color, active and unfocused:");
@@ -222,11 +202,7 @@ impl MyContext {
                 ui.end_row();
 
                 ui.label("Close button color unfocused:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.buttons.close_tab_color,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.buttons.close_tab_color, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Close button color focused:");
@@ -238,28 +214,16 @@ impl MyContext {
                 ui.end_row();
 
                 ui.label("Close button background color:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.buttons.close_tab_bg_fill,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.buttons.close_tab_bg_fill, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Bar background color:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tab_bar.bg_fill,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.tab_bar.bg_fill, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Outline color:")
                     .on_hover_text("The outline around the active tab name.");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tabs.outline_color,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.tabs.outline_color, Alpha::OnlyBlend);
                 ui.end_row();
 
                 ui.label("Horizontal line color:").on_hover_text(
@@ -269,11 +233,7 @@ impl MyContext {
                 ui.end_row();
 
                 ui.label("Background color:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tabs.bg_fill,
-                    Alpha::OnlyBlend,
-                );
+                color_edit_button_srgba(ui, &mut style.tabs.bg_fill, Alpha::OnlyBlend);
                 ui.end_row();
             });
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,42 +275,42 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         self.show_add_popup = show_add_popup;
         self
     }
-    
+
     /// Shows or hides the tab add buttons.
     /// By default it's false.
     pub fn show_add_buttons(mut self, show_add_buttons: bool) -> Self {
         self.show_add_buttons = show_add_buttons;
         self
     }
-    
+
     /// Shows or hides the tab close buttons.
     /// By default it's true.
     pub fn show_close_buttons(mut self, show_close_buttons: bool) -> Self {
         self.show_close_buttons = show_close_buttons;
         self
     }
-    
+
     /// Whether tabs show a context menu.
     /// By default it's true.
     pub fn tab_context_menus(mut self, tab_context_menus: bool) -> Self {
         self.tab_context_menus = tab_context_menus;
         self
     }
-    
+
     /// Whether tabs can be dragged between nodes and reordered on the tab bar.
     /// By default it's true.
     pub fn draggable_tabs(mut self, draggable_tabs: bool) -> Self {
         self.draggable_tabs = draggable_tabs;
         self
     }
-    
+
     /// Whether tabs show their name when hovered over them.
     /// By default it's false.
     pub fn show_tab_name_on_hover(mut self, show_tab_name_on_hover: bool) -> Self {
         self.show_tab_name_on_hover = show_tab_name_on_hover;
         self
     }
-    
+
     /// Whether tabs have a [`ScrollArea`] out of the box.
     /// By default it's true.
     pub fn scroll_area_in_tabs(mut self, scroll_area_in_tabs: bool) -> Self {
@@ -450,11 +450,8 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                 // tabs
                 ui.scope(|ui| {
-                    ui.painter().rect_filled(
-                        tabbar,
-                        style.tabs.rounding,
-                        style.tab_bar.bg_fill,
-                    );
+                    ui.painter()
+                        .rect_filled(tabbar, style.tabs.rounding, style.tab_bar.bg_fill);
 
                     let mut available_width = tabbar.max.x - tabbar.min.x;
                     if self.show_add_buttons {
@@ -477,8 +474,8 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         for (tab_index, tab) in tabs.iter_mut().enumerate() {
                             let id = self.id.with((node_index, tab_index, "tab"));
                             let tab_index = TabIndex(tab_index);
-                            let is_being_dragged = ui.memory(|mem| mem.is_being_dragged(id))
-                                && self.draggable_tabs;
+                            let is_being_dragged =
+                                ui.memory(|mem| mem.is_being_dragged(id)) && self.draggable_tabs;
 
                             if is_being_dragged {
                                 ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
@@ -651,8 +648,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     }
 
                     if tab_viewer.clear_background(tab) {
-                        ui.painter()
-                            .rect_filled(rect, 0.0, style.tabs.bg_fill);
+                        ui.painter().rect_filled(rect, 0.0, style.tabs.bg_fill);
                     }
 
                     let mut ui = ui.child_ui(rect, Default::default());
@@ -714,16 +710,15 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         if let (Some((src, tab_index)), Some(hover)) = (drag_data, hover_data) {
             let dst = hover.dst;
 
-            if self.tree[src].is_leaf() && self.tree[dst].is_leaf() {
+            if self.tree[src].is_leaf()
+                && self.tree[dst].is_leaf()
+                && (src != dst || self.tree[dst].tabs_count() > 1)
+            {
                 let (overlay, tab_dst) = hover.resolve();
-
-                if src != dst || self.tree[dst].tabs_count() > 1 {
-                    let id = Id::new("overlay");
-                    let layer_id = LayerId::new(Order::Foreground, id);
-                    let painter = ui.ctx().layer_painter(layer_id);
-                    painter.rect_filled(overlay, 0.0, style.selection_color);
-                }
-
+                let id = Id::new("overlay");
+                let layer_id = LayerId::new(Order::Foreground, id);
+                let painter = ui.ctx().layer_painter(layer_id);
+                painter.rect_filled(overlay, 0.0, style.selection_color);
                 if ui.input(|i| i.pointer.any_released()) {
                     self.tree.move_tab((src, tab_index), (dst, tab_dst));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,8 @@ use std::fmt;
 use utils::expand_to_pixel;
 
 mod popup;
-mod style;
+/// egui_dock theme (color, sizes...)
+pub mod style;
 mod tree;
 mod utils;
 
@@ -215,7 +216,7 @@ pub trait TabViewer {
         style.default_inner_margin
     }
 
-    /// Whether the tab will be cleared with the color specified in [`Style::tab_background_color`]
+    /// Whether the tab will be cleared with the color specified in [`style::TabBar::bg_fill`]
     fn clear_background(&self, _tab: &Self::Tab) -> bool {
         true
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -30,6 +30,7 @@ pub struct Style {
     pub tabs: Tabs,
 }
 
+/// Specifies the look and feel of buttons.
 #[derive(Clone, Debug)]
 pub struct Buttons {
     /// Color of the close tab button.
@@ -54,6 +55,7 @@ pub struct Buttons {
     pub add_tab_bg_fill: Color32,
 }
 
+/// Specifies the look and feel of node separators.
 #[derive(Clone, Debug)]
 pub struct Separator {
     /// Width of the rectangle separator between nodes. By `Default` it's `1.0`.
@@ -73,6 +75,7 @@ pub struct Separator {
     pub color_dragged: Color32,
 }
 
+/// Specifies the look and feel of tab bars.
 #[derive(Clone, Debug)]
 pub struct TabBar {
     /// Background color of tab bar. By `Default` it's [`Color32::WHITE`].
@@ -82,6 +85,7 @@ pub struct TabBar {
     pub height: f32,
 }
 
+/// Specifies the look and feel of individual tabs.
 #[derive(Clone, Debug)]
 pub struct Tabs {
     /// Color of the outline around tabs. By `Default` it's [`Color32::BLACK`].

--- a/src/style.rs
+++ b/src/style.rs
@@ -388,11 +388,8 @@ impl Style {
             self.buttons.add_tab_color
         };
         if response.hovered() {
-            ui.painter().rect_filled(
-                rect,
-                Rounding::same(2.0),
-                self.buttons.add_tab_bg_fill,
-            );
+            ui.painter()
+                .rect_filled(rect, Rounding::same(2.0), self.buttons.add_tab_bg_fill);
         }
 
         let rect = rect.shrink(1.75);
@@ -440,10 +437,7 @@ impl Style {
                 self.tab_bar.height,
             )
         } else {
-            vec2(
-                galley.size().x + offset.x * 2.0,
-                self.tab_bar.height,
-            )
+            vec2(galley.size().x + offset.x * 2.0, self.tab_bar.height)
         };
 
         let (rect, mut response) = ui.allocate_at_least(desired_size, Sense::hover());
@@ -451,31 +445,26 @@ impl Style {
             response = response.on_hover_cursor(CursorIcon::Grab);
         }
 
-        let (close_rect, close_response) =
-            if (active || response.hovered()) && show_close {
-                let mut pos = rect.right_top();
-                pos.x -= offset.x + x_size.x / 2.0;
-                pos.y += rect.size().y / 2.0;
-                let x_rect = Rect::from_center_size(pos, x_size);
-                let response = ui
-                    .interact(x_rect, id, Sense::click())
-                    .on_hover_cursor(CursorIcon::PointingHand);
-                (x_rect, Some(response))
-            } else {
-                (Rect::NOTHING, None)
-            };
+        let (close_rect, close_response) = if (active || response.hovered()) && show_close {
+            let mut pos = rect.right_top();
+            pos.x -= offset.x + x_size.x / 2.0;
+            pos.y += rect.size().y / 2.0;
+            let x_rect = Rect::from_center_size(pos, x_size);
+            let response = ui
+                .interact(x_rect, id, Sense::click())
+                .on_hover_cursor(CursorIcon::PointingHand);
+            (x_rect, Some(response))
+        } else {
+            (Rect::NOTHING, None)
+        };
 
         if active {
             if is_being_dragged {
-                ui.painter().rect_stroke(
-                    rect,
-                    rounding,
-                    Stroke::new(1.0, self.tabs.outline_color),
-                );
+                ui.painter()
+                    .rect_stroke(rect, rounding, Stroke::new(1.0, self.tabs.outline_color));
             } else {
                 let stroke = Stroke::new(1.0, self.tabs.outline_color);
-                ui.painter()
-                    .rect(rect, rounding, self.tabs.bg_fill, stroke);
+                ui.painter().rect(rect, rounding, self.tabs.bg_fill, stroke);
 
                 // Make the tab name area connect with the tab ui area:
                 ui.painter().hline(
@@ -674,7 +663,7 @@ impl StyleBuilder {
 
     /// If `true`, show the hline below the active tabs name.
     /// If `false`, show the active tab as merged with the tab ui area.
-    /// 
+    ///
     /// By `Default` it's `false`.
     #[inline(always)]
     pub fn with_hline_below_active_tab_name(mut self, hline_below_active_tab_name: bool) -> Self {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -567,6 +567,11 @@ impl<Tab> Tree<Tab> {
         (src_node, src_tab): (NodeIndex, TabIndex),
         (dst_node, dst_tab): (NodeIndex, TabDestination),
     ) {
+        // Moving a single tab inside its own node is a no-op
+        if src_node == dst_node && self[src_node].tabs_count() == 1 {
+            return;
+        }
+
         // Call `Node::remove_tab` to avoid auto remove of the node by
         // `Tree::remove_tab` from Tree.
         let tab = self[src_node].remove_tab(src_tab).unwrap();


### PR DESCRIPTION
This PR fixes a bug in the release-0.5 branch that was introduced in commit a90677f70ad30f78993682ec1ac2ebfdeaac1c23 where we could split a single tab into itself, causing an empty node to be displayed.

Also enables CI for releases branch and fixes several CI errors.