### PR TITLE
Add the NodeIndex to context_menu() parameter list

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -55,7 +55,7 @@ impl TabViewer for MyContext {
         }
     }
 
-    fn context_menu(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {
+    fn context_menu(&mut self, ui: &mut Ui, tab: &mut Self::Tab, _node: NodeIndex) {
         match tab.as_str() {
             "Simple Demo" => self.simple_demo_menu(ui),
             _ => {

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -627,7 +627,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                 if self.tab_context_menus {
                     response = response.context_menu(|ui| {
-                        tab_viewer.context_menu(ui, tab);
+                        tab_viewer.context_menu(ui, tab, node_index);
                         if show_close_button && ui.button("Close").clicked() {
                             if tab_viewer.on_close(tab) {
                                 self.to_remove.push((node_index, tab_index));

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -10,7 +10,10 @@ pub trait TabViewer {
     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab);
 
     /// Content inside context_menu.
-    fn context_menu(&mut self, _ui: &mut Ui, _tab: &mut Self::Tab) {}
+    ///
+    /// The `_node` specifies which `Node` or split of the tree that this
+    /// particular context menu belongs to.
+    fn context_menu(&mut self, _ui: &mut Ui, _tab: &mut Self::Tab, _node: NodeIndex) {}
 
     /// The title to be displayed.
     fn title(&mut self, tab: &mut Self::Tab) -> WidgetText;


### PR DESCRIPTION
### Problem to solve

I use the `context_menu(...)` function so display options for splitting the current window. To call the `split(...)` function, I need to know the `parent` node. However this is not available at the moment.

I tried using the `focused_leaf(...)` function, but depending on the mouse position the split goes into the wrong parent.
![Splitting-focused-leaf](https://github.com/Adanos020/egui_dock/assets/17766093/a913d77a-30ef-4a54-bb0f-c695a8c01e0d)

### Solution in this PR

Pass the `NodeIndex` to the `context_menu(...)` function, the same way as it is done in the `on_add` function.