### PR TITLE
Fix deserialization of `WindowState::screen_rect` when it contains any `f32::INFINITY` values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+## 0.8.2 - 2023-11-02
+
+### Fixed
+- Deserializing `WindowState` no longer crashes when `screen_rect` contains any `f32::INFINITY` values. Make sure to fix your last serialized app state by setting `screen_rect: null`. ([#198](https://github.com/Adanos020/egui_dock/pull/198))
+
 ## 0.8.1 - 2023-10-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_dock"
-description = "Docking system for `egui` - an immediate-mode GUI library for Rust"
+description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
 version = "0.8.2"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for `egui` - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT"

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -264,7 +264,7 @@ impl<Tab> Tree<Tab> {
     /// assert_eq!(root_node.tabs(), Some(["single tab"].as_slice()));
     /// ```
     pub fn root_node(&self) -> Option<&Node<Tab>> {
-        self.tree.get(0)
+        self.tree.first()
     }
 
     /// Acquire a mutable borrow to the [`Node`] at the root of the tree.
@@ -282,7 +282,7 @@ impl<Tab> Tree<Tab> {
     /// assert_eq!(root_node.tabs(), Some(["single tab", "partner tab"].as_slice()));
     /// ```
     pub fn root_node_mut(&mut self) -> Option<&mut Node<Tab>> {
-        self.tree.get_mut(0)
+        self.tree.first_mut()
     }
 
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -7,7 +7,7 @@ use egui::{Id, Pos2, Rect, Vec2};
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct WindowState {
     /// The [`Rect`] that this window was last taking up.
-    screen_rect: Rect,
+    screen_rect: Option<Rect>,
 
     /// Was this window dragged in the last frame?
     dragged: bool,
@@ -26,7 +26,7 @@ pub struct WindowState {
 impl Default for WindowState {
     fn default() -> Self {
         Self {
-            screen_rect: Rect::NOTHING,
+            screen_rect: None,
             dragged: false,
             next_position: None,
             next_size: None,
@@ -56,7 +56,7 @@ impl WindowState {
     /// Get the [`Rect`] which this window occupies.
     /// If this window hasn't been shown before, this will be [`Rect::NOTHING`].
     pub fn rect(&self) -> Rect {
-        self.screen_rect
+        self.screen_rect.unwrap_or(Rect::NOTHING)
     }
 
     /// Returns if this window is currently being dragged or not.

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -56,6 +56,9 @@ impl WindowState {
     /// Get the [`Rect`] which this window occupies.
     /// If this window hasn't been shown before, this will be [`Rect::NOTHING`].
     pub fn rect(&self) -> Rect {
+        // The reason why we're unwrapping an Option with a default value instead of
+        // just storing Rect::NOTHING for the None variant is that deserializing Rect::NOTHING
+        // with serde_json causes a panic, because f32::INFINITY serializes into null in JSON.
         self.screen_rect.unwrap_or(Rect::NOTHING)
     }
 


### PR DESCRIPTION
Fixes #197 

Make sure to fix your last serialized app state by setting `screen_rect: null`.