### PR TITLE
feat: allow disabling vertical/horizontal splits

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,7 +8,9 @@ use egui::{
     CentralPanel, ComboBox, Frame, Slider, TopBottomPanel, Ui, WidgetText,
 };
 
-use egui_dock::{DockArea, Node, NodeIndex, Style, TabInteractionStyle, TabViewer, Tree};
+use egui_dock::{
+    DockArea, Node, NodeIndex, SplitTypes, Style, TabInteractionStyle, TabViewer, Tree,
+};
 
 fn main() -> eframe::Result<()> {
     let options = NativeOptions {
@@ -32,6 +34,7 @@ struct MyContext {
     show_add_buttons: bool,
     draggable_tabs: bool,
     show_tab_name_on_hover: bool,
+    allowed_splits: SplitTypes,
 }
 
 struct MyApp {
@@ -102,6 +105,22 @@ impl MyContext {
             ui.checkbox(&mut self.show_add_buttons, "Show add buttons");
             ui.checkbox(&mut self.draggable_tabs, "Draggable tabs");
             ui.checkbox(&mut self.show_tab_name_on_hover, "Show tab name on hover");
+            ComboBox::new("cbox:allowed_splits", "Split direction(s)")
+                .selected_text(format!("{:?}", self.allowed_splits))
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(&mut self.allowed_splits, SplitTypes::All, "All");
+                    ui.selectable_value(
+                        &mut self.allowed_splits,
+                        SplitTypes::LeftRightOnly,
+                        "LeftRightOnly",
+                    );
+                    ui.selectable_value(
+                        &mut self.allowed_splits,
+                        SplitTypes::TopBottomOnly,
+                        "TopBottomOnly",
+                    );
+                    ui.selectable_value(&mut self.allowed_splits, SplitTypes::None, "None");
+                });
         });
 
         let style = self.style.as_mut().unwrap();
@@ -345,6 +364,7 @@ impl Default for MyApp {
             show_add_buttons: false,
             draggable_tabs: true,
             show_tab_name_on_hover: false,
+            allowed_splits: SplitTypes::default(),
         };
 
         Self { context, tree }
@@ -393,6 +413,7 @@ impl eframe::App for MyApp {
                     .show_add_buttons(self.context.show_add_buttons)
                     .draggable_tabs(self.context.draggable_tabs)
                     .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
+                    .allowed_splits(self.context.allowed_splits)
                     .show_inside(ui, &mut self.context);
             });
     }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -207,7 +207,7 @@ impl MyContext {
 
             ui.separator();
 
-            fn tab_style_editor_ui(ui: &mut egui::Ui, tab_style: &mut TabInteractionStyle) {
+            fn tab_style_editor_ui(ui: &mut Ui, tab_style: &mut TabInteractionStyle) {
                 ui.separator();
 
                 ui.label("Rounding");

--- a/src/style.rs
+++ b/src/style.rs
@@ -36,9 +36,9 @@ pub enum SplitTypes {
     /// Allow splits in any direction (horizontal and vertical).
     All,
     /// Only allow split in a horizontal direction.
-    HorizontalOnly,
+    LeftRightOnly,
     /// Only allow splits in a vertical direction.
-    VertialOnly,
+    TopBottomOnly,
     /// Don't allow splits at all.
     None,
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -27,22 +27,6 @@ pub struct Style {
     pub separator: SeparatorStyle,
     pub tab_bar: TabBarStyle,
     pub tab: TabStyle,
-
-    pub allowed_splits: SplitTypes,
-}
-
-/// What directions can this dock split in?
-#[derive(Clone, Debug, Default)]
-pub enum SplitTypes {
-    #[default]
-    /// Allow splits in any direction (horizontal and vertical).
-    All,
-    /// Only allow split in a horizontal direction.
-    LeftRightOnly,
-    /// Only allow splits in a vertical direction.
-    TopBottomOnly,
-    /// Don't allow splits at all.
-    None,
 }
 
 /// Specifies the look and feel of buttons.
@@ -193,7 +177,6 @@ impl Default for Style {
             separator: SeparatorStyle::default(),
             tab_bar: TabBarStyle::default(),
             tab: TabStyle::default(),
-            allowed_splits: SplitTypes::default(),
         }
     }
 }
@@ -437,6 +420,7 @@ impl TabInteractionStyle {
             ..TabInteractionStyle::from_egui_active(style)
         }
     }
+
     /// Derives relevant fields from `egui::Style` for a focused tab and sets the remaining fields to their default values.
     ///
     /// Fields overwritten by [`egui::Style`] are:
@@ -450,6 +434,7 @@ impl TabInteractionStyle {
             ..TabInteractionStyle::from_egui_active(style)
         }
     }
