### PR TITLE
fix  bug 

### DIFF
--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -789,7 +789,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let galley = label.into_galley(ui, None, f32::INFINITY, TextStyle::Button);
         let x_spacing = 8.0;
         let text_width = galley.size().x + 2.0 * x_spacing;
-        let close_button_size = if self.show_close_buttons {
+        let close_button_size = if show_close_button {
             Style::TAB_CLOSE_BUTTON_SIZE.min(style.tab_bar.height)
         } else {
             0.0


### PR DESCRIPTION
![1691723125725](https://github.com/Adanos020/egui_dock/assets/108512675/01d8a015-0cee-4a69-bf13-0b6ee40ad769)



Remove white space where the close button is not enabled