### PR TITLE
Keyboard focus fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 0.10.0 - TBD
 
 ### Added
-- Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
-- Separators are now focusable with the keyboard and movable using the arrow keys. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
+  - Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar.
+  - Separators are now focusable with the keyboard and movable using the arrow keys.
+  - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for style of tabs that are focused with the keyboard.
 
 ### Fixed
 - Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
   - Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar.
-  - Separators are now focusable with the keyboard and movable using the arrow keys.
+  - Separators are now focusable with the keyboard and movable using the arrow keys while control or shift is held.
   - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for style of tabs that are focused with the keyboard.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+## 0.9.1 - 2023-12-10
+
+### Fixed
+- Fix crash after calling `DockState::remove_tab`. ([#208](https://github.com/Adanos020/egui_dock/pull/208))
+
 ## 0.9.0 - 2023-11-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # egui_dock changelog
 
+## 0.10.0 - TBD
+
+### Added
+- Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+- Separators are now focusable with the keyboard and movable using the arrow keys. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+
+### Fixed
+- Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+
 ## 0.9.1 - 2023-12-10
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.72"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Then proceed by setting up `egui`, following its [quick start guide](https://git
 Once that's done, you can start using `egui_dock` – more details on that can be found in the
 [documentation](https://docs.rs/egui_dock/latest/egui_dock/).
 
+## Examples
+
+The Git repository of this crate contains some example applications demonstrating how to achieve certain effects.
+You can find all of them in the [`examples`](examples) folder.
+
+You can run them with Cargo from the crate's root directory, for example: `cargo run --example hello`.
+
 ## Demo
 
 ![demo](images/demo.gif "Demo")

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -297,7 +297,11 @@ impl<Tab> DockState<Tab> {
         &mut self,
         (surface_index, node_index, tab_index): (SurfaceIndex, NodeIndex, TabIndex),
     ) -> Option<Tab> {
-        self[surface_index].remove_tab((node_index, tab_index))
+        let removed_tab = self[surface_index].remove_tab((node_index, tab_index));
+        if !surface_index.is_main() && self[surface_index].is_empty() {
+            self.remove_surface(surface_index);
+        }
+        removed_tab
     }
 
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -580,8 +580,10 @@ impl<Tab> Tree<Tab> {
     ///
     /// # Panics
     ///
-    /// If the node at index `node` is not a [`Leaf`](Node::Leaf).
+    /// - If the tree is empty.
+    /// - If the node at index `node` is not a [`Leaf`](Node::Leaf).
     pub fn remove_leaf(&mut self, node: NodeIndex) {
+        assert!(!self.is_empty());
         assert!(self[node].is_leaf());
 
         let Some(parent) = node.parent() else {

--- a/src/style.rs
+++ b/src/style.rs
@@ -151,6 +151,15 @@ pub struct TabStyle {
     /// Style of the tab when it is hovered.
     pub hovered: TabInteractionStyle,
 
+    /// Style of the tab when it is inactive and has keyboard focus.
+    pub inactive_with_kb_focus: TabInteractionStyle,
+
+    /// Style of the tab when it is active and has keyboard focus.
+    pub active_with_kb_focus: TabInteractionStyle,
+
+    /// Style of the tab when it is focused and has keyboard focus.
+    pub focused_with_kb_focus: TabInteractionStyle,
+
     /// Style for the tab body.
     pub tab_body: TabBodyStyle,
 
@@ -357,6 +366,15 @@ impl Default for TabStyle {
                 text_color: Color32::BLACK,
                 ..Default::default()
             },
+            active_with_kb_focus: TabInteractionStyle::default(),
+            inactive_with_kb_focus: TabInteractionStyle {
+                text_color: Color32::DARK_GRAY,
+                ..Default::default()
+            },
+            focused_with_kb_focus: TabInteractionStyle {
+                text_color: Color32::BLACK,
+                ..Default::default()
+            },
             tab_body: TabBodyStyle::default(),
             hline_below_active_tab_name: false,
             minimum_width: None,
@@ -532,6 +550,9 @@ impl TabStyle {
             inactive: TabInteractionStyle::from_egui_inactive(style),
             focused: TabInteractionStyle::from_egui_focused(style),
             hovered: TabInteractionStyle::from_egui_hovered(style),
+            active_with_kb_focus: TabInteractionStyle::from_egui_active_with_kb_focus(style),
+            inactive_with_kb_focus: TabInteractionStyle::from_egui_inactive_with_kb_focus(style),
+            focused_with_kb_focus: TabInteractionStyle::from_egui_focused_with_kb_focus(style),
             tab_body: TabBodyStyle::from_egui(style),
             ..Default::default()
         }
@@ -607,6 +628,51 @@ impl TabInteractionStyle {
             text_color: style.visuals.strong_text_color(),
             outline_color: style.visuals.widgets.hovered.bg_stroke.color,
             ..TabInteractionStyle::from_egui_inactive(style)
+        }
+    }
+
+    /// Derives relevant fields from `egui::Style` for an active tab with keyboard focus and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabInteractionStyle::outline_color`]
+    /// - [`TabInteractionStyle::bg_fill`]
+    /// - [`TabInteractionStyle::text_color`]
+    /// - [`TabInteractionStyle::rounding`]
+    pub fn from_egui_active_with_kb_focus(style: &egui::Style) -> Self {
+        Self {
+            text_color: style.visuals.strong_text_color(),
+            outline_color: style.visuals.widgets.hovered.bg_stroke.color,
+            ..TabInteractionStyle::from_egui_active(style)
+        }
+    }
+
+    /// Derives relevant fields from `egui::Style` for an inactive tab with keyboard focus and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabInteractionStyle::outline_color`]
+    /// - [`TabInteractionStyle::bg_fill`]
+    /// - [`TabInteractionStyle::text_color`]
+    /// - [`TabInteractionStyle::rounding`]
+    pub fn from_egui_inactive_with_kb_focus(style: &egui::Style) -> Self {
+        Self {
+            text_color: style.visuals.strong_text_color(),
+            outline_color: style.visuals.widgets.hovered.bg_stroke.color,
+            ..TabInteractionStyle::from_egui_inactive(style)
+        }
+    }
+
+    /// Derives relevant fields from `egui::Style` for a focused tab with keyboard focus and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabInteractionStyle::outline_color`]
+    /// - [`TabInteractionStyle::bg_fill`]
+    /// - [`TabInteractionStyle::text_color`]
+    /// - [`TabInteractionStyle::rounding`]
+    pub fn from_egui_focused_with_kb_focus(style: &egui::Style) -> Self {
+        Self {
+            text_color: style.visuals.strong_text_color(),
+            outline_color: style.visuals.widgets.hovered.bg_stroke.color,
+            ..TabInteractionStyle::from_egui_focused(style)
         }
     }
 }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -446,7 +446,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         response = response.on_hover_cursor(CursorIcon::PointingHand);
 
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
-        let color = if response.hovered() {
+        let color = if response.hovered() || response.has_focus() {
             ui.painter()
                 .rect_filled(rect, Rounding::ZERO, style.buttons.add_tab_bg_fill);
             style.buttons.add_tab_active_color
@@ -535,7 +535,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             &tab_style.focused
         } else if active {
             &tab_style.active
-        } else if response.hovered() {
+        } else if response.hovered() || response.has_focus() {
             &tab_style.hovered
         } else {
             &tab_style.inactive
@@ -591,13 +591,13 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 .interact(close_button_rect, id, Sense::click())
                 .on_hover_cursor(CursorIcon::PointingHand);
 
-            let color = if response.hovered() {
+            let color = if response.hovered() || response.has_focus() {
                 style.buttons.close_tab_active_color
             } else {
                 style.buttons.close_tab_color
             };
 
-            if response.hovered() {
+            if response.hovered() || response.has_focus() {
                 let mut rounding = tab_style.rounding;
                 rounding.nw = 0.0;
                 rounding.sw = 0.0;

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -322,7 +322,8 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     };
                     let tab = &mut tabs[tab_index.0];
 
-                    response = response.context_menu(|ui| {
+                    let response = tabs_ui.interact(response.rect, id, Sense::click());
+                    response.context_menu(|ui| {
                         tab_viewer.context_menu(ui, tab, surface_index, node_index);
                         if (surface_index.is_main() || !is_lonely_tab)
                             && tab_viewer.allowed_in_windows(tab)

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -552,12 +552,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             }
         } else if response.hovered() {
             &tab_style.hovered
+        } else if response.has_focus() {
+            &tab_style.inactive_with_kb_focus
         } else {
-            if response.has_focus() {
-                &tab_style.inactive_with_kb_focus
-            } else {
-                &tab_style.inactive
-            }
+            &tab_style.inactive
         };
 
         // Draw the full tab first and then the stroke on top to avoid the stroke

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -538,14 +538,26 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             response = response.on_hover_cursor(CursorIcon::PointingHand);
         }
 
-        let tab_style = if focused || is_being_dragged || (active && response.has_focus()) {
-            &tab_style.focused
+        let tab_style = if focused || is_being_dragged {
+            if response.has_focus() {
+                &tab_style.focused_with_kb_focus
+            } else {
+                &tab_style.focused
+            }
         } else if active {
-            &tab_style.active
-        } else if response.hovered() || response.has_focus() {
+            if response.has_focus() {
+                &tab_style.active_with_kb_focus
+            } else {
+                &tab_style.active
+            }
+        } else if response.hovered() {
             &tab_style.hovered
         } else {
-            &tab_style.inactive
+            if response.has_focus() {
+                &tab_style.inactive_with_kb_focus
+            } else {
+                &tab_style.inactive
+            }
         };
 
         // Draw the full tab first and then the stroke on top to avoid the stroke

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1,9 +1,9 @@
 use std::ops::RangeInclusive;
 
 use egui::{
-    epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, CursorIcon, Frame, Id, LayerId,
-    Layout, NumExt, Order, PointerButton, Rect, Response, Rounding, ScrollArea, Sense, Stroke,
-    TextStyle, Ui, Vec2, WidgetText,
+    epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, CursorIcon, Frame, Id, Key,
+    LayerId, Layout, NumExt, Order, PointerButton, Rect, Response, Rounding, ScrollArea, Sense,
+    Stroke, TextStyle, Ui, Vec2, WidgetText,
 };
 
 use crate::{
@@ -235,7 +235,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
             let show_close_button = self.show_close_buttons && closeable;
 
-            let response = if is_being_dragged {
+            let (response, title_id) = if is_being_dragged {
                 let layer_id = LayerId::new(Order::Tooltip, id);
                 let response = tabs_ui
                     .with_layer_id(layer_id, |ui| {
@@ -253,6 +253,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         )
                     })
                     .response;
+                let title_id = response.id;
 
                 let sense = Sense::click_and_drag();
                 let response = tabs_ui.interact(response.rect, id, sense);
@@ -272,7 +273,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     }
                 }
 
-                response
+                (response, title_id)
             } else {
                 let (mut response, close_response) = self.tab_title(
                     tabs_ui,
@@ -286,6 +287,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     show_close_button,
                     fade,
                 );
+                let title_id = response.id;
 
                 let (close_hovered, close_clicked) = close_response
                     .map(|res| (res.hovered(), res.clicked()))
@@ -375,7 +377,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     }
                 }
 
-                response
+                (response, title_id)
             };
 
             // Paint hline below each tab unless its active (or option says otherwise).
@@ -400,7 +402,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 );
             }
 
-            if response.clicked() {
+            if response.clicked()
+                || (tabs_ui.memory(|m| m.has_focus(title_id))
+                    && tabs_ui.input(|i| i.key_pressed(Key::Enter) || i.key_pressed(Key::Space)))
+            {
                 *active = tab_index;
                 self.new_focused = Some((surface_index, node_index));
             }
@@ -525,8 +530,10 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             .at_least(text_width + close_button_size);
         let tab_width = prefered_width.unwrap_or(0.0).at_least(minimum_width);
 
-        let (rect, mut response) =
-            ui.allocate_exact_size(vec2(tab_width, ui.available_height()), Sense::hover());
+        let (rect, mut response) = ui.allocate_exact_size(
+            vec2(tab_width, ui.available_height()),
+            Sense::focusable_noninteractive(),
+        );
         if !ui.memory(|mem| mem.is_anything_being_dragged()) && self.draggable_tabs {
             response = response.on_hover_cursor(CursorIcon::PointingHand);
         }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -81,7 +81,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let (tabbar_outer_rect, tabbar_response) = ui.allocate_exact_size(
             vec2(ui.available_width(), style.tab_bar.height),
-            Sense::click(),
+            Sense::hover(),
         );
         ui.painter().rect_filled(
             tabbar_outer_rect,

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -538,7 +538,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             response = response.on_hover_cursor(CursorIcon::PointingHand);
         }
 
-        let tab_style = if focused || is_being_dragged {
+        let tab_style = if focused || is_being_dragged || (active && response.has_focus()) {
             &tab_style.focused
         } else if active {
             &tab_style.active

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -311,7 +311,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         if surface == SurfaceIndex::main() {
             rect = rect.expand(-style.main_surface_border_stroke.width / 2.0);
         }
-        ui.allocate_rect(rect, Sense::click());
+        ui.allocate_rect(rect, Sense::hover());
 
         if self.dock_state[surface].is_empty() {
             return rect;
@@ -409,7 +409,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                 let color = if response.dragged() {
                     style.separator.color_dragged
-                } else if response.hovered() {
+                } else if response.hovered() || response.has_focus() {
                     style.separator.color_hovered
                 } else {
                     style.separator.color_idle


### PR DESCRIPTION
This pull request closes #207 by fixing the behaviour of keyboard focus when using the Tab key on the keyboard.

I also added highlighting to the buttons in the tab titles when they are focused with the keyboard, and added the ability to change the current tab by focusing it with the keyboard and then pressing Enter or Space.

If you want me to update the changelog, let me know what I should put for the version.