### PR TITLE
Fix for issue #172

### DIFF
--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -183,13 +183,6 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let drag_state = state.dnd.as_mut().unwrap();
         let style = self.style.as_ref().unwrap();
 
-        // If were hovering over ourselves, we're not moving anywhere.
-        if drag_state.hover.dst.node_address() == drag_state.drag.src.node_address()
-            && drag_state.is_on_title_bar()
-        {
-            return None;
-        }
-
         let deserted_node = {
             match (
                 drag_state.drag.src.node_address(),


### PR DESCRIPTION
Fixes #172 

removes the a check that prevented users from rearranging tabs in the node they reside in. 

Now in order for the user to "regret" a move in the middle of an undock while in the widgeted overlay style would be to move the tab to the center overlay icon.