### PR TITLE
feat: double click on separator to reset size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `egui_dock`: docking support for [egui](https://github.com/emilk/egui)
 
-[![egui_ver](https://img.shields.io/badge/egui-0.21-blue)](https://github.com/emilk/egui)
+[![egui_ver](https://img.shields.io/badge/egui-0.22-blue)](https://github.com/emilk/egui)
 [![Crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
 

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -346,6 +346,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         *fraction = (*fraction + delta / range).clamp(min, max);
                     }
                 }
+
+                if response.double_clicked() {
+                    *fraction = 0.5;
+                }
             }
         }
     }

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -188,7 +188,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             }
         }
 
-        // Finaly draw separators so that their "interaction zone" is above
+        // Finally draw separators so that their "interaction zone" is above
         // bodies (see `SeparatorStyle::extra_interact_width`).
         for node_index in self.tree.breadth_first_index_iter() {
             if self.tree[node_index].is_parent() {


### PR DESCRIPTION
double clicking on the separator will now reset the fraction to 0.5, this behaviour is consistent with other docking tools like VSCode.