### PR TITLE
Implemented PartialEq for Tree

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -69,7 +69,7 @@ pub enum TabDestination {
 /// For "Vertical" nodes:
 ///  - left child contains Top node.
 ///  - right child contains Bottom node.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tree<Tab> {
     tree: Vec<Node<Tab>>,

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -2,7 +2,7 @@
 use egui::Rect;
 
 /// Represents an abstract node of a [`Tree`](crate::Tree).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Node<Tab> {
     /// Empty node


### PR DESCRIPTION
I separated my app to multiple components and sharing the state using the `Rc<RefCell<State>>` between those components without using `egui::Context::data_mut`. I need to add tabs from an external component and do the rendering process in a separate component. This is my rendering method.

```rust
let mut tree_cloned = self.tree.borrow().clone();
DockArea::new(&mut tree_cloned)
    .show_add_buttons(true)
    .style(Style::from_egui(ctx.style().as_ref()))
    .show(
        ctx,
        &mut self.tab_viewer,
    );
if tree_cloned != *self.tree.borrow() {
    *self.tree.borrow_mut() = tree_cloned;
}
```

So I need the `PartialEq` to compare those `Tree` instances.