### PR TITLE
Expand styling options for tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # egui_dock changelog
 
+## Unreleased
+
+### Fixed
+
+- Correctly draw a border around a dock area using the `Style::border` property.
+
+### Added
+
+- `Style::rounding` for the rounding of the dock area border.
+
 ## 0.6.1 - 2023-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,28 @@
 ### Added
 
 - `Style::rounding` for the rounding of the dock area border.
+- `TabStyle::active` for the active style of a tab.
+- `TabStyle::inactive` for the active style of a tab.
+- `TabStyle::focused` for the active style of a tab.
+- `TabStyle::hovered` for the active style of a tab.
 - `TabStyle::tab_body` for styling the body of the tab including background color, stroke color, rounding and inner margin.
+- `TabStyle::prefered_width` to set the prefered width of the tab.
+- `TabInteractionStyle` to style the active/inactive/focused/hovered states of a tab.
+
 
 ### Breaking changes
 
 - Moved `TabStyle::inner_margin` to `TabBodyStyle::inner_margin`.
+- Moved `TabStyle::fill_tab_bar` to `TabBarStyle::fill_tab_bar`.
+- Moved `TabStyle::outline_color` to `TabInteractionStyle::outline_color`.
+- Moved `TabStyle::rounding` to `TabInteractionStyle::rounding`.
+- Moved `TabStyle::bg_fill` to `TabInteractionStyle::bg_fill`.
+- Moved `TabStyle::text_color_unfocused` to `TabStyle::inactive.text_color`.
+- Moved `TabStyle::text_color_active_focused` to `TabStyle::focused.text_color`.
+- Moved `TabStyle::text_color_active_unfocused` to `TabStyle::active.text_color`.
+- Renamed `Style::tabs` to `Style::tab`
+- Removed `TabStyle::text_color_focused`. This style was pratically never reachable.
+
 
 ## 0.6.1 - 2023-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 ### Added
 
 - `Style::rounding` for the rounding of the dock area border.
+- `TabStyle::tab_body` for styling the body of the tab including background color, stroke color, rounding and inner margin.
+
+### Breaking changes
+
+- Moved `TabStyle::inner_margin` to `TabBodyStyle::inner_margin`.
 
 ## 0.6.1 - 2023-05-29
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -165,6 +165,10 @@ impl MyContext {
                 &mut style.tab_bar.show_scroll_bar_on_overflow,
                 "Show scroll bar on tab overflow",
             );
