### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui_dock changelog
 
+## 0.7.1 - 2023-09-18
+
+### Fixed
+
+- (Breaking) Renamed `OverlayStyle::selection_storke_width` to `OverlayStyle::selection_stroke_width`.
+
 ## 0.7.0 - 2023-09-18
 
 This is the biggest update so far, introducing the long awaited undocking feature: tabs can now be dragged out into

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking support for `egui` - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.65"
 license = "MIT"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -448,7 +448,7 @@ impl MyContext {
                 );
                 labeled_widget!(
                     ui,
-                    egui::Slider::new(&mut style.overlay.selection_storke_width, 0.0..=50.0),
+                    egui::Slider::new(&mut style.overlay.selection_stroke_width, 0.0..=50.0),
                     "Selection stroke width",
                     "width of a selection which uses a outline stroke instead of filled rect."
                 );

--- a/src/style.rs
+++ b/src/style.rs
@@ -206,7 +206,7 @@ pub struct OverlayStyle {
     pub selection_color: Color32,
 
     /// Width of stroke when a selection uses an outline instead of filled rectangle.
-    pub selection_storke_width: f32,
+    pub selection_stroke_width: f32,
 
     /// Units of padding between each button.
     pub button_spacing: f32,
@@ -390,7 +390,7 @@ impl Default for OverlayStyle {
     fn default() -> Self {
         Self {
             selection_color: Color32::from_rgb(0, 191, 255).linear_multiply(0.5),
-            selection_storke_width: 1.0,
+            selection_stroke_width: 1.0,
             button_spacing: 10.0,
             max_button_size: 100.0,
 

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -429,7 +429,7 @@ fn draw_window_rect(rect: Rect, ui: &Ui, style: &Style) {
         rect,
         0.0,
         Stroke::new(
-            style.overlay.selection_storke_width,
+            style.overlay.selection_stroke_width,
             style.overlay.selection_color,
         ),
     );


### PR DESCRIPTION
Slightly embarrassing one. :sweat_smile: 

Renamed `OverlayStyle::selection_storke_width` to `OverlayStyle::selection_stroke_width`.

I hope I'm publishing this one soon enough not to affect too many users with the breaking change.