### PR TITLE
Patch 0.7.3: Hide the 'Eject' button if a tab isn't allowed in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui_dock changelog
 
+## 0.7.3 - 2023-09-22
+
+### Fixed
+
+- The "Eject" button is not available on tabs which are disallowed in windows. ([#188](https://github.com/Adanos020/egui_dock/pull/188))
+
 ## 0.7.2 - 2023-09-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking support for `egui` - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.65"
 license = "MIT"

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -322,6 +322,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     response = response.context_menu(|ui| {
                         tab_viewer.context_menu(ui, tab, surface_index, node_index);
                         if (surface_index.is_main() || !is_lonely_tab)
+                            && tab_viewer.allowed_in_windows(tab)
                             && ui.add(eject_button).clicked()
                         {
                             self.to_detach.push((surface_index, node_index, tab_index));


### PR DESCRIPTION
Fixes #187 