### PR TITLE
Release 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - `Surface::iter_all_tabs[_mut]`
 
 ### Breaking changes
-- Removed the deprecated `DockState::iter`
+- Upgraded to egui 0.24.
+- Removed the deprecated `DockState::iter`.
 
 ### Deprecated
 - `DockState::iter_nodes` – use `iter_all_nodes` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # egui_dock changelog
 
+## 0.9.0 - undetermined
+
+### Added
+- `DockArea::surfaces_count`
+- `DockArea::iter_surfaces[_mut]`
+- `DockArea::iter_all_tabs[_mut]`
+- `DockArea::iter_all_nodes[_mut]`
+- `Node::iter_tabs[_mut]`
+- `Surface::iter_nodes[_mut]`
+- `Surface::iter_all_tabs[_mut]`
+
+### Breaking changes
+- Removed the deprecated `DockState::iter`
+
+### Deprecated
+- `DockState::iter_nodes` – use `iter_all_nodes` instead.
+- `DockState::iter_main_surface_nodes[_mut]` – use `dock_state.main_surface().iter()` (and corresponding `mut` versions) instead.
+
 ## 0.8.2 - 2023-11-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # egui_dock changelog
 
-## 0.9.0 - undetermined
+## 0.9.0 - 2023-11-23
 
 ### Added
 - `DockArea::surfaces_count`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.72"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/Adanos020/egui_dock"
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.23", default-features = false }
+egui = { version = "0.24", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "1.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.23", default-features = false, features = [
+eframe = { version = "0.24", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# `egui_dock`: docking support for [egui](https://github.com/emilk/egui)
+# `egui_dock`: docking system for [egui](https://github.com/emilk/egui)
 
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
 [![Crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.23-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.24-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
@@ -32,7 +32,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.23"
+egui = "0.24"
 egui_dock = "0.9"
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
 [![egui_version](https://img.shields.io/badge/egui-0.23-blue)](https://github.com/emilk/egui)
 
-Originally created by [@lain-dono](https://github.com/lain-dono), this library provides docking support for `egui`.
+Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
 ## Contributing
 
@@ -33,7 +33,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 ```toml
 [dependencies]
 egui = "0.23"
-egui_dock = "0.8"
+egui_dock = "0.9"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,8 @@ use std::collections::HashSet;
 use eframe::{egui, NativeOptions};
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    CentralPanel, ComboBox, Frame, Rounding, Slider, TopBottomPanel, Ui, WidgetText,
+    vec2, CentralPanel, ComboBox, Frame, Rounding, Slider, TopBottomPanel, Ui, ViewportBuilder,
+    WidgetText,
 };
 
 use egui_dock::{
@@ -52,7 +53,7 @@ macro_rules! unit_slider {
 fn main() -> eframe::Result<()> {
     std::env::set_var("RUST_BACKTRACE", "1");
     let options = NativeOptions {
-        initial_window_size: Some(egui::vec2(1024.0, 1024.0)),
+        viewport: ViewportBuilder::default().with_inner_size(vec2(1024.0, 1024.0)),
         ..Default::default()
     };
     eframe::run_native(

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -453,6 +453,27 @@ impl<Tab> DockState<Tab> {
             .filter_map(|surface| surface.node_tree())
             .flat_map(|nodes| nodes.iter())
     }
+
+    /// Returns a new DockState while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> DockState<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab + Clone,
+    {
+        let DockState {
+            surfaces,
+            focused_surface,
+            translations,
+        } = self;
+        let surfaces = surfaces
+            .iter()
+            .map(|surface| surface.map_tabs(function.clone()))
+            .collect();
+        DockState {
+            surfaces,
+            focused_surface: *focused_surface,
+            translations: translations.clone(),
+        }
+    }
 }
 
 impl<Tab> DockState<Tab>

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -77,14 +77,14 @@ impl<Tab> DockState<Tab> {
         self
     }
 
-    /// Get a mutable borrow to the tree at the main surface.
-    pub fn main_surface_mut(&mut self) -> &mut Tree<Tab> {
-        &mut self[SurfaceIndex::main()]
-    }
-
     /// Get an immutable borrow to the tree at the main surface.
     pub fn main_surface(&self) -> &Tree<Tab> {
         &self[SurfaceIndex::main()]
+    }
+
+    /// Get a mutable borrow to the tree at the main surface.
+    pub fn main_surface_mut(&mut self) -> &mut Tree<Tab> {
+        &mut self[SurfaceIndex::main()]
     }
 
     /// Get the [`WindowState`] which corresponds to a [`SurfaceIndex`].
@@ -186,7 +186,7 @@ impl<Tab> DockState<Tab> {
         &mut self,
         (surface_index, node_index, tab_index): (SurfaceIndex, NodeIndex, TabIndex),
     ) {
-        if let Some(Node::Leaf { active, .. }) = self[surface_index].tree.get_mut(node_index.0) {
+        if let Some(Node::Leaf { active, .. }) = self[surface_index].nodes.get_mut(node_index.0) {
             *active = tab_index;
         }
     }
@@ -368,36 +368,90 @@ impl<Tab> DockState<Tab> {
         self[SurfaceIndex::main()].push_to_first_leaf(tab);
     }
 
-    /// Returns an `Iterator` of the underlying collection of nodes on the **main surface**.
-    #[deprecated = "Use `iter_main_surface_nodes` or `iter_nodes` instead"]
-    pub fn iter(&self) -> std::slice::Iter<'_, Node<Tab>> {
-        self.iter_main_surface_nodes()
+    /// Returns the current number of surfaces.
+    pub fn surfaces_count(&self) -> usize {
+        self.surfaces.len()
     }
 
-    /// Returns an `Iterator` of the underlying collection of nodes on the main surface.
-    pub fn iter_main_surface_nodes(&self) -> std::slice::Iter<'_, Node<Tab>> {
+    /// Returns an [`Iterator`] over all surfaces.
+    pub fn iter_surfaces(&self) -> impl Iterator<Item = &Surface<Tab>> {
+        self.surfaces.iter()
+    }
+
+    /// Returns a mutable [`Iterator`] over all surfaces.
+    pub fn iter_surfaces_mut(&mut self) -> impl Iterator<Item = &mut Surface<Tab>> {
+        self.surfaces.iter_mut()
+    }
+
+    /// Returns an [`Iterator`] of **all** underlying nodes in the dock state,
+    /// and the indices of containing surfaces.
+    pub fn iter_all_nodes(&self) -> impl Iterator<Item = (SurfaceIndex, &Node<Tab>)> {
+        self.iter_surfaces()
+            .enumerate()
+            .flat_map(|(surface_index, surface)| {
+                surface
+                    .iter_nodes()
+                    .map(move |node| (SurfaceIndex(surface_index), node))
+            })
+    }
+
+    /// Returns a mutable [`Iterator`] of **all** underlying nodes in the dock state,
+    /// and the indices of containing surfaces.
+    pub fn iter_all_nodes_mut(&mut self) -> impl Iterator<Item = (SurfaceIndex, &mut Node<Tab>)> {
+        self.iter_surfaces_mut()
+            .enumerate()
+            .flat_map(|(surface_index, surface)| {
+                surface
+                    .iter_nodes_mut()
+                    .map(move |node| (SurfaceIndex(surface_index), node))
+            })
+    }
+
+    /// Returns an [`Iterator`] of **all** tabs in the dock state,
+    /// and the indices of containing surfaces and nodes.
+    pub fn iter_all_tabs(&self) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &Tab)> {
+        self.iter_surfaces()
+            .enumerate()
+            .flat_map(|(surface_index, surface)| {
+                surface
+                    .iter_all_tabs()
+                    .map(move |(node_index, tab)| ((SurfaceIndex(surface_index), node_index), tab))
+            })
+    }
+
+    /// Returns a mutable [`Iterator`] of **all** tabs in the dock state,
+    /// and the indices of containing surfaces and nodes.
+    pub fn iter_all_tabs_mut(
+        &mut self,
+    ) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &mut Tab)> {
+        self.iter_surfaces_mut()
+            .enumerate()
+            .flat_map(|(surface_index, surface)| {
+                surface
+                    .iter_all_tabs_mut()
+                    .map(move |(node_index, tab)| ((SurfaceIndex(surface_index), node_index), tab))
+            })
+    }
+
+    /// Returns an [`Iterator`] of the underlying collection of nodes on the main surface.
+    #[deprecated = "Use `dock_state.main_surface().iter()` instead"]
+    pub fn iter_main_surface_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self[SurfaceIndex::main()].iter()
     }
 
-    /// Returns a mutable `Iterator` of the underlying collection of nodes on the main surface.
-    pub fn iter_main_surface_nodes_mut(&mut self) -> std::slice::IterMut<'_, Node<Tab>> {
+    /// Returns a mutable [`Iterator`] of the underlying collection of nodes on the main surface.
+    #[deprecated = "Use `dock_state.main_surface_mut().iter_mut()` instead"]
+    pub fn iter_main_surface_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
         self[SurfaceIndex::main()].iter_mut()
     }
 
-    /// Returns an `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
+    /// Returns an [`Iterator`] of **all** underlying nodes in the dock state and all subsequent trees.
+    #[deprecated = "Use `iter_all_nodes` instead"]
     pub fn iter_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self.surfaces
             .iter()
-            .filter_map(|tree| tree.node_tree())
+            .filter_map(|surface| surface.node_tree())
             .flat_map(|nodes| nodes.iter())
-    }
-
-    /// Returns a mutable `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
-    pub fn iter_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
-        self.surfaces
-            .iter_mut()
-            .filter_map(|tree| tree.node_tree_mut())
-            .flat_map(|nodes| nodes.iter_mut())
     }
 }
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -379,12 +379,25 @@ impl<Tab> DockState<Tab> {
         self[SurfaceIndex::main()].iter()
     }
 
+    /// Returns a mutable `Iterator` of the underlying collection of nodes on the main surface.
+    pub fn iter_main_surface_nodes_mut(&mut self) -> std::slice::IterMut<'_, Node<Tab>> {
+        self[SurfaceIndex::main()].iter_mut()
+    }
+
     /// Returns an `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
     pub fn iter_nodes(&self) -> impl Iterator<Item = &Node<Tab>> {
         self.surfaces
             .iter()
             .filter_map(|tree| tree.node_tree())
             .flat_map(|nodes| nodes.iter())
+    }
+
+    /// Returns a mutable `Iterator` of **all** underlying nodes in the dock state and all subsequent trees.
+    pub fn iter_nodes_mut(&mut self) -> impl Iterator<Item = &mut Node<Tab>> {
+        self.surfaces
+            .iter_mut()
+            .filter_map(|tree| tree.node_tree_mut())
+            .flat_map(|nodes| nodes.iter_mut())
     }
 }
 

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -75,4 +75,18 @@ impl<Tab> Surface<Tab> {
             .enumerate()
             .flat_map(|(index, node)| node.iter_tabs_mut().map(move |tab| (NodeIndex(index), tab)))
     }
+
+    /// Returns a new Surface while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> Surface<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab + Clone,
+    {
+        match self {
+            Surface::Empty => Surface::Empty,
+            Surface::Main(tree) => Surface::Main(tree.map_tabs(function)),
+            Surface::Window(tree, window_state) => {
+                Surface::Window(tree.map_tabs(function), window_state.clone())
+            }
+        }
+    }
 }

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -122,7 +122,7 @@ impl TabDestination {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tree<Tab> {
     // Binary tree vector
-    pub(super) tree: Vec<Node<Tab>>,
+    pub(super) nodes: Vec<Node<Tab>>,
     focused_node: Option<NodeIndex>,
 }
 
@@ -135,7 +135,7 @@ impl<Tab> fmt::Debug for Tree<Tab> {
 impl<Tab> Default for Tree<Tab> {
     fn default() -> Self {
         Self {
-            tree: Vec::new(),
+            nodes: Vec::new(),
             focused_node: None,
         }
     }
@@ -146,14 +146,14 @@ impl<Tab> Index<NodeIndex> for Tree<Tab> {
 
     #[inline(always)]
     fn index(&self, index: NodeIndex) -> &Self::Output {
-        &self.tree[index.0]
+        &self.nodes[index.0]
     }
 }
 
 impl<Tab> IndexMut<NodeIndex> for Tree<Tab> {
     #[inline(always)]
     fn index_mut(&mut self, index: NodeIndex) -> &mut Self::Output {
-        &mut self.tree[index.0]
+        &mut self.nodes[index.0]
     }
 }
 
@@ -163,7 +163,7 @@ impl<Tab> Tree<Tab> {
     pub fn new(tabs: Vec<Tab>) -> Self {
         let root = Node::leaf_with(tabs);
         Self {
-            tree: vec![root],
+            nodes: vec![root],
             focused_node: None,
         }
     }
@@ -172,7 +172,7 @@ impl<Tab> Tree<Tab> {
     /// or `None` if no leaf exists in the [`Tree`].
     #[inline]
     pub fn find_active(&mut self) -> Option<(Rect, &mut Tab)> {
-        self.tree.iter_mut().find_map(|node| match node {
+        self.nodes.iter_mut().find_map(|node| match node {
             Node::Leaf {
                 tabs,
                 active,
@@ -188,13 +188,13 @@ impl<Tab> Tree<Tab> {
     /// This includes [`Empty`](Node::Empty) nodes.
     #[inline(always)]
     pub fn len(&self) -> usize {
-        self.tree.len()
+        self.nodes.len()
     }
 
     /// Returns `true` if the number of nodes in the tree is 0, otherwise `false`.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.tree.is_empty()
+        self.nodes.is_empty()
     }
 
     /// Returns an [`Iterator`] of the underlying collection of nodes.
@@ -202,7 +202,7 @@ impl<Tab> Tree<Tab> {
     /// This includes [`Empty`](Node::Empty) nodes.
     #[inline(always)]
     pub fn iter(&self) -> Iter<'_, Node<Tab>> {
-        self.tree.iter()
+        self.nodes.iter()
     }
 
     /// Returns [`IterMut`] of the underlying collection of nodes.
@@ -210,13 +210,13 @@ impl<Tab> Tree<Tab> {
     /// This includes [`Empty`](Node::Empty) nodes.
     #[inline(always)]
     pub fn iter_mut(&mut self) -> IterMut<'_, Node<Tab>> {
-        self.tree.iter_mut()
+        self.nodes.iter_mut()
     }
 
     /// Returns an [`Iterator`] of [`NodeIndex`] ordered in a breadth first manner.
     #[inline(always)]
     pub(crate) fn breadth_first_index_iter(&self) -> impl Iterator<Item = NodeIndex> {
-        (0..self.tree.len()).map(NodeIndex)
+        (0..self.nodes.len()).map(NodeIndex)
     }
 
     /// Returns an iterator over all tabs in arbitrary order.
@@ -243,7 +243,7 @@ impl<Tab> Tree<Tab> {
     #[inline]
     pub fn num_tabs(&self) -> usize {
         let mut count = 0;
-        for node in self.tree.iter() {
+        for node in self.nodes.iter() {
             if let Node::Leaf { tabs, .. } = node {
                 count += tabs.len();
             }
@@ -264,7 +264,7 @@ impl<Tab> Tree<Tab> {
     /// assert_eq!(root_node.tabs(), Some(["single tab"].as_slice()));
     /// ```
     pub fn root_node(&self) -> Option<&Node<Tab>> {
-        self.tree.first()
+        self.nodes.first()
     }
 
     /// Acquire a mutable borrow to the [`Node`] at the root of the tree.
@@ -282,7 +282,7 @@ impl<Tab> Tree<Tab> {
     /// assert_eq!(root_node.tabs(), Some(["single tab", "partner tab"].as_slice()));
     /// ```
     pub fn root_node_mut(&mut self) -> Option<&mut Node<Tab>> {
-        self.tree.first_mut()
+        self.nodes.first_mut()
     }
 
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node
@@ -476,9 +476,9 @@ impl<Tab> Tree<Tab> {
         assert_ne!(new.tabs_count(), 0);
         // Resize vector to fit the new size of the binary tree.
         {
-            let index = self.tree.iter().rposition(|n| !n.is_empty()).unwrap_or(0);
+            let index = self.nodes.iter().rposition(|n| !n.is_empty()).unwrap_or(0);
             let level = NodeIndex(index).level();
-            self.tree
+            self.nodes
                 .resize_with((1 << (level + 1)) - 1, || Node::Empty);
         }
 
@@ -489,7 +489,7 @@ impl<Tab> Tree<Tab> {
 
         // If the node were splitting is a parent, all it's children need to be moved.
         if old.is_parent() {
-            let levels_to_move = NodeIndex(self.tree.len()).level() - index[0].level();
+            let levels_to_move = NodeIndex(self.nodes.len()).level() - index[0].level();
 
             // Level 0 is ourself, which is done when we assign self[index[0]] = old, so start at 1.
             for level in (1..levels_to_move).rev() {
@@ -504,7 +504,7 @@ impl<Tab> Tree<Tab> {
                 // Swap self[old_start..(old_start+len)] with self[new_start..(new_start+len)]
                 // (the new part will only contain empty entries).
                 let (old_range, new_range) = {
-                    let (first_part, second_part) = self.tree.split_at_mut(new_start);
+                    let (first_part, second_part) = self.nodes.split_at_mut(new_start);
                     // Cut to length.
                     (
                         &mut first_part[old_start..old_start + len],
@@ -526,7 +526,7 @@ impl<Tab> Tree<Tab> {
     fn first_leaf(&self, top: NodeIndex) -> Option<NodeIndex> {
         let left = top.left();
         let right = top.right();
-        match (self.tree.get(left.0), self.tree.get(right.0)) {
+        match (self.nodes.get(left.0), self.nodes.get(right.0)) {
             (Some(&Node::Leaf { .. }), _) => Some(left),
             (_, Some(&Node::Leaf { .. })) => Some(right),
 
@@ -547,7 +547,7 @@ impl<Tab> Tree<Tab> {
     /// Returns the viewport [`Rect`] and the `Tab` inside the focused leaf node or [`None`] if it does not exist.
     #[inline]
     pub fn find_active_focused(&mut self) -> Option<(Rect, &mut Tab)> {
-        match self.focused_node.and_then(|idx| self.tree.get_mut(idx.0)) {
+        match self.focused_node.and_then(|idx| self.nodes.get_mut(idx.0)) {
             Some(Node::Leaf {
                 tabs,
                 active,
@@ -570,7 +570,7 @@ impl<Tab> Tree<Tab> {
     #[inline]
     pub fn set_focused_node(&mut self, node_index: NodeIndex) {
         self.focused_node = self
-            .tree
+            .nodes
             .get(node_index.0)
             .filter(|node| node.is_leaf())
             .map(|_| node_index);
@@ -585,7 +585,7 @@ impl<Tab> Tree<Tab> {
         assert!(self[node].is_leaf());
 
         let Some(parent) = node.parent() else {
-            self.tree.clear();
+            self.nodes.clear();
             return;
         };
 
@@ -598,7 +598,7 @@ impl<Tab> Tree<Tab> {
                 } else {
                     parent.left()
                 };
-                if self.tree.get(next.0).is_some_and(|node| node.is_leaf()) {
+                if self.nodes.get(next.0).is_some_and(|node| node.is_leaf()) {
                     self.focused_node = Some(next);
                     break;
                 }
@@ -620,13 +620,13 @@ impl<Tab> Tree<Tab> {
                 let dst = parent.children_at(level);
                 let src = parent.children_right(level + 1);
                 for (dst, src) in dst.zip(src) {
-                    if src >= self.tree.len() {
+                    if src >= self.nodes.len() {
                         break 'left_end;
                     }
                     if Some(NodeIndex(src)) == self.focused_node {
                         self.focused_node = Some(NodeIndex(dst));
                     }
-                    self.tree[dst] = std::mem::replace(&mut self.tree[src], Node::Empty);
+                    self.nodes[dst] = std::mem::replace(&mut self.nodes[src], Node::Empty);
                 }
                 level += 1;
             }
@@ -635,13 +635,13 @@ impl<Tab> Tree<Tab> {
                 let dst = parent.children_at(level);
                 let src = parent.children_left(level + 1);
                 for (dst, src) in dst.zip(src) {
-                    if src >= self.tree.len() {
+                    if src >= self.nodes.len() {
                         break 'right_end;
                     }
                     if Some(NodeIndex(src)) == self.focused_node {
                         self.focused_node = Some(NodeIndex(dst));
                     }
-                    self.tree[dst] = std::mem::replace(&mut self.tree[src], Node::Empty);
+                    self.nodes[dst] = std::mem::replace(&mut self.nodes[src], Node::Empty);
                 }
                 level += 1;
             }
@@ -650,7 +650,7 @@ impl<Tab> Tree<Tab> {
 
     /// Pushes a tab to the first `Leaf` it finds or create a new leaf if an `Empty` node is encountered.
     pub fn push_to_first_leaf(&mut self, tab: Tab) {
-        for (index, node) in &mut self.tree.iter_mut().enumerate() {
+        for (index, node) in &mut self.nodes.iter_mut().enumerate() {
             match node {
                 Node::Leaf { tabs, active, .. } => {
                     *active = TabIndex(tabs.len());
@@ -666,15 +666,15 @@ impl<Tab> Tree<Tab> {
                 _ => {}
             }
         }
-        assert!(self.tree.is_empty());
-        self.tree.push(Node::leaf_with(vec![tab]));
+        assert!(self.nodes.is_empty());
+        self.nodes.push(Node::leaf_with(vec![tab]));
         self.focused_node = Some(NodeIndex(0));
     }
 
     /// Sets which is the active tab within a specific node.
     #[inline]
     pub fn set_active_tab(&mut self, node_index: NodeIndex, tab_index: TabIndex) {
-        if let Some(Node::Leaf { active, .. }) = self.tree.get_mut(node_index.0) {
+        if let Some(Node::Leaf { active, .. }) = self.nodes.get_mut(node_index.0) {
             *active = tab_index;
         }
     }
@@ -687,8 +687,8 @@ impl<Tab> Tree<Tab> {
     pub fn push_to_focused_leaf(&mut self, tab: Tab) {
         match self.focused_node {
             Some(node) => {
-                if self.tree.is_empty() {
-                    self.tree.push(Node::leaf(tab));
+                if self.nodes.is_empty() {
+                    self.nodes.push(Node::leaf(tab));
                     self.focused_node = Some(NodeIndex::root());
                 } else {
                     match &mut self[node] {
@@ -708,8 +708,8 @@ impl<Tab> Tree<Tab> {
                 }
             }
             None => {
-                if self.tree.is_empty() {
-                    self.tree.push(Node::leaf(tab));
+                if self.nodes.is_empty() {
+                    self.nodes.push(Node::leaf(tab));
                     self.focused_node = Some(NodeIndex::root());
                 } else {
                     self.push_to_first_leaf(tab);
@@ -745,7 +745,7 @@ where
     ///
     /// In case there are several hits, only the first is returned.
     pub fn find_tab(&self, needle_tab: &Tab) -> Option<(NodeIndex, TabIndex)> {
-        for (node_index, node) in self.tree.iter().enumerate() {
+        for (node_index, node) in self.nodes.iter().enumerate() {
             if let Some(tabs) = node.tabs() {
                 for (tab_index, tab) in tabs.iter().enumerate() {
                     if tab == needle_tab {

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -731,6 +731,25 @@ impl<Tab> Tree<Tab> {
         }
         tab
     }
+
+    /// Returns a new Tree while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> Tree<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab + Clone,
+    {
+        let Tree {
+            focused_node,
+            nodes,
+        } = self;
+        let nodes = nodes
+            .iter()
+            .map(|node| node.map_tabs(function.clone()))
+            .collect();
+        Tree {
+            nodes,
+            focused_node: *focused_node,
+        }
+    }
 }
 
 impl<Tab> Tree<Tab>

--- a/src/dock_state/tree/node.rs
+++ b/src/dock_state/tree/node.rs
@@ -288,4 +288,35 @@ impl<Tab> Node<Tab> {
             _ => Default::default(),
         }
     }
+
+    /// Returns a new Node while mapping the tab type
+    pub fn map_tabs<F, NewTab>(&self, function: F) -> Node<NewTab>
+    where
+        F: FnMut(&Tab) -> NewTab,
+    {
+        match self {
+            Node::Leaf {
+                rect,
+                viewport,
+                tabs,
+                active,
+                scroll,
+            } => Node::Leaf {
+                rect: *rect,
+                viewport: *viewport,
+                tabs: tabs.iter().map(function).collect(),
+                active: *active,
+                scroll: *scroll,
+            },
+            Node::Empty => Node::Empty,
+            Node::Vertical { rect, fraction } => Node::Vertical {
+                rect: *rect,
+                fraction: *fraction,
+            },
+            Node::Horizontal { rect, fraction } => Node::Horizontal {
+                rect: *rect,
+                fraction: *fraction,
+            },
+        }
+    }
 }

--- a/src/dock_state/tree/node.rs
+++ b/src/dock_state/tree/node.rs
@@ -191,6 +191,28 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Returns an [`Iterator`] of tabs in this node.
+    ///
+    /// If this node is not a [`Leaf`](Self::Leaf), then the returned [`Iterator`] will be empty.
+    #[inline]
+    pub fn iter_tabs(&self) -> impl Iterator<Item = &Tab> {
+        match self.tabs() {
+            Some(tabs) => tabs.iter(),
+            None => core::slice::Iter::default(),
+        }
+    }
+
+    /// Returns a mutable [`Iterator`] of tabs in this node.
+    ///
+    /// If this node is not a [`Leaf`](Self::Leaf), then the returned [`Iterator`] will be empty.
+    #[inline]
+    pub fn iter_tabs_mut(&mut self) -> impl Iterator<Item = &mut Tab> {
+        match self.tabs_mut() {
+            Some(tabs) => tabs.iter_mut(),
+            None => core::slice::IterMut::default(),
+        }
+    }
+
     /// Adds `tab` to the node and sets it as the active tab.
     ///
     /// # Panics

--- a/src/dock_state/tree/tab_iter.rs
+++ b/src/dock_state/tree/tab_iter.rs
@@ -22,7 +22,7 @@ impl<'a, Tab> Iterator for TabIter<'a, Tab> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.tree.tree.get(self.node_idx)?.tabs() {
+            match self.tree.nodes.get(self.node_idx)?.tabs() {
                 Some(tabs) => match tabs.get(self.tab_idx) {
                     Some(tab) => {
                         self.tab_idx += 1;

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -82,7 +82,7 @@ impl WindowState {
         let new = self.new;
         let mut window_constructor = egui::Window::new("")
             .id(id)
-            .constraint_to(bounds)
+            .constrain_to(bounds)
             .title_bar(false);
 
         if let Some(position) = self.next_position() {


### PR DESCRIPTION
### Added
- `DockArea::surfaces_count`
- `DockArea::iter_surfaces[_mut]`
- `DockArea::iter_all_tabs[_mut]`
- `DockArea::iter_all_nodes[_mut]`
- `Node::iter_tabs[_mut]`
- `Surface::iter_nodes[_mut]`
- `Surface::iter_all_tabs[_mut]`

### Breaking changes
- Upgraded to egui 0.24.
- Removed the deprecated `DockState::iter`.

### Deprecated
- `DockState::iter_nodes` – use `iter_all_nodes` instead.
- `DockState::iter_main_surface_nodes[_mut]` – use `dock_state.main_surface().iter()` (and corresponding `mut` versions) instead.