### PR TITLE
Fix for issue #174

### DIFF
--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -1,7 +1,4 @@
-use std::{
-    ops::BitOrAssign,
-    time::Duration,
-};
+use std::{ops::BitOrAssign, time::Duration};
 
 use crate::{
     AllowedSplits, NodeIndex, Split, Style, SurfaceIndex, TabDestination, TabIndex, TabInsert,
@@ -364,7 +361,7 @@ impl DragDropState {
         match self.locked.as_mut() {
             Some(lock_time) => {
                 if target_state == LockState::HardLock {
-                    *lock_time = ctx.input(|i| i.time );
+                    *lock_time = ctx.input(|i| i.time);
                 }
                 let window_hold = if !self.hover.dst.surface_address().is_main() {
                     ctx.request_repaint();
@@ -378,7 +375,7 @@ impl DragDropState {
             }
             None => {
                 if target_state != LockState::Unlocked {
-                    self.locked = Some(ctx.input(|i| i.time ));
+                    self.locked = Some(ctx.input(|i| i.time));
                 }
             }
         }
@@ -387,7 +384,7 @@ impl DragDropState {
     pub(super) fn is_locked(&self, style: &Style, ctx: &Context) -> bool {
         match self.locked.as_ref() {
             Some(lock_time) => {
-                let elapsed = (ctx.input(|i| i.time ) - lock_time) as f32;
+                let elapsed = (ctx.input(|i| i.time) - lock_time) as f32;
                 ctx.request_repaint_after(Duration::from_secs_f32(
                     (style.overlay.feel.max_preference_time - elapsed).max(0.0),
                 ));

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -1,4 +1,4 @@
-use std::{ops::BitOrAssign, time::Duration};
+use std::ops::BitOrAssign;
 
 use crate::{
     AllowedSplits, NodeIndex, Split, Style, SurfaceIndex, TabDestination, TabIndex, TabInsert,
@@ -385,9 +385,7 @@ impl DragDropState {
         match self.locked.as_ref() {
             Some(lock_time) => {
                 let elapsed = (ctx.input(|i| i.time) - lock_time) as f32;
-                ctx.request_repaint_after(Duration::from_secs_f32(
-                    (style.overlay.feel.max_preference_time - elapsed).max(0.0),
-                ));
+                ctx.request_repaint();
                 elapsed < style.overlay.feel.max_preference_time
             }
             None => false,

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -1,6 +1,6 @@
 use std::{
     ops::BitOrAssign,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use crate::{
@@ -150,8 +150,8 @@ pub(super) struct DragDropState {
     pub hover: HoverData,
     pub drag: DragData,
     pub pointer: Pos2,
-    /// Is some when the pointer is over rect, instant holds when the lock was last active.
-    pub locked: Option<Instant>,
+    /// Is some when the pointer is over rect, f64 holds the time when the lock was last active.
+    pub locked: Option<f64>,
 }
 
 impl DragDropState {
@@ -364,7 +364,7 @@ impl DragDropState {
         match self.locked.as_mut() {
             Some(lock_time) => {
                 if target_state == LockState::HardLock {
-                    *lock_time = Instant::now();
+                    *lock_time = ctx.input(|i| i.time );
                 }
                 let window_hold = if !self.hover.dst.surface_address().is_main() {
                     ctx.request_repaint();
@@ -378,7 +378,7 @@ impl DragDropState {
             }
             None => {
                 if target_state != LockState::Unlocked {
-                    self.locked = Some(Instant::now());
+                    self.locked = Some(ctx.input(|i| i.time ));
                 }
             }
         }
@@ -387,7 +387,7 @@ impl DragDropState {
     pub(super) fn is_locked(&self, style: &Style, ctx: &Context) -> bool {
         match self.locked.as_ref() {
             Some(lock_time) => {
-                let elapsed = lock_time.elapsed().as_secs_f32();
+                let elapsed = (ctx.input(|i| i.time ) - lock_time) as f32;
                 ctx.request_repaint_after(Duration::from_secs_f32(
                     (style.overlay.feel.max_preference_time - elapsed).max(0.0),
                 ));

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use egui::{
     CentralPanel, Color32, Context, CursorIcon, Frame, LayerId, Order, Pos2, Rect, Rounding, Sense,
     Ui, Vec2,
@@ -146,8 +144,8 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 };
                 if let Some(destination) = tab_dst {
                     self.dock_state.move_tab(source, destination);
-                    state.reset_drag();
                 }
+                state.reset_drag();
             }
         }
         state.store(ui.ctx(), self.id);
@@ -163,13 +161,14 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     ) -> Option<SurfaceIndex> {
         if let Some(dnd_state) = &state.dnd {
             if dnd_state.is_locked(self.style.as_ref().unwrap(), ctx) {
-                state.window_fade = Some((Instant::now(), dnd_state.hover.dst.surface_address()));
+                state.window_fade =
+                    Some((ctx.input(|i| i.time), dnd_state.hover.dst.surface_address()));
             }
         }
 
         state.window_fade.and_then(|(time, surface)| {
             ctx.request_repaint();
-            (time.elapsed().as_secs_f32() < hold_time).then_some(surface)
+            (hold_time > (ctx.input(|i| i.time) - time) as f32).then_some(surface)
         })
     }
 

--- a/src/widgets/dock_area/state.rs
+++ b/src/widgets/dock_area/state.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use egui::{Context, Id, Pos2};
 
 use crate::{Style, SurfaceIndex};
@@ -10,7 +8,7 @@ use super::drag_and_drop::{DragData, DragDropState, HoverData};
 pub(super) struct State {
     pub drag_start: Option<Pos2>,
     pub dnd: Option<DragDropState>,
-    pub window_fade: Option<(Instant, SurfaceIndex)>,
+    pub window_fade: Option<(f64, SurfaceIndex)>,
 }
 
 impl State {


### PR DESCRIPTION
fixes issue #174 by removing the use of ``Instant`` inside the drag/drop state. As methods like ``Instant::now()`` is not implemented for wasm. This has been replaced with ``egui::InputState::time`` instead. 