### PR TITLE
Allow individual tabs to be closable or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui_dock changelog
 
+## Next
+
+### Added
+
+- `TabViewer::closable` lets individual tabs be closable or not ([#113])
+
 ## 0.6.3 - 2023-06-16
 
 ### Fixed

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -70,10 +70,7 @@ impl TabViewer for MyContext {
     }
 
     fn closeable(&mut self, tab: &mut Self::Tab) -> bool {
-        match tab.as_str() {
-            "Inspector" => false,
-            _ => true,
-        }
+        ["Inspector", "Style Editor"].contains(&tab.as_str())
     }
 
     fn on_close(&mut self, tab: &mut Self::Tab) -> bool {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -66,6 +66,13 @@ impl TabViewer for MyContext {
         tab.as_str().into()
     }
 
+    fn closeable(&mut self, tab: &mut Self::Tab) -> bool {
+        match tab.as_str() {
+            "Inspector" => false,
+            _ => true,
+        }
+    }
+
     fn on_close(&mut self, tab: &mut Self::Tab) -> bool {
         self.open_tabs.remove(tab);
         true

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -25,6 +25,13 @@ pub trait TabViewer {
     /// Called after each tab button is shown, so you can add a tooltip, check for clicks, etc.
     fn on_tab_button(&mut self, _tab: &mut Self::Tab, _response: &egui::Response) {}
 
+    /// Called before showing the close button.
+    ///
+    /// Return `false` if the close buttons should not be shown.
+    fn closeable(&mut self, _tab: &mut Self::Tab) -> bool {
+        true
+    }
+
     /// This is called when the tabs close button is pressed.
     ///
     /// Returns `true` if the tab should close immediately, `false` otherwise.


### PR DESCRIPTION
﻿Closes #113

Mandatory requirements (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
- [x] I ran `cargo clippy` and it does not output any errors or warnings
- [x] I ran `cargo fmt`
- [x] I pushed to a new branch, not to `main`
- [x] I updated CHANGELOG.md
- [x] I documented all new public API
- [x] I provided an example of how to use the feature

## Description

The close button and context menu item is now only shown if `TabViewer::closable` returns true. A default implementation is provided that always return true. No default behaviour have changed

## Demo
Here only the "Inspector" tab is not closable:
![image](https://github.com/Adanos020/egui_dock/assets/56919/9becff4f-7417-455e-910e-d2b56f67a421)