### PR TITLE
Iterators overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 - Removed the deprecated `DockState::iter`
 
 ### Deprecated
-- `DockState::iter_nodes` - use `iter_all_nodes` instead.
-- `DockState::iter_main_surface_nodes[_mut]` - use `dock_state.main_surface[_mut]().iter[_mut]()` instead.
+- `DockState::iter_nodes` – use `iter_all_nodes` instead.
+- `DockState::iter_main_surface_nodes[_mut]` – use `dock_state.main_surface().iter()` (and corresponding `mut` versions) instead.
 
 ## 0.8.1 - 2023-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 - Removed the deprecated `DockState::iter`
 
 ### Deprecated
-- `DockState::iter_main_surface_nodes` and `DockState::iter_main_surface_nodes_mut`.
+- `DockState::iter_main_surface_nodes`
+- `DockState::iter_main_surface_nodes_mut`
+- `DockState::iter_nodes`
 
 ## 0.8.1 - 2023-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## 0.9.0 - undetermined
 
+### Added
+- `DockArea::iter_surfaces[_mut]`
+- `DockArea::iter_all_tabs[_mut]`
+- `DockArea::iter_all_nodes[_mut]`
+
 ### Breaking changes
 - Removed the deprecated `DockState::iter`
 
 ### Deprecated
-- `DockState::iter_main_surface_nodes`
-- `DockState::iter_main_surface_nodes_mut`
-- `DockState::iter_nodes`
+- `DockState::iter_nodes` - use `iter_all_nodes` instead.
+- `DockState::iter_main_surface_nodes[_mut]` - use `dock_state.main_surface[_mut]().iter[_mut]()` instead.
 
 ## 0.8.1 - 2023-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## 0.9.0 - undetermined
 
 ### Added
+- `DockArea::surfaces_count`
 - `DockArea::iter_surfaces[_mut]`
 - `DockArea::iter_all_tabs[_mut]`
 - `DockArea::iter_all_nodes[_mut]`
