### PR TITLE
Always allocate area for the `DockArea`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+## 0.6.3 - 2023-06-16
+
+### Fixed
+- Made the `DockArea` always allocate an area ([#143](https://github.com/Adanos020/egui_dock/pull/143))
+
 ## 0.6.2 - 2023-06-09
 
 ### Fixed
@@ -17,7 +22,7 @@
 - `TabViewer::tab_style_override` that lets you define a custom `TabsStyle` for an individual tab ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
 - `ButtonsStyle::add_tab_border_color` for the `+` button's left border ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
 - `TabBarStyle::rounding` for rounding of the tab bar, independent from tab rounding ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
-- Separate `from_egui` methods for `ButtonsStyle`, `SeparatorStyle`, `TabBarStyle`, and `TabStyle`. ([a660497](https://github.com/Adanos020/egui_dock/commit/a660497b21651dd9920665bf50d8fc9e75d0e1e0))
+- Separate `from_egui` methods for `ButtonsStyle`, `SeparatorStyle`, `TabBarStyle`, and `TabStyle` ([a660497](https://github.com/Adanos020/egui_dock/commit/a660497b21651dd9920665bf50d8fc9e75d0e1e0))
 
 ### Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking support for `egui` - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.65"
 license = "MIT"

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -241,8 +241,9 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             );
         }
 
+        ui.allocate_rect(rect, Sense::hover());
+
         if self.tree.is_empty() {
-            ui.allocate_rect(rect, Sense::hover());
             return;
         }
 


### PR DESCRIPTION
Fixes #142 

The bug and the fix are trivial:

```rs
fn allocate_area_for_root(&mut self, ui: &mut Ui) {
    let style = self.style.as_ref().unwrap();
    let mut rect = ui.available_rect_before_wrap();

    if let Some(margin) = style.dock_area_padding {
        rect.min += margin.left_top();
        rect.max -= margin.right_bottom();
        ui.painter().rect(
            rect,
            margin.top,
            style.separator.color_idle,
            Stroke::new(margin.top, style.border.color),
        );
    }

    if self.tree.is_empty() {
        ui.allocate_rect(rect, Sense::hover()); // <------ THIS SHOULDN'T BE IN THIS BRANCH
        return;
    }

    self.tree[NodeIndex::root()].set_rect(rect);
}
```