### PR TITLE
Misc. fixes of two bugs regarding dragging tabs

### DIFF
--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -2,8 +2,8 @@ use std::ops::RangeInclusive;
 
 use egui::{
     epaint::TextShape, lerp, pos2, vec2, Align, Align2, CursorIcon, Frame, Id, LayerId, Layout,
-    NumExt, Order, Rect, Response, Rounding, ScrollArea, Sense, Stroke, TextStyle, Ui, Vec2,
-    WidgetText,
+    NumExt, Order, PointerButton, Rect, Response, Rounding, ScrollArea, Sense, Stroke, TextStyle,
+    Ui, Vec2, WidgetText,
 };
 
 use crate::{
@@ -205,8 +205,9 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 .with((node_index, "node"))
                 .with((tab_index, "tab"));
             let tab_index = TabIndex(tab_index);
-            let is_being_dragged =
-                tabs_ui.memory(|mem| mem.is_being_dragged(id)) && self.draggable_tabs;
+            let is_being_dragged = tabs_ui.memory(|mem| mem.is_being_dragged(id))
+                && tabs_ui.input(|i| i.pointer.primary_down() || i.pointer.primary_released())
+                && self.draggable_tabs;
 
             if is_being_dragged {
                 tabs_ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
@@ -338,7 +339,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     }
                 }
                 let response = tabs_ui.interact(response.rect, id, sense);
-                if response.drag_started() {
+                if response.drag_started_by(PointerButton::Primary) {
                     state.drag_start = response.hover_pos();
                 }
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -131,7 +131,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 })
                 .inner
             };
-            if ui.input(|i| i.pointer.any_released()) {
+            if ui.input(|i| i.pointer.primary_released()) {
                 let source = {
                     match state.dnd.as_ref().unwrap().drag.src {
                         TreeComponent::Tab(src_surf, src_node, src_tab) => {


### PR DESCRIPTION
Fixes two minor bugs found with dragging and droppping tabs.

1.Dragging a tab from a window with a single tab to an empty surface causes a panic

Steps to reproduce:
* dragging each tab from a dock state into a window
* drag one of the tabs out to create a second window
* take the single tab from the second window and put it into the empty surface

2.Dragging a tab and pressing new mouse buttons causes unintended behavior

Steps to reproduce:
* drag any tab
* press any secondary mouse button while dragging

both of these have been fixed by restricting drags to only be carried out by the primary mouse button and restructuring code to properly delete empty assets from the tree (unless they're explicitly meant to be like eg. an empty surface)
