### PR TITLE
make tab bar default bg opaque, a bit darker than active tab

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -241,7 +241,7 @@ impl Style {
                 ..Separator::default()
             },
             tab_bar: TabBar {
-                bg_fill: style.visuals.faint_bg_color,
+                bg_fill: (Rgba::from(style.visuals.window_fill()) * Rgba::from_gray(0.7)).into(),
                 ..TabBar::default()
             },
             tabs: Tabs {


### PR DESCRIPTION
Proposed fix for #111, using the same color as `tabs.bg_fill`, only a little darker.

Dark Theme:
![image](https://user-images.githubusercontent.com/48593807/232162649-25438753-e81f-4222-bc93-1495982aa6e2.png)

Light Theme:
![image](https://user-images.githubusercontent.com/48593807/232162711-4bfa2b07-130c-4955-b44f-5d083f514632.png)
