### PR TITLE
Fix crash after calling `DockState::remove_tab`.

### DIFF
--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -297,7 +297,11 @@ impl<Tab> DockState<Tab> {
         &mut self,
         (surface_index, node_index, tab_index): (SurfaceIndex, NodeIndex, TabIndex),
     ) -> Option<Tab> {
-        self[surface_index].remove_tab((node_index, tab_index))
+        let removed_tab = self[surface_index].remove_tab((node_index, tab_index));
+        if !surface_index.is_main() && self[surface_index].is_empty() {
+            self.remove_surface(surface_index);
+        }
+        removed_tab
     }
 
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -580,8 +580,10 @@ impl<Tab> Tree<Tab> {
     ///
     /// # Panics
     ///
-    /// If the node at index `node` is not a [`Leaf`](Node::Leaf).
+    /// - If the tree is empty.
+    /// - If the node at index `node` is not a [`Leaf`](Node::Leaf).
     pub fn remove_leaf(&mut self, node: NodeIndex) {
+        assert!(!self.is_empty());
         assert!(self[node].is_leaf());
 
         let Some(parent) = node.parent() else {


### PR DESCRIPTION
Fixes #206 

Deleting the last tab from a window surface using `DockState::remove_tab` doesn't delete the surface, which causes applications to crash on the following frame where `DockArea` attempts to render an empty window.

Solution: remove the window surface if its `Tree` is empty.