### PR TITLE
Multi-viewport support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*.rs", "Cargo.toml", "LICENSE"]
 
 [features]
 default = []
+multi-viewport = []
 
 # Enable serialization of `Tree`.
 serde = ["dep:serde", "egui/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.72"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*.rs", "Cargo.toml", "LICENSE"]
 
 [features]
 default = []
-multi-viewport = []
+viewports = []
 
 # Enable serialization of `Tree`.
 serde = ["dep:serde", "egui/serde"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 ```toml
 [dependencies]
 egui = "0.24"
-egui_dock = "0.9"
+egui_dock = "0.10"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -1,9 +1,9 @@
 use egui::{Id, Pos2, Rect, Vec2};
 
-#[cfg(feature = "multi-viewport")]
+#[cfg(feature = "viewports")]
 use egui::ViewportBuilder;
 
-#[cfg(not(feature = "multi-viewport"))]
+#[cfg(not(feature = "viewports"))]
 use egui::Window;
 
 /// The state of a [`Surface::Window`](crate::Surface::Window).

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -1,5 +1,11 @@
 use egui::{Id, Pos2, Rect, Vec2};
 
+#[cfg(feature = "multi-viewport")]
+use egui::ViewportBuilder;
+
+#[cfg(not(feature = "multi-viewport"))]
+use egui::Window;
+
 /// The state of a [`Surface::Window`](crate::Surface::Window).
 ///
 /// Doubles as a handle for the surface, allowing the user to set its size and position.
@@ -77,13 +83,30 @@ impl WindowState {
         self.next_size.take()
     }
 
-    //the 'static in this case means that the `open` field is always `None`
-    pub(crate) fn create_window(&mut self, id: Id, bounds: Rect) -> (egui::Window<'static>, bool) {
+    #[cfg(feature = "multi-viewport")]
+    pub(crate) fn create_window(&mut self, id: Id, bounds: Rect) -> (ViewportBuilder, bool) {
         let new = self.new;
-        let mut window_constructor = egui::Window::new("")
-            .id(id)
-            .constrain_to(bounds)
-            .title_bar(false);
+        let mut viewport_builder = ViewportBuilder::default()
+            .with_decorations(false)
+            .with_resizable(true)
+            .with_drag_and_drop(true);
+
+        if let Some(position) = self.next_position() {
+            viewport_builder = viewport_builder.with_position(position);
+        }
+        if let Some(size) = self.next_size() {
+            viewport_builder = viewport_builder.with_inner_size(size);
+        }
+
+        self.new = false;
+        (viewport_builder, new)
+    }
+
+    // The 'static in this case means that the `open` field is always `None`
+    #[cfg(not(feature = "multi-viewport"))]
+    pub(crate) fn create_window(&mut self, id: Id, bounds: Rect) -> (Window<'static>, bool) {
+        let new = self.new;
+        let mut window_constructor = Window::new("").id(id).constrain_to(bounds).title_bar(false);
 
         if let Some(position) = self.next_position() {
             window_constructor = window_constructor.current_pos(position);

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -83,7 +83,7 @@ impl WindowState {
         self.next_size.take()
     }
 
-    #[cfg(feature = "multi-viewport")]
+    #[cfg(feature = "viewports")]
     pub(crate) fn create_window(&mut self, id: Id, bounds: Rect) -> (ViewportBuilder, bool) {
         let new = self.new;
         let mut viewport_builder = ViewportBuilder::default()
@@ -103,7 +103,7 @@ impl WindowState {
     }
 
     // The 'static in this case means that the `open` field is always `None`
-    #[cfg(not(feature = "multi-viewport"))]
+    #[cfg(not(feature = "viewports"))]
     pub(crate) fn create_window(&mut self, id: Id, bounds: Rect) -> (Window<'static>, bool) {
         let new = self.new;
         let mut window_constructor = Window::new("").id(id).constrain_to(bounds).title_bar(false);

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -10,9 +10,7 @@ use egui::{
 use egui::{CentralPanel, ViewportId};
 
 use crate::{
-    dock_area::{state::State, tab_removal::TabRemoval},
-    utils::fade_visuals,
-    DockArea, Node, Style, SurfaceIndex, TabViewer,
+    dock_area::state::State, utils::fade_visuals, DockArea, Node, Style, SurfaceIndex, TabViewer,
 };
 
 impl<'tree, Tab> DockArea<'tree, Tab> {
@@ -95,7 +93,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         #[cfg(feature = "viewports")]
         {
             let window = window
-                .with_close_button(self.show_window_close_buttons && disabled.is_none())
+                .with_close_button(self.show_window_close_buttons && disabled)
                 .with_title(title.text());
             ui.ctx().show_viewport_immediate(
                 ViewportId::from_hash_of(id),

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -2,9 +2,12 @@ use std::convert::identity;
 use std::sync::Arc;
 
 use egui::{
-    CentralPanel, CollapsingHeader, CollapsingResponse, Frame, Galley, Id, Layout, Rect, Response,
-    Sense, TextStyle, Ui, Vec2, ViewportId, Widget,
+    CollapsingHeader, CollapsingResponse, Frame, Galley, Id, Layout, Rect, Response, Sense,
+    TextStyle, Ui, Vec2, Widget,
 };
+
+#[cfg(feature = "viewports")]
+use egui::{CentralPanel, ViewportId};
 
 use crate::{
     dock_area::{state::State, tab_removal::TabRemoval},
@@ -25,7 +28,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let id = format!("window {surf_index:?}").into();
         let bounds = self.window_bounds.unwrap();
         let mut open = true;
-        let (mut window, new) = self
+        let (window, new) = self
             .dock_state
             .get_window_state_mut(surf_index)
             .unwrap()
@@ -91,9 +94,9 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             frame.shadow.color = frame.shadow.color.linear_multiply(fade_factor);
         }
 
-        #[cfg(feature = "multi-viewport")]
+        #[cfg(feature = "viewports")]
         {
-            window = window
+            let window = window
                 .with_close_button(self.show_window_close_buttons && disabled.is_none())
                 .with_title(title.text());
             ui.ctx().show_viewport_immediate(
@@ -124,7 +127,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 },
             )
         }
-        #[cfg(not(feature = "multi-viewport"))]
+        #[cfg(not(feature = "viewports"))]
         {
             window
                 .frame(frame)


### PR DESCRIPTION
Should close #202 

I hacked together a quick proof of concept implementation which lets you pull out a tab into a new window.

It is by no means complete, as there a few of issues that need addressing.
Below is a list of subtasks that should bring this feature to completion.

- [x] Opening new native windows for undocked tabs.
- [ ] Use deferred viewports for better performance in the general use case.
- [ ] Drag & drop between windows (currently we cannot dock a second tab into an existing window).
- [ ] Dropping a window outside of the main viewport.
- [ ] Minimizing and maximizing windows.
- [ ] For tiling window managers: make windows floating by default.
- [ ] Configurability.

This will be gated behind a cargo feature `viewports`, as some backends (e.g., web) don't support multiple viewports.