### PR TITLE
Fix close button hidden when tab bar too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+# Unreleased
+
+## Fixed
+- Ensure close button can be scrolled to when tab bar is small ([#129](https://github.com/Adanos020/egui_dock/pull/129))
+
 ## 0.5.0 - 2023-04-22
 
 ### Fixed


### PR DESCRIPTION
Fixes #126 
![output](https://github.com/Adanos020/egui_dock/assets/48593807/00323f74-af01-4def-8b8b-24a83ddb1c27)
