### PR TITLE
add cargo config for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,15 @@ eframe = { version = "0.22", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }
+
+# examples
+[[example]]
+name = "hello" # examples/hello.rs
+[[example]]
+name = "simple" # examples/simple.rs
+[[example]]
+name = "tab_add_popup" # examples/tab_add_popup.rs
+[[example]]
+name = "tab_add" # examples/tab_add.rs
+[[example]]
+name = "text_editor" # examples/text_editor.rs

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ Once that's done, you can start using `egui_dock` – more details on that can b
 ## Demo
 
 ![demo](images/demo.gif "Demo")
+
+## Examples
+
+Run examples locally with `cargo run --example example_name`.
+
+Available examples:
+- [hello](examples/hello.rs)
+- [simple](examples/simple.rs)
+- [tab_add_popup](examples/tab_add_popup.rs)
+- [tab_add](examples/tab_add.rs)
+- [text_editor](examples/text_editor.rs)


### PR DESCRIPTION
Mandatory requirements (see [CONTRIBUTING.md](../../CONTRIBUTING.md)):
- [X] I ran `cargo clippy` and it does not output any errors or warnings
- [X] I ran `cargo fmt`
- [X] I pushed to a new branch, not to `main`
- [X] I updated CHANGELOG.md
- [X] I documented all new public API
- [X] I provided an example of how to use the feature

## Description
You can run any examples now with `cargo run --example example_name`.