+
     /// Derives relevant fields from `egui::Style` for a hovered tab and sets the remaining fields to their default values.
     ///
     /// Fields overwritten by [`egui::Style`] are:

--- a/src/style.rs
+++ b/src/style.rs
@@ -25,6 +25,22 @@ pub struct Style {
     pub separator: SeparatorStyle,
     pub tab_bar: TabBarStyle,
     pub tabs: TabStyle,
+
+    pub allowed_splits: SplitTypes,
+}
+
+/// What directions can this dock split in?
+#[derive(Clone, Debug, Default)]
+pub enum SplitTypes {
+    #[default]
+    /// Allow splits in any direction (horizontal and vertical).
+    All,
+    /// Only allow split in a horizontal direction.
+    HorizontalOnly,
+    /// Only allow splits in a vertical direction.
+    VertialOnly,
+    /// Don't allow splits at all.
+    None,
 }
 
 /// Specifies the look and feel of buttons.
@@ -145,6 +161,7 @@ impl Default for Style {
             separator: SeparatorStyle::default(),
             tab_bar: TabBarStyle::default(),
             tabs: TabStyle::default(),
+            allowed_splits: SplitTypes::default(),
         }
     }
 }

--- a/src/widgets/dock_area/hover_data.rs
+++ b/src/widgets/dock_area/hover_data.rs
@@ -1,4 +1,4 @@
-use crate::{NodeIndex, Split, TabDestination, TabIndex};
+use crate::{NodeIndex, Split, SplitTypes, TabDestination, TabIndex};
 use egui::{Pos2, Rect};
 
 #[derive(Debug)]
