### PR TITLE
Add egui tiles as alternative in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 egui = "0.22"
 egui_dock = "0.6"
 ```
-https://github.com/rerun-io/egui_tiles#comparison-with-egui_dock
+
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).
 Once that's done, you can start using `egui_dock` – more details on that can be found in the
 [documentation](https://docs.rs/egui_dock/latest/egui_dock/).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 egui = "0.22"
 egui_dock = "0.6"
 ```
-
+https://github.com/rerun-io/egui_tiles#comparison-with-egui_dock
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).
 Once that's done, you can start using `egui_dock` – more details on that can be found in the
 [documentation](https://docs.rs/egui_dock/latest/egui_dock/).
@@ -30,3 +30,8 @@ Once that's done, you can start using `egui_dock` – more details on that can b
 ## Demo
 
 ![demo](images/demo.gif "Demo")
+
+## Alternatives
+### [egui_ties](https://https://github.com/rerun-io/egui_tiles) 
+> [!NOTE]
+> egui_tiles is not as mature as egui_docks check the [comparision](https://github.com/rerun-io/egui_tiles#comparison-with-egui_dock)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Once that's done, you can start using `egui_dock` – more details on that can b
 ![demo](images/demo.gif "Demo")
 
 ## Alternatives
-### [egui_ties](https://https://github.com/rerun-io/egui_tiles) 
+### [egui_tiles](https://https://github.com/rerun-io/egui_tiles) 
 > [!NOTE]
 > egui_tiles is not as mature as egui_docks check the [comparision](https://github.com/rerun-io/egui_tiles#comparison-with-egui_dock)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Once that's done, you can start using `egui_dock` – more details on that can b
 ![demo](images/demo.gif "Demo")
 
 ## Alternatives
+
 ### [egui_tiles](https://https://github.com/rerun-io/egui_tiles) 
+
+It's a library aiming to achieve similar goals in addition to being more flexible and customizable.
+
+One feature it supports that `egui_dock` does not at the moment is the ability to divide nodes into more than two children,
+enabling horizontal, vertical, and grid layouts.
+
 > [!NOTE]
-> egui_tiles is not as mature as egui_docks check the [comparision](https://github.com/rerun-io/egui_tiles#comparison-with-egui_dock)
+> `egui_tiles` is much earlier in development than `egui_dock` and doesn't yet support a lot of features.


### PR DESCRIPTION
It would be nice to list egui_tiles as an alternative 

Here is the [comparision](https://github.com/rerun-io/egui_tiles#comparison-with-egui_dock)