+            ui.checkbox(
+                &mut style.tab.hline_below_active_tab_name,
+                "Show a line below the active tab name",
+            );
             ui.horizontal(|ui| {
                 ui.add(Slider::new(&mut style.tab_bar.height, 20.0..=50.0));
                 ui.label("Tab bar height");
@@ -185,13 +189,6 @@ impl MyContext {
             ui.separator();
 
             fn tab_style_editor_ui(ui: &mut egui::Ui, tab_style: &mut TabInteractionStyle) {
-                ui.separator();
-
-                ui.checkbox(
-                    &mut tab_style.hline_below_active_tab_name,
-                    "Show a line below the active tab name",
-                );
-
                 ui.separator();
 
                 ui.label("Rounding");

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,7 +8,7 @@ use egui::{
     CentralPanel, ComboBox, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
-use egui_dock::{DockArea, Node, NodeIndex, Style, TabViewer, Tree};
+use egui_dock::{DockArea, Node, NodeIndex, Style, TabStyle, TabViewer, Tree};
 
 fn main() -> eframe::Result<()> {
     let options = NativeOptions {
@@ -160,14 +160,7 @@ impl MyContext {
         ui.collapsing("Tabs", |ui| {
             ui.separator();
 
-            ui.checkbox(&mut style.tabs.fill_tab_bar, "Expand tabs");
-            ui.checkbox(
-                &mut style.tabs.hline_below_active_tab_name,
-                "Show a line below the active tab name",
-            );
-
-            ui.separator();
-
+            ui.checkbox(&mut style.tab_bar.fill_tab_bar, "Expand tabs");
             ui.checkbox(
                 &mut style.tab_bar.show_scroll_bar_on_overflow,
                 "Show scroll bar on tab overflow",
@@ -191,51 +184,71 @@ impl MyContext {
 
             ui.separator();
 
-            ui.label("Rounding");
-            ui.horizontal(|ui| {
-                ui.add(Slider::new(&mut style.tabs.rounding.nw, 0.0..=15.0));
-                ui.label("North-West");
+            fn tab_style_editor_ui(ui: &mut egui::Ui, tab_style: &mut TabStyle) {
+                ui.separator();
+
+                ui.checkbox(
+                    &mut tab_style.hline_below_active_tab_name,
+                    "Show a line below the active tab name",
+                );
+
+                ui.separator();
+
+                ui.label("Rounding");
+                ui.horizontal(|ui| {
+                    ui.add(Slider::new(&mut tab_style.rounding.nw, 0.0..=15.0));
+                    ui.label("North-West");
+                });
+                ui.horizontal(|ui| {
+                    ui.add(Slider::new(&mut tab_style.rounding.ne, 0.0..=15.0));
+                    ui.label("North-East");
+                });
+                ui.horizontal(|ui| {
+                    ui.add(Slider::new(&mut tab_style.rounding.sw, 0.0..=15.0));
+                    ui.label("South-West");
+                });
+                ui.horizontal(|ui| {
+                    ui.add(Slider::new(&mut tab_style.rounding.se, 0.0..=15.0));
+                    ui.label("South-East");
+                });
+
+                ui.separator();
+
+                egui::Grid::new("tabs_colors").show(ui, |ui| {
+                    ui.label("Title text color:");
+                    color_edit_button_srgba(ui, &mut tab_style.text_color, Alpha::OnlyBlend);
+                    ui.end_row();
+
+                    ui.label("Outline color:")
+                        .on_hover_text("The outline around the active tab name.");
+                    color_edit_button_srgba(ui, &mut tab_style.outline_color, Alpha::OnlyBlend);
+                    ui.end_row();
+
+                    ui.label("Background color:");
+                    color_edit_button_srgba(ui, &mut tab_style.bg_fill, Alpha::OnlyBlend);
+                    ui.end_row();
+                });
+            }
+
+            ui.collapsing("Active", |ui| {
+                tab_style_editor_ui(ui, &mut style.tab.active);
             });
-            ui.horizontal(|ui| {
-                ui.add(Slider::new(&mut style.tabs.rounding.ne, 0.0..=15.0));
-                ui.label("North-East");
+
+            ui.collapsing("Inactive", |ui| {
+                tab_style_editor_ui(ui, &mut style.tab.inactive);
             });
-            ui.horizontal(|ui| {
-                ui.add(Slider::new(&mut style.tabs.rounding.sw, 0.0..=15.0));
-                ui.label("South-West");
+
+            ui.collapsing("Focused", |ui| {
+                tab_style_editor_ui(ui, &mut style.tab.focused);
             });
-            ui.horizontal(|ui| {
-                ui.add(Slider::new(&mut style.tabs.rounding.se, 0.0..=15.0));
-                ui.label("South-East");
+
+            ui.collapsing("Hovered", |ui| {
+                tab_style_editor_ui(ui, &mut style.tab.hovered);
             });
 
             ui.separator();
 
             egui::Grid::new("tabs_colors").show(ui, |ui| {
-                ui.label("Title text color, inactive and unfocused:");
-                color_edit_button_srgba(ui, &mut style.tabs.text_color_unfocused, Alpha::OnlyBlend);
-                ui.end_row();
-
-                ui.label("Title text color, inactive and focused:");
-                color_edit_button_srgba(ui, &mut style.tabs.text_color_focused, Alpha::OnlyBlend);
-                ui.end_row();
-
-                ui.label("Title text color, active and unfocused:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tabs.text_color_active_unfocused,
-                    Alpha::OnlyBlend,
-                );
-                ui.end_row();
-
-                ui.label("Title text color, active and focused:");
-                color_edit_button_srgba(
-                    ui,
-                    &mut style.tabs.text_color_active_focused,
-                    Alpha::OnlyBlend,
-                );
-                ui.end_row();
-
                 ui.label("Close button color unfocused:");
                 color_edit_button_srgba(ui, &mut style.buttons.close_tab_color, Alpha::OnlyBlend);
                 ui.end_row();
@@ -256,19 +269,49 @@ impl MyContext {
                 color_edit_button_srgba(ui, &mut style.tab_bar.bg_fill, Alpha::OnlyBlend);
                 ui.end_row();
 
-                ui.label("Outline color:")
-                    .on_hover_text("The outline around the active tab name.");
-                color_edit_button_srgba(ui, &mut style.tabs.outline_color, Alpha::OnlyBlend);
-                ui.end_row();
-
                 ui.label("Horizontal line color:").on_hover_text(
                     "The line separating the tab name area from the tab content area",
                 );
                 color_edit_button_srgba(ui, &mut style.tab_bar.hline_color, Alpha::OnlyBlend);
                 ui.end_row();
+            });
+        });
+
+        ui.collapsing("Tab body", |ui| {
+            ui.separator();
+
+            ui.label("Rounding");
+            ui.horizontal(|ui| {
+                ui.add(Slider::new(&mut style.tab.tab_body.rounding.nw, 0.0..=15.0));
+                ui.label("North-West");
+            });
+            ui.horizontal(|ui| {
+                ui.add(Slider::new(&mut style.tab.tab_body.rounding.ne, 0.0..=15.0));
+                ui.label("North-East");
+            });
+            ui.horizontal(|ui| {
+                ui.add(Slider::new(&mut style.tab.tab_body.rounding.sw, 0.0..=15.0));
+                ui.label("South-West");
+            });
+            ui.horizontal(|ui| {
+                ui.add(Slider::new(&mut style.tab.tab_body.rounding.se, 0.0..=15.0));
+                ui.label("South-East");
+            });
+
+            ui.label("Stroke width:");
+            ui.add(Slider::new(
+                &mut style.tab.tab_body.stroke.width,
+                0.0..=10.0,
+            ));
+            ui.end_row();
+
+            egui::Grid::new("tab_body_colors").show(ui, |ui| {
+                ui.label("Stroke color:");
+                color_edit_button_srgba(ui, &mut style.tab.tab_body.stroke.color, Alpha::OnlyBlend);
+                ui.end_row();
 
                 ui.label("Background color:");
-                color_edit_button_srgba(ui, &mut style.tabs.bg_fill, Alpha::OnlyBlend);
+                color_edit_button_srgba(ui, &mut style.tab.tab_body.bg_fill, Alpha::OnlyBlend);
                 ui.end_row();
             });
         });

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,7 +8,7 @@ use egui::{
     CentralPanel, ComboBox, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
-use egui_dock::{DockArea, Node, NodeIndex, Style, TabStyle, TabViewer, Tree};
+use egui_dock::{DockArea, Node, NodeIndex, Style, TabInteractionStyle, TabViewer, Tree};
 
 fn main() -> eframe::Result<()> {
     let options = NativeOptions {
@@ -184,7 +184,7 @@ impl MyContext {
 
             ui.separator();
 
-            fn tab_style_editor_ui(ui: &mut egui::Ui, tab_style: &mut TabStyle) {
+            fn tab_style_editor_ui(ui: &mut egui::Ui, tab_style: &mut TabInteractionStyle) {
                 ui.separator();
 
                 ui.checkbox(

--- a/examples/tab_add.rs
+++ b/examples/tab_add.rs
@@ -58,7 +58,7 @@ impl eframe::App for MyApp {
             .show_add_buttons(true)
             .style({
                 let mut style = Style::from_egui(ctx.style().as_ref());
-                style.tabs.fill_tab_bar = true;
+                style.tab_bar.fill_tab_bar = true;
                 style
             })
             .show(

--- a/src/style.rs
+++ b/src/style.rs
@@ -21,6 +21,8 @@ pub struct Style {
     pub selection_color: Color32,
 
     pub border: Stroke,
+    pub rounding: Rounding,
+
     pub buttons: ButtonsStyle,
     pub separator: SeparatorStyle,
     pub tab_bar: TabBarStyle,
@@ -140,6 +142,7 @@ impl Default for Style {
         Self {
             dock_area_padding: None,
             border: Stroke::new(f32::default(), Color32::BLACK),
+            rounding: Rounding::default(),
             selection_color: Color32::from_rgb(0, 191, 255).linear_multiply(0.5),
             buttons: ButtonsStyle::default(),
             separator: SeparatorStyle::default(),
@@ -229,6 +232,7 @@ impl Style {
                 color: style.visuals.widgets.active.bg_fill,
                 ..Stroke::default()
             },
+            rounding: style.visuals.widgets.active.rounding,
             selection_color: style.visuals.selection.bg_fill.linear_multiply(0.5),
             buttons: ButtonsStyle::from_egui(style),
             separator: SeparatorStyle::from_egui(style),

--- a/src/style.rs
+++ b/src/style.rs
@@ -121,6 +121,11 @@ pub struct TabStyle {
 
     /// Style for the tab body.
     pub tab_body: TabBodyStyle,
+
+    /// If `true`, show the hline below the active tabs name.
+    /// If `false`, show the active tab as merged with the tab ui area.
+    /// By `Default` it's `false`.
+    pub hline_below_active_tab_name: bool,
 }
 
 /// Specifies the look and feel of individual tabs.
@@ -137,11 +142,6 @@ pub struct TabInteractionStyle {
 
     /// Color of the title text.
     pub text_color: Color32,
-
-    /// If `true`, show the hline below the active tabs name.
-    /// If `false`, show the active tab as merged with the tab ui area.
-    /// By `Default` it's `false`.
-    pub hline_below_active_tab_name: bool,
 }
 
 /// Specifies the look and feel of the tab body.
@@ -234,6 +234,7 @@ impl Default for TabStyle {
                 ..Default::default()
             },
             tab_body: TabBodyStyle::default(),
+            hline_below_active_tab_name: false,
         }
     }
 }
@@ -242,7 +243,6 @@ impl Default for TabInteractionStyle {
     fn default() -> Self {
         Self {
             bg_fill: Color32::WHITE,
-            hline_below_active_tab_name: false,
             outline_color: Color32::BLACK,
             rounding: Rounding::default(),
             text_color: Color32::DARK_GRAY,
@@ -363,6 +363,7 @@ impl TabStyle {
             focused: TabInteractionStyle::from_egui_focused(style),
             hovered: TabInteractionStyle::from_egui_hovered(style),
             tab_body: TabBodyStyle::from_egui(style),
+            ..Default::default()
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -99,6 +99,9 @@ pub struct TabBarStyle {
     /// Color of th line separating the tab name area from the tab content area.
     /// By `Default` it's [`Color32::BLACK`].
     pub hline_color: Color32,
+
+    /// Whether tab titles expand to fill the width of their tab bars.
+    pub fill_tab_bar: bool,
 }
 
 /// Styles for a tab in its different variations.
@@ -139,9 +142,6 @@ pub struct TabStyle {
     /// If `false`, show the active tab as merged with the tab ui area.
     /// By `Default` it's `false`.
     pub hline_below_active_tab_name: bool,
-
-    /// Whether tab titles expand to fill the width of their tab bars.
-    pub fill_tab_bar: bool,
 }
 
 /// Specifies the look and feel of the tab body.
@@ -212,6 +212,7 @@ impl Default for TabBarStyle {
             show_scroll_bar_on_overflow: true,
             rounding: Rounding::default(),
             hline_color: Color32::BLACK,
+            fill_tab_bar: false,
         }
     }
 }
@@ -241,7 +242,6 @@ impl Default for TabStyle {
     fn default() -> Self {
         Self {
             bg_fill: Color32::WHITE,
-            fill_tab_bar: false,
             hline_below_active_tab_name: false,
             outline_color: Color32::BLACK,
             rounding: Rounding::default(),

--- a/src/style.rs
+++ b/src/style.rs
@@ -26,7 +26,7 @@ pub struct Style {
     pub buttons: ButtonsStyle,
     pub separator: SeparatorStyle,
     pub tab_bar: TabBarStyle,
-    pub tab: TabStyles,
+    pub tab: TabStyle,
 }
 
 /// Specifies the look and feel of buttons.
@@ -106,18 +106,18 @@ pub struct TabBarStyle {
 
 /// Styles for a tab in its different variations.
 #[derive(Clone, Debug)]
-pub struct TabStyles {
+pub struct TabStyle {
     /// Style of the tab when it is active.
-    pub active: TabStyle,
+    pub active: TabInteractionStyle,
 
     /// Style of the tab when it is inactive.
-    pub inactive: TabStyle,
+    pub inactive: TabInteractionStyle,
 
     /// Style of the tab when it is focused.
-    pub focused: TabStyle,
+    pub focused: TabInteractionStyle,
 
     /// Style of the tab when it is hovered.
-    pub hovered: TabStyle,
+    pub hovered: TabInteractionStyle,
 
     /// Style for the tab body.
     pub tab_body: TabBodyStyle,
@@ -125,7 +125,7 @@ pub struct TabStyles {
 
 /// Specifies the look and feel of individual tabs.
 #[derive(Clone, Debug)]
-pub struct TabStyle {
+pub struct TabInteractionStyle {
     /// Color of the outline around tabs. By `Default` it's [`Color32::BLACK`].
     pub outline_color: Color32,
 
@@ -170,7 +170,7 @@ impl Default for Style {
             buttons: ButtonsStyle::default(),
             separator: SeparatorStyle::default(),
             tab_bar: TabBarStyle::default(),
-            tab: TabStyles::default(),
+            tab: TabStyle::default(),
         }
     }
 }
@@ -217,19 +217,19 @@ impl Default for TabBarStyle {
     }
 }
 
-impl Default for TabStyles {
+impl Default for TabStyle {
     fn default() -> Self {
         Self {
-            active: TabStyle::default(),
-            inactive: TabStyle {
+            active: TabInteractionStyle::default(),
+            inactive: TabInteractionStyle {
                 text_color: Color32::DARK_GRAY,
                 ..Default::default()
             },
-            focused: TabStyle {
+            focused: TabInteractionStyle {
                 text_color: Color32::BLACK,
                 ..Default::default()
             },
-            hovered: TabStyle {
+            hovered: TabInteractionStyle {
                 text_color: Color32::BLACK,
                 ..Default::default()
             },
@@ -238,7 +238,7 @@ impl Default for TabStyles {
     }
 }
 
-impl Default for TabStyle {
+impl Default for TabInteractionStyle {
     fn default() -> Self {
         Self {
             bg_fill: Color32::WHITE,
@@ -288,7 +288,7 @@ impl Style {
             buttons: ButtonsStyle::from_egui(style),
             separator: SeparatorStyle::from_egui(style),
             tab_bar: TabBarStyle::from_egui(style),
-            tab: TabStyles::from_egui(style),
+            tab: TabStyle::from_egui(style),
             ..Self::default()
         }
     }
@@ -351,23 +351,23 @@ impl TabBarStyle {
     }
 }
 
-impl TabStyles {
+impl TabStyle {
     ///Derives tab styles from `egui::Style`.
     ///
     /// See also: [`TabStyle::from_egui_active`], [`TabStyle::from_egui_inactive`],
     /// [`TabStyle::from_egui_focused`], [`TabStyle::from_egui_hovered`], [`TabBodyStyle::from_egui`],
-    pub fn from_egui(style: &egui::Style) -> TabStyles {
+    pub fn from_egui(style: &egui::Style) -> TabStyle {
         Self {
-            active: TabStyle::from_egui_active(style),
-            inactive: TabStyle::from_egui_inactive(style),
-            focused: TabStyle::from_egui_focused(style),
-            hovered: TabStyle::from_egui_hovered(style),
+            active: TabInteractionStyle::from_egui_active(style),
+            inactive: TabInteractionStyle::from_egui_inactive(style),
+            focused: TabInteractionStyle::from_egui_focused(style),
+            hovered: TabInteractionStyle::from_egui_hovered(style),
             tab_body: TabBodyStyle::from_egui(style),
         }
     }
 }
 
-impl TabStyle {
+impl TabInteractionStyle {
     /// Derives relevant fields from `egui::Style` for an active tab and sets the remaining fields to their default values.
     ///
     /// Fields overwritten by [`egui::Style`] are:
@@ -382,7 +382,7 @@ impl TabStyle {
             outline_color: style.visuals.widgets.active.bg_fill,
             bg_fill: style.visuals.window_fill(),
             text_color: style.visuals.text_color(),
-            ..TabStyle::default()
+            ..TabInteractionStyle::default()
         }
     }
     /// Derives relevant fields from `egui::Style` for an inactive tab and sets the remaining fields to their default values.
@@ -397,7 +397,9 @@ impl TabStyle {
     pub fn from_egui_inactive(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.text_color(),
-            ..TabStyle::from_egui_active(style)
+            bg_fill: Color32::TRANSPARENT,
+            outline_color: Color32::TRANSPARENT,
+            ..TabInteractionStyle::from_egui_active(style)
         }
     }
     /// Derives relevant fields from `egui::Style` for a focused tab and sets the remaining fields to their default values.
@@ -412,7 +414,7 @@ impl TabStyle {
     pub fn from_egui_focused(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
-            ..TabStyle::from_egui_active(style)
+            ..TabInteractionStyle::from_egui_active(style)
         }
     }
     /// Derives relevant fields from `egui::Style` for a hovered tab and sets the remaining fields to their default values.
@@ -427,7 +429,9 @@ impl TabStyle {
     pub fn from_egui_hovered(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
-            ..TabStyle::from_egui_active(style)
+            bg_fill: Color32::TRANSPARENT,
+            outline_color: Color32::TRANSPARENT,
+            ..TabInteractionStyle::from_egui_active(style)
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -104,9 +104,6 @@ pub struct TabBarStyle {
 /// Specifies the look and feel of individual tabs.
 #[derive(Clone, Debug)]
 pub struct TabStyle {
-    /// Inner margin of tab body. By `Default` it's `Margin::same(4.0)`
-    pub inner_margin: Margin,
-
     /// Color of the outline around tabs. By `Default` it's [`Color32::BLACK`].
     pub outline_color: Color32,
 
@@ -135,6 +132,25 @@ pub struct TabStyle {
 
     /// Whether tab titles expand to fill the width of their tab bars.
     pub fill_tab_bar: bool,
+
+    /// Style for the tab body.
+    pub tab_body: TabBodyStyle,
+}
+
+/// Specifies the look and feel of the tab body.
+#[derive(Clone, Debug)]
+pub struct TabBodyStyle {
+    /// Inner margin of tab body. By `Default` it's `Margin::same(4.0)`
+    pub inner_margin: Margin,
+
+    /// Color of the tabs border. By `Default` it's ['Stroke::default']
+    pub stroke: Stroke,
+
+    /// Tab rounding. By `Default` it's [`Rounding::default`]
+    pub rounding: Rounding,
+
+    /// Colour of the tab's background. By `Default` it's [`Color32::WHITE`]
+    pub bg_fill: Color32,
 }
 
 impl Default for Style {
@@ -196,7 +212,6 @@ impl Default for TabBarStyle {
 impl Default for TabStyle {
     fn default() -> Self {
         Self {
-            inner_margin: Margin::same(4.0),
             bg_fill: Color32::WHITE,
             fill_tab_bar: false,
             hline_below_active_tab_name: false,
@@ -206,6 +221,18 @@ impl Default for TabStyle {
             text_color_focused: Color32::BLACK,
             text_color_active_unfocused: Color32::DARK_GRAY,
             text_color_active_focused: Color32::BLACK,
+            tab_body: TabBodyStyle::default(),
+        }
+    }
+}
+
+impl Default for TabBodyStyle {
+    fn default() -> Self {
+        Self {
+            inner_margin: Margin::same(4.0),
+            stroke: Stroke::default(),
+            rounding: Rounding::default(),
+            bg_fill: Color32::WHITE,
         }
     }
 }
@@ -310,6 +337,7 @@ impl TabStyle {
     /// - [`TabStyle::text_color_focused`]
     /// - [`TabStyle::text_color_active_unfocused`]
     /// - [`TabStyle::text_color_active_focused`]
+    /// - [`TabStyle::tab_body`]
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             outline_color: style.visuals.widgets.active.bg_fill,
@@ -318,7 +346,27 @@ impl TabStyle {
             text_color_focused: style.visuals.strong_text_color(),
             text_color_active_unfocused: style.visuals.text_color(),
             text_color_active_focused: style.visuals.strong_text_color(),
+            tab_body: TabBodyStyle::from_egui(style),
             ..TabStyle::default()
+        }
+    }
+}
+
+impl TabBodyStyle {
+    /// Derives relevant fields from `egui::Style` and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabBodyStyle::inner_margin`]
+    /// - [`TabBodyStyle::stroke]
+    /// - [`TabBodyStyle::rounding`]
+    /// - [`TabBodyStyle::bg_fill`]
+    pub fn from_egui(style: &egui::Style) -> Self {
+        Self {
+            inner_margin: style.spacing.window_margin,
+            stroke: Stroke::new(0.0, style.visuals.widgets.active.bg_fill),
+            rounding: style.visuals.widgets.active.rounding,
+            bg_fill: style.visuals.window_fill(),
+            ..Default::default()
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -126,6 +126,12 @@ pub struct TabStyle {
     /// If `false`, show the active tab as merged with the tab ui area.
     /// By `Default` it's `false`.
     pub hline_below_active_tab_name: bool,
+
+    /// The prefered width of the tab. The tab will allways bet atleast
+    /// wide enough to fully show the title.
+    ///
+    /// Overriden by [`TabBarStyle::fill_tab_bar`]
+    pub prefered_width: Option<f32>,
 }
 
 /// Specifies the look and feel of individual tabs.
@@ -235,6 +241,7 @@ impl Default for TabStyle {
             },
             tab_body: TabBodyStyle::default(),
             hline_below_active_tab_name: false,
+            prefered_width: None,
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -104,7 +104,7 @@ pub struct TabBarStyle {
     pub fill_tab_bar: bool,
 }
 
-/// Styles for a tab in its different variations.
+/// Specifies the look and feel of an individual tab.
 #[derive(Clone, Debug)]
 pub struct TabStyle {
     /// Style of the tab when it is active.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,3 +25,9 @@ pub fn rect_set_size_centered(rect: &mut Rect, size: Vec2) {
     rect.set_height(size.y);
     rect.set_center(center);
 }
+
+/// Shrink a rectangle so that the stroke is fully contained inside
+/// the original rectangle.
+pub fn rect_stroke_box(rect: Rect, width: f32) -> Rect {
+    rect.expand(-f32::ceil(width / 2.0))
+}

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -237,7 +237,6 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
         ui.painter().rect_stroke(rect, style.rounding, style.border);
         rect = rect.expand(-style.border.width / 2.0);
-        
 
         if self.tree.is_empty() {
             ui.allocate_rect(rect, Sense::hover());
@@ -264,8 +263,16 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 let rect = expand_to_pixel(*rect, pixels_per_point);
 
                 let midpoint = rect.min.dim_point + rect.dim_size() * *fraction;
-                let left_separator_border = midpoint - style.separator.width * 0.5;
-                let right_separator_border = midpoint + style.separator.width * 0.5;
+                let left_separator_border = map_to_pixel(
+                    midpoint - style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round
+                );
+                let right_separator_border = map_to_pixel(
+                    midpoint + style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round
+                );
 
                 paste! {
                     let left = rect.intersect(Rect::[<everything_ left_of>](left_separator_border));

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -761,7 +761,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let (rect, mut response) =
             ui.allocate_exact_size(vec2(tab_width, ui.available_height()), Sense::hover());
         if !ui.memory(|mem| mem.is_anything_being_dragged()) && self.draggable_tabs {
-            response = response.on_hover_cursor(CursorIcon::Grab);
+            response = response.on_hover_cursor(CursorIcon::PointingHand);
         }
 
         let tab_style = if focused || is_being_dragged {

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -760,7 +760,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let minimum_width = text_width + close_button_size;
 
         // Compute total width of the tab bar
-        let tab_width = if tab_style.fill_tab_bar {
+        let tab_width = if style.tab_bar.fill_tab_bar {
             expanded_width
         } else {
             minimum_width
@@ -797,7 +797,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let mut text_rect = rect;
         text_rect.set_width(tab_width - close_button_size);
 
-        let text_pos = if tab_style.fill_tab_bar {
+        let text_pos = if style.tab_bar.fill_tab_bar {
             let mut pos =
                 Align2::CENTER_CENTER.pos_in_rect(&text_rect.shrink2(vec2(x_spacing, 0.0)));
             pos -= galley.size() / 2.0;

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -629,7 +629,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             let tab_style = tab_style.as_ref().unwrap_or(&style.tab);
 
             // TODO: Aask for the correct style here.
-            if !is_active || tab_style.active.hline_below_active_tab_name {
+            if !is_active || tab_style.hline_below_active_tab_name {
                 let px = tabs_ui.ctx().pixels_per_point().recip();
                 tabs_ui.painter().hline(
                     response.rect.x_range(),

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -964,7 +964,8 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             let tabs_style = tab_viewer.tab_style_override(tab, &style.tabs);
             let tabs_style = tabs_style.as_ref().unwrap_or(&style.tabs);
             if tab_viewer.clear_background(tab) {
-                ui.painter().rect_filled(body_rect, 0.0, tabs_style.bg_fill);
+                ui.painter()
+                    .rect_filled(body_rect, 0.0, tabs_style.tab_body.bg_fill);
             }
 
             // Construct a new ui with the correct tab id
@@ -988,7 +989,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             if self.scroll_area_in_tabs {
                 ScrollArea::both().show(ui, |ui| {
                     Frame::none()
-                        .inner_margin(tabs_style.inner_margin)
+                        .outer_margin(egui::Margin::same(tabs_style.tab_body.stroke.width / 2.0))
+                        .inner_margin(tabs_style.tab_body.inner_margin)
+                        .stroke(tabs_style.tab_body.stroke)
+                        .rounding(tabs_style.tab_body.rounding)
                         .show(ui, |ui| {
                             let available_rect = ui.available_rect_before_wrap();
                             ui.expand_to_include_rect(available_rect);
@@ -997,7 +1001,9 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 });
             } else {
                 Frame::none()
-                    .inner_margin(tabs_style.inner_margin)
+                    .inner_margin(tabs_style.tab_body.inner_margin)
+                    .stroke(tabs_style.tab_body.stroke)
+                    .rounding(tabs_style.tab_body.rounding)
                     .show(ui, |ui| {
                         tab_viewer.ui(ui, tab);
                     });

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -1002,10 +1002,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             // Use initial spacing for ui
             ui.spacing_mut().item_spacing = spacing;
 
-            let tab_body_rect = Rect::from_min_max(
-                ui.clip_rect().min + vec2(0.0, style.tab_bar.height),
-                ui.clip_rect().max,
-            );
+            let tab_body_rect = Rect::from_min_max(ui.cursor().min, ui.clip_rect().max);
             ui.painter().rect(
                 rect_stroke_box(tab_body_rect, tabs_styles.tab_body.stroke.width),
                 tabs_styles.tab_body.rounding,

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -6,7 +6,7 @@ use std::ops::RangeInclusive;
 use crate::{
     utils::{expand_to_pixel, map_to_pixel, rect_set_size_centered, rect_stroke_box},
     widgets::popup::popup_under_widget,
-    Node, NodeIndex, Style, TabAddAlign, TabIndex, TabStyles, TabViewer, Tree,
+    Node, NodeIndex, Style, TabAddAlign, TabIndex, TabStyle, TabViewer, Tree,
 };
 
 use duplicate::duplicate;
@@ -732,7 +732,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     fn tab_title(
         &mut self,
         ui: &mut Ui,
-        tab_styles: &TabStyles,
+        tab_styles: &TabStyle,
         id: Id,
         label: WidgetText,
         focused: bool,

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -233,13 +233,11 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         if let Some(margin) = style.dock_area_padding {
             rect.min += margin.left_top();
             rect.max -= margin.right_bottom();
-            ui.painter().rect(
-                rect,
-                margin.top,
-                style.separator.color_idle,
-                Stroke::new(margin.top, style.border.color),
-            );
         }
+
+        ui.painter().rect_stroke(rect, style.rounding, style.border);
+        rect = rect.expand(-style.border.width / 2.0);
+        
 
         if self.tree.is_empty() {
             ui.allocate_rect(rect, Sense::hover());

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -1,4 +1,4 @@
-use crate::{NodeIndex, TabStyles};
+use crate::{NodeIndex, TabStyle};
 use egui::{Id, Ui, WidgetText};
 
 /// Defines how to display a tab inside a [`Tree`](crate::Tree).
@@ -58,7 +58,7 @@ pub trait TabViewer {
     }
 
     /// Sets custom style for given tab.
-    fn tab_style_override(&self, _tab: &Self::Tab, _global_style: &TabStyles) -> Option<TabStyles> {
+    fn tab_style_override(&self, _tab: &Self::Tab, _global_style: &TabStyle) -> Option<TabStyle> {
         None
     }
 

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -1,4 +1,4 @@
-use crate::{NodeIndex, TabStyle};
+use crate::{NodeIndex, TabStyles};
 use egui::{Id, Ui, WidgetText};
 
 /// Defines how to display a tab inside a [`Tree`](crate::Tree).
@@ -58,7 +58,7 @@ pub trait TabViewer {
     }
 
     /// Sets custom style for given tab.
-    fn tab_style_override(&self, _tab: &Self::Tab, _global_style: &TabStyle) -> Option<TabStyle> {
+    fn tab_style_override(&self, _tab: &Self::Tab, _global_style: &TabStyles) -> Option<TabStyles> {
         None
     }
 


### PR DESCRIPTION
Closes #137 

I think im pretty happy with this. 

I added four interaction styles similar to egui widget styles. `active`, `inative`, `hovered` and `focused`.  If the `from_egui` methods derive their styling from those variants then adding a third party theme to egui would automatically apply that theme to the dock area aswell.
I didnt do that right now since i didn't want to change the default styling of the dock area. Everything should look almost the same as before.

About that almost...  
Egui has this quirk (technically eframe) where it renders 1px wide lines as anti aliased. It draws half the line width on either side of the line. This causes a 1px line to actually be rendered as 2px.  
This is a group with a label inside and a 1px solid black outline.
![image](https://github.com/Adanos020/egui_dock/assets/25527438/77de884c-3fb6-4046-9940-5abcc938adda)

The same was happening for the tab outlines, however they were limited by the clip rect so they appeared as 1px.
You can see how the right border is actually 2px wide because it is the only one not clipped.
![image](https://github.com/Adanos020/egui_dock/assets/25527438/2b7efab0-5f05-4a16-bfd7-dd4f700458a1)

I added a function to reduce the size of a rect to make sure that a border around the rect does not exceed the original area of the rect. 
All this means is that now the tabs look like this:
![image](https://github.com/Adanos020/egui_dock/assets/25527438/b1bef029-5d1d-4b17-8c9d-ab82237f9aa2)

This now also plays well with the border of the tab body and the colors now match aswell.

If you have a dock area that doesnt fill its parent container then you can set a border on the tab body and get this effect which is quite nice i think.
You just have to change `style.tab.tab_body.stroke.width = 1.0;` in the style.
![image](https://github.com/Adanos020/egui_dock/assets/25527438/40566f80-57e7-450b-8d5d-ba74a3309a00)







