### PR TITLE
Mapping over tab types

### DIFF
--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -386,6 +386,27 @@ impl<Tab> DockState<Tab> {
             .filter_map(|tree| tree.node_tree())
             .flat_map(|nodes| nodes.iter())
     }
+
+    /// Returns a new DockState while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> DockState<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab + Clone,
+    {
+        let DockState {
+            surfaces,
+            focused_surface,
+            translations,
+        } = self;
+        let surfaces = surfaces
+            .iter()
+            .map(|surface| surface.map_tabs(function.clone()))
+            .collect();
+        DockState {
+            surfaces,
+            focused_surface: *focused_surface,
+            translations: translations.clone(),
+        }
+    }
 }
 
 impl<Tab> DockState<Tab>

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -39,7 +39,7 @@ impl<Tab> Surface<Tab> {
             Surface::Window(tree, _) => Some(tree),
         }
     }
-  
+
     /// Returns an [`Iterator`] of nodes in this surface's tree.
     ///
     /// If the surface is [`Empty`](Self::Empty), then the returned [`Iterator`] will be empty.

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -39,4 +39,18 @@ impl<Tab> Surface<Tab> {
             Surface::Window(tree, _) => Some(tree),
         }
     }
+
+    /// Returns a new Surface while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> Surface<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab + Clone,
+    {
+        match self {
+            Surface::Empty => Surface::Empty,
+            Surface::Main(tree) => Surface::Main(tree.map_tabs(function)),
+            Surface::Window(tree, window_state) => {
+                Surface::Window(tree.map_tabs(function), window_state.clone())
+            }
+        }
+    }
 }

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -737,13 +737,16 @@ impl<Tab> Tree<Tab> {
     where
         F: FnMut(&Tab) -> NewTab + Clone,
     {
-        let Tree { focused_node, tree } = self;
-        let tree = tree
+        let Tree {
+            focused_node,
+            nodes,
+        } = self;
+        let nodes = nodes
             .iter()
             .map(|node| node.map_tabs(function.clone()))
             .collect();
         Tree {
-            tree,
+            nodes,
             focused_node: *focused_node,
         }
     }

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -731,6 +731,22 @@ impl<Tab> Tree<Tab> {
         }
         tab
     }
+
+    /// Returns a new Tree while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> Tree<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab + Clone,
+    {
+        let Tree { focused_node, tree } = self;
+        let tree = tree
+            .iter()
+            .map(|node| node.map_tabs(function.clone()))
+            .collect();
+        Tree {
+            tree,
+            focused_node: *focused_node,
+        }
+    }
 }
 
 impl<Tab> Tree<Tab>

--- a/src/dock_state/tree/node.rs
+++ b/src/dock_state/tree/node.rs
@@ -266,4 +266,35 @@ impl<Tab> Node<Tab> {
             _ => Default::default(),
         }
     }
+
+    /// Returns a new Node while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> Node<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab,
+    {
+        match self {
+            Node::Leaf {
+                rect,
+                viewport,
+                tabs,
+                active,
+                scroll,
+            } => Node::Leaf {
+                rect: *rect,
+                viewport: *viewport,
+                tabs: tabs.iter().map(function).collect(),
+                active: *active,
+                scroll: *scroll,
+            },
+            Node::Empty => Node::Empty,
+            Node::Vertical { rect, fraction } => Node::Vertical {
+                rect: *rect,
+                fraction: *fraction,
+            },
+            Node::Horizontal { rect, fraction } => Node::Horizontal {
+                rect: *rect,
+                fraction: *fraction,
+            },
+        }
+    }
 }


### PR DESCRIPTION
This PR implements a `map` function for all types containing tabs.
The concept is similar to the map function in `Iterator`s, `Result`s, `Option`s, etc, taking a closure which receives a value and returns a new one, possibly of a different type.

### Usage example

Since serde deserialization does not allow partial deserialization or passing additional values, this feature can be used to construct the tab types from intermediate deserialized values while mixing in things like shared pointers.

```rs
let some_non_deserializable_value = Arc::new(..);

let tree: Tree<serde_json::Value> = from_str(..).unwrap();
let tree = tree.map_tabs(|value| {
    ActualTabType::new(some_non_deserializable_value.clone(), value).unwrap()
});
```

Also see https://github.com/Adanos020/egui_dock/pull/196#issuecomment-1786986562