+- `Surface::iter_nodes[_mut]`
+- `Surface::iter_all_tabs[_mut]`
 
 ### Breaking changes
 - Removed the deprecated `DockState::iter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking changes
 - Removed the deprecated `DockState::iter`
 
+### Deprecated
+- `DockState::iter_main_surface_nodes` and `DockState::iter_main_surface_nodes_mut`.
+
 ## 0.8.1 - 2023-10-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+## 0.9.0 - undetermined
+
+### Breaking changes
+- Removed the deprecated `DockState::iter`
+
 ## 0.8.1 - 2023-10-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `DockArea::iter_surfaces[_mut]`
 - `DockArea::iter_all_tabs[_mut]`
 - `DockArea::iter_all_nodes[_mut]`
+- `Node::iter_tabs[_mut]`
 - `Surface::iter_nodes[_mut]`
 - `Surface::iter_all_tabs[_mut]`
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -368,12 +368,6 @@ impl<Tab> DockState<Tab> {
         self[SurfaceIndex::main()].push_to_first_leaf(tab);
     }
 
-    /// Returns an `Iterator` of the underlying collection of nodes on the **main surface**.
-    #[deprecated = "Use `iter_main_surface_nodes` or `iter_nodes` instead"]
-    pub fn iter(&self) -> std::slice::Iter<'_, Node<Tab>> {
-        self.iter_main_surface_nodes()
-    }
-
     /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
     pub fn iter_main_surface_nodes(&self) -> std::slice::Iter<'_, Node<Tab>> {
         self[SurfaceIndex::main()].iter()

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -373,17 +373,17 @@ impl<Tab> DockState<Tab> {
         self.surfaces.len()
     }
 
-    /// Returns an `Iterator` over all surfaces.
+    /// Returns an [`Iterator`] over all surfaces.
     pub fn iter_surfaces(&self) -> impl Iterator<Item = &Surface<Tab>> {
         self.surfaces.iter()
     }
 
-    /// Returns a mutable `Iterator` over all surfaces.
+    /// Returns a mutable [`Iterator`] over all surfaces.
     pub fn iter_surfaces_mut(&mut self) -> impl Iterator<Item = &mut Surface<Tab>> {
         self.surfaces.iter_mut()
     }
 
-    /// Returns an `Iterator` of **all** underlying nodes in the dock state,
+    /// Returns an [`Iterator`] of **all** underlying nodes in the dock state,
     /// and the indices of containing surfaces.
     pub fn iter_all_nodes(&self) -> impl Iterator<Item = (SurfaceIndex, &Node<Tab>)> {
         self.iter_surfaces()
@@ -395,7 +395,7 @@ impl<Tab> DockState<Tab> {
             })
     }
 
-    /// Returns a mutable `Iterator` of **all** underlying nodes in the dock state,
+    /// Returns a mutable [`Iterator`] of **all** underlying nodes in the dock state,
     /// and the indices of containing surfaces.
     pub fn iter_all_nodes_mut(&mut self) -> impl Iterator<Item = (SurfaceIndex, &mut Node<Tab>)> {
         self.iter_surfaces_mut()
@@ -407,7 +407,7 @@ impl<Tab> DockState<Tab> {
             })
     }
 
-    /// Returns an `Iterator` of **all** tabs in the dock state,
+    /// Returns an [`Iterator`] of **all** tabs in the dock state,
     /// and the indices of containing surfaces and nodes.
     pub fn iter_all_tabs(&self) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &Tab)> {
         self.iter_surfaces()
@@ -419,7 +419,7 @@ impl<Tab> DockState<Tab> {
             })
     }
 
-    /// Returns a mutable `Iterator` of **all** tabs in the dock state,
+    /// Returns a mutable [`Iterator`] of **all** tabs in the dock state,
     /// and the indices of containing surfaces and nodes.
     pub fn iter_all_tabs_mut(
         &mut self,
@@ -433,19 +433,19 @@ impl<Tab> DockState<Tab> {
             })
     }
 
-    /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
+    /// Returns an [`Iterator`] of the underlying collection of nodes on the main surface.
     #[deprecated = "Use `dock_state.main_surface().iter()` instead"]
     pub fn iter_main_surface_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self[SurfaceIndex::main()].iter()
     }
 
-    /// Returns a mutable `Iterator` of the underlying collection of nodes on the main surface.
+    /// Returns a mutable [`Iterator`] of the underlying collection of nodes on the main surface.
     #[deprecated = "Use `dock_state.main_surface_mut().iter_mut()` instead"]
     pub fn iter_main_surface_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         self[SurfaceIndex::main()].iter_mut()
     }
 
-    /// Returns an `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
+    /// Returns an [`Iterator`] of **all** underlying nodes in the dock state and all subsequent trees.
     #[deprecated = "Use `iter_all_nodes` instead"]
     pub fn iter_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self.surfaces

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -384,11 +384,13 @@ impl<Tab> DockState<Tab> {
     }
 
     /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
+    #[deprecated("Use `dock_state.main_surface().iter()` instead")]
     pub fn iter_main_surface_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self[SurfaceIndex::main()].iter()
     }
 
     /// Returns a mutable `Iterator` of the underlying collection of nodes on the main surface.
+    #[deprecated("Use `dock_state.main_surface_mut().iter_mut()` instead")]
     pub fn iter_main_surface_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         self[SurfaceIndex::main()].iter_mut()
     }

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -369,17 +369,23 @@ impl<Tab> DockState<Tab> {
     }
 
     /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
-    pub fn iter_main_surface_nodes(&self) -> std::slice::Iter<'_, Node<Tab>> {
+    pub fn iter_main_surface_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self[SurfaceIndex::main()].iter()
     }
 
     /// Returns a mutable `Iterator` of the underlying collection of nodes on the main surface.
-    pub fn iter_main_surface_nodes_mut(&mut self) -> std::slice::IterMut<'_, Node<Tab>> {
+    pub fn iter_main_surface_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         self[SurfaceIndex::main()].iter_mut()
     }
 
     /// Returns an `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
+    #[deprecated = "Use `iter_all_nodes` instead"]
     pub fn iter_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