@@ -11,7 +11,7 @@ pub(super) struct HoverData {
 }
 
 impl HoverData {
-    pub(super) fn resolve(&self) -> (Rect, TabDestination) {
+    pub(super) fn resolve(&self, allowed_splits: &SplitTypes) -> (Rect, TabDestination) {
         if let Some(tab) = self.tab {
             return (tab.0, TabDestination::Insert(tab.1));
         }
@@ -22,33 +22,66 @@ impl HoverData {
         let (rect, pointer) = (self.rect, self.pointer);
 
         let center = rect.center();
-        let pts = [
-            (
-                center.distance(pointer),
-                TabDestination::Append,
-                Rect::EVERYTHING,
-            ),
-            (
-                rect.left_center().distance(pointer),
-                TabDestination::Split(Split::Left),
-                Rect::everything_left_of(center.x),
-            ),
-            (
-                rect.right_center().distance(pointer),
-                TabDestination::Split(Split::Right),
-                Rect::everything_right_of(center.x),
-            ),
-            (
-                rect.center_top().distance(pointer),
-                TabDestination::Split(Split::Above),
-                Rect::everything_above(center.y),
-            ),
-            (
-                rect.center_bottom().distance(pointer),
-                TabDestination::Split(Split::Below),
-                Rect::everything_below(center.y),
-            ),
-        ];
+
+        let pts = match allowed_splits {
+            SplitTypes::All => vec![
+                (
+                    center.distance(pointer),
+                    TabDestination::Append,
+                    Rect::EVERYTHING,
+                ),
+                (
+                    rect.left_center().distance(pointer),
+                    TabDestination::Split(Split::Left),
+                    Rect::everything_left_of(center.x),
+                ),
+                (
+                    rect.right_center().distance(pointer),
+                    TabDestination::Split(Split::Right),
+                    Rect::everything_right_of(center.x),
+                ),
+                (
+                    rect.center_top().distance(pointer),
+                    TabDestination::Split(Split::Above),
+                    Rect::everything_above(center.y),
+                ),
+                (
+                    rect.center_bottom().distance(pointer),
+                    TabDestination::Split(Split::Below),
+                    Rect::everything_below(center.y),
+                ),
+            ],
+            SplitTypes::HorizontalOnly => vec![
+                (
+                    center.distance(pointer),
+                    TabDestination::Append,
+                    Rect::EVERYTHING,
+                ),
+                (
+                    rect.left_center().distance(pointer),
+                    TabDestination::Split(Split::Left),
+                    Rect::everything_left_of(center.x),
+                ),
+                (
+                    rect.right_center().distance(pointer),
+                    TabDestination::Split(Split::Right),
+                    Rect::everything_right_of(center.x),
+                ),
+            ],
+            SplitTypes::VertialOnly => vec![
+                (
+                    rect.center_top().distance(pointer),
+                    TabDestination::Split(Split::Above),
+                    Rect::everything_above(center.y),
+                ),
+                (
+                    rect.center_bottom().distance(pointer),
+                    TabDestination::Split(Split::Below),
+                    Rect::everything_below(center.y),
+                ),
+            ],
+            SplitTypes::None => vec![],
+        };
 
         let (_, tab_dst, overlay) = pts
             .into_iter()

--- a/src/widgets/dock_area/hover_data.rs
+++ b/src/widgets/dock_area/hover_data.rs
@@ -51,7 +51,7 @@ impl HoverData {
                     Rect::everything_below(center.y),
                 ),
             ],
-            SplitTypes::HorizontalOnly => vec![
+            SplitTypes::LeftRightOnly => vec![
                 (
                     center.distance(pointer),
                     TabDestination::Append,
@@ -68,7 +68,7 @@ impl HoverData {
                     Rect::everything_right_of(center.x),
                 ),
             ],
-            SplitTypes::VertialOnly => vec![
+            SplitTypes::TopBottomOnly => vec![
                 (
                     rect.center_top().distance(pointer),
                     TabDestination::Split(Split::Above),

--- a/src/widgets/dock_area/hover_data.rs
+++ b/src/widgets/dock_area/hover_data.rs
@@ -80,7 +80,11 @@ impl HoverData {
                     Rect::everything_below(center.y),
                 ),
             ],
-            SplitTypes::None => vec![],
+            SplitTypes::None => vec![(
+                center.distance(pointer),
+                TabDestination::Append,
+                Rect::EVERYTHING,
+            )],
         };
 
         let (_, tab_dst, overlay) = pts

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -212,7 +212,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 && self.tree[dst].is_leaf()
                 && (src != dst || self.tree[dst].tabs_count() > 1)
             {
-                let (overlay, tab_dst) = hover.resolve();
+                let (overlay, tab_dst) = hover.resolve(&style.allowed_splits);
                 let id = Id::new("overlay");
                 let layer_id = LayerId::new(Order::Foreground, id);
                 let painter = ui.ctx().layer_painter(layer_id);

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -19,7 +19,7 @@ use paste::paste;
 use state::State;
 
 /// What directions can this dock split in?
-#[derive(Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum SplitTypes {
     #[default]
     /// Allow splits in any direction (horizontal and vertical).

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -6,5 +6,5 @@ pub(crate) mod popup;
 /// Trait for tab-viewing types.
 pub mod tab_viewer;
 
-pub use dock_area::DockArea;
+pub use dock_area::{DockArea, SplitTypes};
 pub use tab_viewer::TabViewer;


### PR DESCRIPTION
I have a use case where I never ever want the user to be able to make vertical splits. This PR allows the programmer to disable vertical or horizontal splits via `allowed_splits` on the `Style` struct.