### PR TITLE
Fix hover_pos on touch screens

### DIFF
--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -40,6 +40,11 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         ui.spacing_mut().item_spacing = Vec2::ZERO;
         ui.set_clip_rect(rect);
 
+        // Delay hover position one frame. On touch screens hover_pos() is None when any_released()
+        if !ui.input(|i| i.pointer.any_released()) {
+            state.hover_pos = ui.input(|i| i.pointer.hover_pos());
+        }
+
         let tabbar_response = self.tab_bar(
             ui,
             state,
@@ -797,7 +802,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         }
 
         //change hover destination
-        if let Some(pointer) = ui.input(|i| i.pointer.hover_pos()) {
+        if let Some(pointer) = state.hover_pos {
             // Prevent borrow checker issues.
             let rect = rect.to_owned();
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -67,13 +67,12 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             .get_or_insert(Style::from_egui(ui.style().as_ref()));
         self.window_bounds.get_or_insert(ui.ctx().screen_rect());
         let mut state = State::load(ui.ctx(), self.id);
-        let style = self.style.as_ref().unwrap();
-
         // Delay hover position one frame. On touch screens hover_pos() is None when any_released()
         if !ui.input(|i| i.pointer.any_released()) {
             state.last_hover_pos = ui.input(|i| i.pointer.hover_pos());
         }
 
+        let style = self.style.as_ref().unwrap();
         let fade_surface =
             self.hovered_window_surface(&mut state, style.overlay.feel.fade_hold_time, ui.ctx());
         let fade_style = {

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -68,6 +68,12 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         self.window_bounds.get_or_insert(ui.ctx().screen_rect());
         let mut state = State::load(ui.ctx(), self.id);
         let style = self.style.as_ref().unwrap();
+
+        // Delay hover position one frame. On touch screens hover_pos() is None when any_released()
+        if !ui.input(|i| i.pointer.any_released()) {
+            state.last_hover_pos = ui.input(|i| i.pointer.hover_pos());
+        }
+
         let fade_surface =
             self.hovered_window_surface(&mut state, style.overlay.feel.fade_hold_time, ui.ctx());
         let fade_style = {
@@ -105,7 +111,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         }
 
         for (surface_index, node_index, tab_index) in self.to_detach.drain(..).rev() {
-            let mouse_pos = ui.input(|input| input.pointer.hover_pos());
+            let mouse_pos = state.last_hover_pos;
             self.dock_state.detach_tab(
                 (surface_index, node_index, tab_index),
                 Rect::from_min_size(
@@ -214,7 +220,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             _ => todo!("collections of tabs, like nodes or surfaces, can't be dragged! (yet)"),
         };
 
-        if let Some(pointer) = ui.input(|i| i.pointer.hover_pos()) {
+        if let Some(pointer) = state.last_hover_pos {
             drag_state.pointer = pointer;
         }
 

--- a/src/widgets/dock_area/state.rs
+++ b/src/widgets/dock_area/state.rs
@@ -7,6 +7,7 @@ use super::drag_and_drop::{DragData, DragDropState, HoverData};
 #[derive(Clone, Debug, Default)]
 pub(super) struct State {
     pub drag_start: Option<Pos2>,
+    pub hover_pos: Option<Pos2>,
     pub dnd: Option<DragDropState>,
     pub window_fade: Option<(f64, SurfaceIndex)>,
 }
@@ -16,6 +17,7 @@ impl State {
     pub(super) fn load(ctx: &Context, id: Id) -> Self {
         ctx.data_mut(|d| d.get_temp(id)).unwrap_or(Self {
             drag_start: None,
+            hover_pos: None,
             dnd: None,
             window_fade: None,
         })

--- a/src/widgets/dock_area/state.rs
+++ b/src/widgets/dock_area/state.rs
@@ -7,7 +7,7 @@ use super::drag_and_drop::{DragData, DragDropState, HoverData};
 #[derive(Clone, Debug, Default)]
 pub(super) struct State {
     pub drag_start: Option<Pos2>,
-    pub hover_pos: Option<Pos2>,
+    pub last_hover_pos: Option<Pos2>,
     pub dnd: Option<DragDropState>,
     pub window_fade: Option<(f64, SurfaceIndex)>,
 }
@@ -17,7 +17,7 @@ impl State {
     pub(super) fn load(ctx: &Context, id: Id) -> Self {
         ctx.data_mut(|d| d.get_temp(id)).unwrap_or(Self {
             drag_start: None,
-            hover_pos: None,
+            last_hover_pos: None,
             dnd: None,
             window_fade: None,
         })


### PR DESCRIPTION
Makes the dock work on mobile devices with wasm. Closes #179 

I was not sure where to put the assignment of the `state.hover_pos`. I ended up putting it inside the `show_leaf` function.
If there is a better place, please feel free to tell me where.