+        self.iter_all_nodes()
+    }
+
+    /// Returns an `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
+    pub fn iter_all_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self.surfaces
             .iter()
             .filter_map(|tree| tree.node_tree())
@@ -387,7 +393,7 @@ impl<Tab> DockState<Tab> {
     }
 
     /// Returns a mutable `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
-    pub fn iter_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
+    pub fn iter_all_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         self.surfaces
             .iter_mut()
             .filter_map(|tree| tree.node_tree_mut())

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -368,6 +368,21 @@ impl<Tab> DockState<Tab> {
         self[SurfaceIndex::main()].push_to_first_leaf(tab);
     }
 
+    /// Returns the current number of surfaces.
+    pub fn num_surfaces(&self) -> usize {
+        self.surfaces.len()
+    }
+
+    /// Returns an `Iterator` over all surfaces.
+    pub fn iter_surfaces(&self) -> impl Iterator<Item = &Surface<Tab>> {
+        self.surfaces.iter()
+    }
+
+    /// Returns a mutable `Iterator` over all surfaces.
+    pub fn iter_surfaces_mut(&mut self) -> impl Iterator<Item = &mut Surface<Tab>> {
+        self.surfaces.iter_mut()
+    }
+
     /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
     pub fn iter_main_surface_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self[SurfaceIndex::main()].iter()

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -384,13 +384,13 @@ impl<Tab> DockState<Tab> {
     }
 
     /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
-    #[deprecated("Use `dock_state.main_surface().iter()` instead")]
+    #[deprecated = "Use `dock_state.main_surface().iter()` instead"]
     pub fn iter_main_surface_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self[SurfaceIndex::main()].iter()
     }
 
     /// Returns a mutable `Iterator` of the underlying collection of nodes on the main surface.
-    #[deprecated("Use `dock_state.main_surface_mut().iter_mut()` instead")]
+    #[deprecated = "Use `dock_state.main_surface_mut().iter_mut()` instead"]
     pub fn iter_main_surface_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         self[SurfaceIndex::main()].iter_mut()
     }
@@ -404,11 +404,10 @@ impl<Tab> DockState<Tab> {
             .flat_map(|nodes| nodes.iter())
     }
 
