### PR TITLE
Prevent division by zero when tab bar width is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+## 0.8.1 - 2023-10-04
+
+### Fixed
+- The tab bar no longer remains empty after it ends up having 0 width in any way. ([#191](https://github.com/Adanos020/egui_dock/pull/191))
+
 ## 0.8.0 - 2023-09-28
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "egui_dock"
-description = "Docking support for `egui` - an immediate-mode GUI library for Rust"
+description = "Docking system for `egui` - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT"


### PR DESCRIPTION
Fixes #190 

Basically, in `DockArea::tab_bar_scroll`, the scrolling coefficient is determined by a calculation which involves division by the available width. The problem is that when the available width is 0, the division results in infinity which is later multiplied by 0, and that produces a NaN here:

```rs
*scroll -= scroll_bar_handle_response.drag_delta().x * points_to_scroll_coefficient;
```

The `scroll` coefficient is later used all over the tab bar code, which spreads the NaN like a disease.

My fix for this is basically just turning off all tab bar code when the width is 0.

I also did a bit of clean-up: the `Response` returned from `DockArea::tab_bar` is only ever used to obtain the occupied `Rect`, so I made the function just return the `Rect` instead.