-    /// Returns an `Iterator` of **all** underlying nodes in the dock state
+    /// Returns an `Iterator` of **all** underlying nodes in the dock state,
     /// and the indices of containing surfaces.
     pub fn iter_all_nodes(&self) -> impl Iterator<Item = (SurfaceIndex, &Node<Tab>)> {
-        self.surfaces
-            .iter()
+        self.iter_surfaces()
             .enumerate()
             .filter_map(|(index, surface)| {
                 surface
@@ -418,11 +417,10 @@ impl<Tab> DockState<Tab> {
             .flat_map(|(surface_index, tree)| tree.iter().map(move |node| (surface_index, node)))
     }
 
-    /// Returns a mutable `Iterator` of **all** underlying nodes in the dock state
+    /// Returns a mutable `Iterator` of **all** underlying nodes in the dock state,
     /// and the indices of containing surfaces.
     pub fn iter_all_nodes_mut(&mut self) -> impl Iterator<Item = (SurfaceIndex, &mut Node<Tab>)> {
-        self.surfaces
-            .iter_mut()
+        self.iter_surfaces_mut()
             .enumerate()
             .filter_map(|(index, surface)| {
                 surface
@@ -432,6 +430,32 @@ impl<Tab> DockState<Tab> {
             .flat_map(|(surface_index, tree)| {
                 tree.iter_mut().map(move |node| (surface_index, node))
             })
+    }
+
+    /// Returns an `Iterator` of **all** tabs in the dock state,
+    /// and the indices of containing surfaces and nodes.
+    pub fn iter_all_tabs(&self) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &Tab)> {
+        self.iter_all_nodes()
+            .enumerate()
+            .filter_map(|(node_index, (surface_index, node))| {
+                node.tabs()
+                    .map(move |tabs| ((surface_index, NodeIndex(node_index)), tabs))
+            })
+            .flat_map(|(indices, tabs)| tabs.iter().map(move |tab| (indices, tab)))
+    }
+
+    /// Returns an `Iterator` of **all** tabs in the dock state,
+    /// and the indices of containing surfaces and nodes.
+    pub fn iter_all_tabs_mut(
+        &mut self,
+    ) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &mut Tab)> {
+        self.iter_all_nodes_mut()
+            .enumerate()
+            .filter_map(|(node_index, (surface_index, node))| {
+                node.tabs_mut()
+                    .map(move |tabs| ((surface_index, NodeIndex(node_index)), tabs))
+            })
+            .flat_map(|(indices, tabs)| tabs.iter_mut().map(move |tab| (indices, tab)))
     }
 }
 

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -1,4 +1,4 @@
-use crate::{Tree, WindowState};
+use crate::{Node, NodeIndex, Tree, WindowState};
 
 /// A [`Surface`] is the highest level component in a [`DockState`](crate::DockState). [`Surface`]s represent an area
 /// in which nodes are placed. Typically, you're only using one surface, which is the main surface. However, if you drag
@@ -22,6 +22,15 @@ impl<Tab> Surface<Tab> {
         matches!(self, Self::Empty)
     }
 
+    /// Get access to the node tree of this surface.
+    pub fn node_tree(&self) -> Option<&Tree<Tab>> {
+        match self {
+            Surface::Empty => None,
+            Surface::Main(tree) => Some(tree),
+            Surface::Window(tree, _) => Some(tree),
+        }
+    }
+
     /// Get mutable access to the node tree of this surface.
     pub fn node_tree_mut(&mut self) -> Option<&mut Tree<Tab>> {
         match self {
@@ -31,12 +40,43 @@ impl<Tab> Surface<Tab> {
         }
     }
 
-    /// Get access to the node tree of this surface.
-    pub fn node_tree(&self) -> Option<&Tree<Tab>> {
-        match self {
-            Surface::Empty => None,
-            Surface::Main(tree) => Some(tree),
-            Surface::Window(tree, _) => Some(tree),
+    /// Returns an `Iterator` of nodes in this surface's tree.
+    pub fn iter_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
+        match self.node_tree() {
+            Some(tree) => tree.iter(),
+            None => core::slice::Iter::default(),
         }
+    }
+
+    /// Returns a mutable `Iterator` of nodes in this surface's tree.
+    pub fn iter_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
+        match self.node_tree_mut() {
+            Some(tree) => tree.iter_mut(),
+            None => core::slice::IterMut::default(),
+        }
+    }
+
+    /// Returns an `Iterator` of **all** tabs in this surface's tree,
+    /// and indices of containing nodes.
+    pub fn iter_all_tabs(&self) -> impl Iterator<Item = (NodeIndex, &Tab)> {
+        self.iter_nodes()
+            .enumerate()
+            .filter_map(|(index, node)| {
+                node.tabs()
+                    .map(|tabs| tabs.iter().map(move |tab| (NodeIndex(index), tab)))
+            })
+            .flatten()
+    }
+
+    /// Returns a mutable `Iterator` of **all** tabs in this surface's tree,
+    /// and indices of containing nodes.
+    pub fn iter_all_tabs_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut Tab)> {
+        self.iter_nodes_mut()
+            .enumerate()
+            .filter_map(|(index, node)| {
+                node.tabs_mut()
+                    .map(|tabs| tabs.iter_mut().map(move |tab| (NodeIndex(index), tab)))
+            })
+            .flatten()
     }
 }

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -40,7 +40,9 @@ impl<Tab> Surface<Tab> {
         }
     }
 
-    /// Returns an `Iterator` of nodes in this surface's tree.
+    /// Returns an [`Iterator`] of nodes in this surface's tree.
+    ///
+    /// If the surface is [`Empty`](Self::Empty), then the returned [`Iterator`] will be empty.
     pub fn iter_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         match self.node_tree() {
             Some(tree) => tree.iter(),
@@ -48,7 +50,9 @@ impl<Tab> Surface<Tab> {
         }
     }
 
-    /// Returns a mutable `Iterator` of nodes in this surface's tree.
+    /// Returns a mutable [`Iterator`] of nodes in this surface's tree.
+    ///
+    /// If the surface is [`Empty`](Self::Empty), then the returned [`Iterator`] will be empty.
     pub fn iter_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         match self.node_tree_mut() {
             Some(tree) => tree.iter_mut(),
@@ -56,27 +60,19 @@ impl<Tab> Surface<Tab> {
         }
     }
 
-    /// Returns an `Iterator` of **all** tabs in this surface's tree,
+    /// Returns an [`Iterator`] of **all** tabs in this surface's tree,
     /// and indices of containing nodes.
     pub fn iter_all_tabs(&self) -> impl Iterator<Item = (NodeIndex, &Tab)> {
         self.iter_nodes()
             .enumerate()
-            .filter_map(|(index, node)| {
-                node.tabs()
-                    .map(|tabs| tabs.iter().map(move |tab| (NodeIndex(index), tab)))
-            })
-            .flatten()
+            .flat_map(|(index, node)| node.iter_tabs().map(move |tab| (NodeIndex(index), tab)))
     }
 
-    /// Returns a mutable `Iterator` of **all** tabs in this surface's tree,
+    /// Returns a mutable [`Iterator`] of **all** tabs in this surface's tree,
     /// and indices of containing nodes.
     pub fn iter_all_tabs_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut Tab)> {
         self.iter_nodes_mut()
             .enumerate()
-            .filter_map(|(index, node)| {
-                node.tabs_mut()
-                    .map(|tabs| tabs.iter_mut().map(move |tab| (NodeIndex(index), tab)))
-            })
-            .flatten()
+            .flat_map(|(index, node)| node.iter_tabs_mut().map(move |tab| (NodeIndex(index), tab)))
     }
 }

--- a/src/dock_state/tree/node.rs
+++ b/src/dock_state/tree/node.rs
@@ -191,6 +191,28 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Returns an [`Iterator`] of tabs in this node.
+    ///
+    /// If this node is not a [`Leaf`](Self::Leaf), then the returned [`Iterator`] will be empty.
+    #[inline]
+    pub fn iter_tabs(&self) -> impl Iterator<Item = &Tab> {
+        match self.tabs() {
+            Some(tabs) => tabs.iter(),
+            None => core::slice::Iter::default(),
+        }
+    }
+
+    /// Returns a mutable [`Iterator`] of tabs in this node.
+    ///
+    /// If this node is not a [`Leaf`](Self::Leaf), then the returned [`Iterator`] will be empty.
+    #[inline]
+    pub fn iter_tabs_mut(&mut self) -> impl Iterator<Item = &mut Tab> {
+        match self.tabs_mut() {
+            Some(tabs) => tabs.iter_mut(),
+            None => core::slice::IterMut::default(),
+        }
+    }
+
     /// Adds `tab` to the node and sets it as the active tab.
     ///
     /// # Panics

--- a/src/dock_state/tree/tab_iter.rs
+++ b/src/dock_state/tree/tab_iter.rs
@@ -22,7 +22,7 @@ impl<'a, Tab> Iterator for TabIter<'a, Tab> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.tree.tree.get(self.node_idx)?.tabs() {
+            match self.tree.nodes.get(self.node_idx)?.tabs() {
                 Some(tabs) => match tabs.get(self.tab_idx) {
                     Some(tab) => {
                         self.tab_idx += 1;


### PR DESCRIPTION
Closes #192 and #194 

This adds more convenient iterators, renames some for clarity, and removes those that can be created just as easily by other means.

Full change list:

### Added
- `DockArea::surfaces_count`
- `DockArea::iter_surfaces[_mut]`
- `DockArea::iter_all_tabs[_mut]`
- `DockArea::iter_all_nodes[_mut]`
- `Node::iter_tabs[_mut]`
- `Surface::iter_nodes[_mut]`
- `Surface::iter_all_tabs[_mut]`

### Breaking changes
- Removed the deprecated `DockState::iter`

### Deprecated
- `DockState::iter_nodes` – use `iter_all_nodes` instead.
- `DockState::iter_main_surface_nodes[_mut]` – use `dock_state.main_surface().iter()` (and corresponding `mut` versions) instead.