### PR TITLE
Release 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # egui_dock changelog
 
+## 0.10.0 - TBD
+
+### Added
+From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
+  - Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar.
+  - Separators are now focusable with the keyboard and movable using the arrow keys while control or shift is held.
+  - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for style of tabs that are focused with the keyboard.
+
+### Fixed
+- Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+
 ## 0.9.1 - 2023-12-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,18 @@
 ## 0.10.0 - 2024-01-08
 
 ### Added
-From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
+- From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
   - Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar.
   - Separators are now focusable with the keyboard and movable using the arrow keys while control or shift is held.
   - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for style of tabs that are focused with the keyboard.
+- Missing translation for the tooltip showing when you hover on a grayed out window close button. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
 
 ### Fixed
 - Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
 
 ### Breaking changes
 - Upgraded to egui 0.25
+- Replaced `Default` implementations for `{TabContextMenu,Window,}Translations` with associated functions called `english`. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
 
 ## 0.9.1 - 2023-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # egui_dock changelog
 
-## 0.10.0 - TBD
+## 0.10.0 - 2024-01-08
 
 ### Added
 From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
@@ -10,6 +10,9 @@ From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
 
 ### Fixed
 - Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+
+### Breaking changes
+- Upgraded to egui 0.25
 
 ## 0.9.1 - 2023-12-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.24", default-features = false }
+egui = { version = "0.25", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "1.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.24", default-features = false, features = [
+eframe = { version = "0.25", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.72"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.24"
+egui = "0.25"
 egui_dock = "0.10"
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `egui` and `egui_dock` to your project's dependencies.
 ```toml
 [dependencies]
 egui = "0.24"
-egui_dock = "0.9"
+egui_dock = "0.10"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
 [![Crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.24-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.25-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -67,7 +67,7 @@ impl<Tab> DockState<Tab> {
         Self {
             surfaces: vec![Surface::Main(Tree::new(tabs))],
             focused_surface: None,
-            translations: Translations::default(),
+            translations: Translations::english(),
         }
     }
 

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -4,6 +4,8 @@
 pub struct Translations {
     /// Text overrides for buttons in tab context menus.
     pub tab_context_menu: TabContextMenuTranslations,
+    /// Text overrides for buttons in windows.
+    pub window: WindowTranslations,
 }
 
 /// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
@@ -16,21 +18,40 @@ pub struct TabContextMenuTranslations {
     pub eject_button: String,
 }
 
-impl Default for Translations {
+/// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct WindowTranslations {
+    /// Message in the tooltip shown while hovering over a grayed out X button of a window
+    /// containing non-closable tabs.
+    pub close_button_tooltip: String,
+}
+
+impl Translations {
     /// Default English translations.
-    fn default() -> Self {
+    pub fn english() -> Self {
         Self {
-            tab_context_menu: TabContextMenuTranslations::default(),
+            tab_context_menu: TabContextMenuTranslations::english(),
+            window: WindowTranslations::english(),
         }
     }
 }
 
-impl Default for TabContextMenuTranslations {
+impl TabContextMenuTranslations {
     /// Default English translations.
-    fn default() -> Self {
+    pub fn english() -> Self {
         Self {
             close_button: String::from("Close"),
             eject_button: String::from("Eject"),
+        }
+    }
+}
+
+impl WindowTranslations {
+    /// Default English translations.
+    pub fn english() -> Self {
+        Self {
+            close_button_tooltip: String::from("This window contains non-closable tabs."),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,13 +192,16 @@
 //! Example usage:
 //!
 //! ```rust
-//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations};
+//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations, WindowTranslations};
 //! # type Tab = ();
 //! let translations_pl = Translations {
 //!     tab_context_menu: TabContextMenuTranslations {
 //!         close_button: "Zamknij zakładkę".to_string(),
 //!         eject_button: "Przenieś zakładkę do nowego okna".to_string(),
 //!     },
+//!     window: WindowTranslations {
+//!         close_button_tooltip: "To okno zawiera zakładki, których nie można zamknąć.".to_string(),
+//!     }
 //! };
 //! let dock_state = DockState::<Tab>::new(vec![]).with_translations(translations_pl);
 //!
@@ -206,6 +209,7 @@
 //! let mut dock_state = DockState::<Tab>::new(vec![]);
 //! dock_state.translations.tab_context_menu.close_button = "タブを閉じる".to_string();
 //! dock_state.translations.tab_context_menu.eject_button = "タブを新しいウィンドウへ移動".to_string();
+//! dock_state.translations.window.close_button_tooltip = "このウィンドウは閉じられないタブがある。".to_string();
 //! ```
 
 #![warn(missing_docs)]

--- a/src/style.rs
+++ b/src/style.rs
@@ -151,6 +151,15 @@ pub struct TabStyle {
     /// Style of the tab when it is hovered.
     pub hovered: TabInteractionStyle,
 
+    /// Style of the tab when it is inactive and has keyboard focus.
+    pub inactive_with_kb_focus: TabInteractionStyle,
+
+    /// Style of the tab when it is active and has keyboard focus.
+    pub active_with_kb_focus: TabInteractionStyle,
+
+    /// Style of the tab when it is focused and has keyboard focus.
+    pub focused_with_kb_focus: TabInteractionStyle,
+
     /// Style for the tab body.
     pub tab_body: TabBodyStyle,
 
@@ -357,6 +366,15 @@ impl Default for TabStyle {
                 text_color: Color32::BLACK,
                 ..Default::default()
             },
+            active_with_kb_focus: TabInteractionStyle::default(),
+            inactive_with_kb_focus: TabInteractionStyle {
+                text_color: Color32::DARK_GRAY,
+                ..Default::default()
+            },
+            focused_with_kb_focus: TabInteractionStyle {
+                text_color: Color32::BLACK,
+                ..Default::default()
+            },
             tab_body: TabBodyStyle::default(),
             hline_below_active_tab_name: false,
             minimum_width: None,
@@ -532,6 +550,9 @@ impl TabStyle {
             inactive: TabInteractionStyle::from_egui_inactive(style),
             focused: TabInteractionStyle::from_egui_focused(style),
             hovered: TabInteractionStyle::from_egui_hovered(style),
+            active_with_kb_focus: TabInteractionStyle::from_egui_active_with_kb_focus(style),
+            inactive_with_kb_focus: TabInteractionStyle::from_egui_inactive_with_kb_focus(style),
+            focused_with_kb_focus: TabInteractionStyle::from_egui_focused_with_kb_focus(style),
             tab_body: TabBodyStyle::from_egui(style),
             ..Default::default()
         }
@@ -607,6 +628,51 @@ impl TabInteractionStyle {
             text_color: style.visuals.strong_text_color(),
             outline_color: style.visuals.widgets.hovered.bg_stroke.color,
             ..TabInteractionStyle::from_egui_inactive(style)
+        }
+    }
+
+    /// Derives relevant fields from `egui::Style` for an active tab with keyboard focus and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabInteractionStyle::outline_color`]
+    /// - [`TabInteractionStyle::bg_fill`]
+    /// - [`TabInteractionStyle::text_color`]
+    /// - [`TabInteractionStyle::rounding`]
+    pub fn from_egui_active_with_kb_focus(style: &egui::Style) -> Self {
+        Self {
+            text_color: style.visuals.strong_text_color(),
+            outline_color: style.visuals.widgets.hovered.bg_stroke.color,
+            ..TabInteractionStyle::from_egui_active(style)
+        }
+    }
+
+    /// Derives relevant fields from `egui::Style` for an inactive tab with keyboard focus and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabInteractionStyle::outline_color`]
+    /// - [`TabInteractionStyle::bg_fill`]
+    /// - [`TabInteractionStyle::text_color`]
+    /// - [`TabInteractionStyle::rounding`]
+    pub fn from_egui_inactive_with_kb_focus(style: &egui::Style) -> Self {
+        Self {
+            text_color: style.visuals.strong_text_color(),
+            outline_color: style.visuals.widgets.hovered.bg_stroke.color,
+            ..TabInteractionStyle::from_egui_inactive(style)
+        }
+    }
+
+    /// Derives relevant fields from `egui::Style` for a focused tab with keyboard focus and sets the remaining fields to their default values.
+    ///
+    /// Fields overwritten by [`egui::Style`] are:
+    /// - [`TabInteractionStyle::outline_color`]
+    /// - [`TabInteractionStyle::bg_fill`]
+    /// - [`TabInteractionStyle::text_color`]
+    /// - [`TabInteractionStyle::rounding`]
+    pub fn from_egui_focused_with_kb_focus(style: &egui::Style) -> Self {
+        Self {
+            text_color: style.visuals.strong_text_color(),
+            outline_color: style.visuals.widgets.hovered.bg_stroke.color,
+            ..TabInteractionStyle::from_egui_focused(style)
         }
     }
 }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -386,10 +386,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 unreachable!()
             };
             let tab = &mut tabs[tab_index.0];
-            let style = match fade {
-                Some(fade) => fade,
-                None => self.style.as_ref().unwrap(),
-            };
+            let style = fade.unwrap_or_else(|| self.style.as_ref().unwrap());
             let tab_style = tab_viewer.tab_style_override(tab, &style.tab);
             let tab_style = tab_style.as_ref().unwrap_or(&style.tab);
 
@@ -815,13 +812,13 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             });
         }
 
-        //change hover destination
+        // change hover destination
         if let Some(pointer) = state.last_hover_pos {
             // Prevent borrow checker issues.
             let rect = rect.to_owned();
 
-            //if the dragged tab isn't allowed in a window,
-            //it's unneccesary to change the hover state
+            // if the dragged tab isn't allowed in a window,
+            // it's unnecessary to change the hover state
             let is_dragged_valid = match &state.dnd {
                 Some(DragDropState {
                     drag: DragData { src, .. },

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -588,15 +588,8 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             pos - galley.size() / 2.0
         };
 
-        let override_text_color = (!galley.galley_has_color).then_some(tab_style.text_color);
-
-        ui.painter().add(TextShape {
-            pos: text_pos,
-            galley: galley.galley,
-            underline: Stroke::NONE,
-            override_text_color,
-            angle: 0.0,
-        });
+        ui.painter()
+            .add(TextShape::new(text_pos, galley, tab_style.text_color));
 
         let close_response = show_close_button.then(|| {
             let mut close_button_rect = rect;

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -400,7 +400,12 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 if response.has_focus() {
                     // Prevent the default behaviour of removing focus from the separators when the
                     // arrow keys are pressed
-                    ui.memory_mut(|m| m.set_focus_lock_filter(response.id, EventFilter { arrows: should_respond_to_arrow_keys, tab: false, escape: false }));
+                    ui.memory_mut(|m| m.set_focus_lock_filter(response.id, EventFilter {
+                        horizontal_arrows: should_respond_to_arrow_keys,
+                        vertical_arrows: should_respond_to_arrow_keys,
+                        tab: false,
+                        escape: false
+                    }));
                 }
 
                 let arrow_key_offset = if response.has_focus() && should_respond_to_arrow_keys {

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -43,24 +43,6 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             None => (1.0, None),
         };
 
-        // Finds out if theres a reason for the close button to be disabled
-        // by iterating over the tree and finding if theres any non-closable nodes.
-        let disabled = (!self.dock_state[surf_index]
-            .iter_mut()
-            .filter_map(|node| {
-                if let Node::Leaf { tabs, .. } = node {
-                    Some(
-                        tabs.iter_mut()
-                            .map(|tab| tab_viewer.closeable(tab))
-                            .all(identity),
-                    )
-                } else {
-                    None
-                }
-            })
-            .all(identity))
-        .then_some("This window contains non-closable tabs.");
-
         // Get galley of currently selected node as a window title
         let title = {
             let node_id = self.dock_state[surf_index]
@@ -82,7 +64,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 .into_galley(ui, Some(false), 0.0, TextStyle::Button)
         };
 
-        // Fade window frame (if neccesary)
+        // Fade window frame (if necessary)
         let mut frame = Frame::window(ui.style());
         if fade_factor != 1.0 {
             frame.fill = frame.fill.linear_multiply(fade_factor);
@@ -94,7 +76,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             .frame(frame)
             .min_width(min_window_width(&title, ui.spacing().indent))
             .show(ui.ctx(), |ui| {
-                //fade inner ui (if neccesary)
+                //fade inner ui (if necessary)
                 if fade_factor != 1.0 {
                     fade_visuals(ui.visuals_mut(), fade_factor);
                 }
@@ -112,6 +94,23 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     title,
                 );
                 if self.show_window_close_buttons {
+                    // Finds out if theres a reason for the close button to be disabled
+                    // by iterating over the tree and finding if theres any non-closable nodes.
+                    let disabled = !self.dock_state[surf_index]
+                        .iter_mut()
+                        .filter_map(|node| {
+                            if let Node::Leaf { tabs, .. } = node {
+                                Some(
+                                    tabs.iter_mut()
+                                        .map(|tab| tab_viewer.closeable(tab))
+                                        .all(identity),
+                                )
+                            } else {
+                                None
+                            }
+                        })
+                        .all(identity);
+
                     self.show_close_button(ui, &mut open, ch_res, disabled);
                 }
             });
@@ -174,7 +173,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         ui: &mut Ui,
         open: &mut bool,
         collapse_response: Option<CollapsingResponse<()>>,
-        disabled: Option<&'static str>,
+        disabled: bool,
     ) {
         let rect = {
             let (top_right, height) = match collapse_response {
@@ -191,10 +190,19 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
             Rect::from_min_size(top_right, Vec2::new(0.0, height))
         };
+        let close_button = close_button(
+            disabled.then_some(
+                self.dock_state
+                    .translations
+                    .window
+                    .close_button_tooltip
+                    .as_str(),
+            ),
+        );
         ui.allocate_ui_at_rect(rect, |ui| {
             ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
                 ui.set_height(rect.height());
-                if ui.add(close_button(disabled)).clicked() {
+                if ui.add(close_button).clicked() {
                     *open = false;
                 }
             });
@@ -206,7 +214,7 @@ fn min_window_width(title: &Galley, button_width: f32) -> f32 {
     (button_width * 2.) + title.size().x
 }
 
-fn close_button(disabled: Option<&'static str>) -> impl Widget {
+fn close_button(disabled: Option<&str>) -> impl Widget + '_ {
     move |ui: &mut Ui| -> Response {
         let sense = disabled.map_or(Sense::click(), |_disabled| Sense::hover());
 

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -80,7 +80,6 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 .title(&mut tabs[active.0])
                 .color(ui.visuals().widgets.noninteractive.fg_stroke.color)
                 .into_galley(ui, Some(false), 0.0, TextStyle::Button)
-                .galley
         };
 
         // Fade window frame (if neccesary)
@@ -152,8 +151,11 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         ch_response.header_response.rect.height(),
                     ),
                 );
-                ui.painter()
-                    .galley(rect.center() - (title.size() * 0.5), title);
+                ui.painter().galley(
+                    rect.center() - (title.size() * 0.5),
+                    title,
+                    ui.visuals().widgets.noninteractive.fg_stroke.color,
+                );
             }
             Some(ch_response)
         } else {
@@ -177,7 +179,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let rect = {
             let (top_right, height) = match collapse_response {
                 Some(collapse) => (
-                    egui::Rect::from_two_pos(
+                    Rect::from_two_pos(
                         collapse.header_response.rect.right_top(),
                         ui.max_rect().right_top(),
                     )
@@ -199,9 +201,11 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         });
     }
 }
+
 fn min_window_width(title: &Galley, button_width: f32) -> f32 {
     (button_width * 2.) + title.size().x
 }
+
 fn close_button(disabled: Option<&'static str>) -> impl Widget {
     move |ui: &mut Ui| -> Response {
         let sense = disabled.map_or(Sense::click(), |_disabled| Sense::hover());


### PR DESCRIPTION
### Added
- From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
  - Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar.
  - Separators are now focusable with the keyboard and movable using the arrow keys while control or shift is held.
  - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for style of tabs that are focused with the keyboard.
- Missing translation for the tooltip showing when you hover on a grayed out window close button. ([#216](https://github.com/Adanos020/egui_dock/pull/216))

### Fixed
- Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))

### Breaking changes
- Upgraded to egui 0.25
- Replaced `Default` implementations for `{TabContextMenu,Window,}Translations` with associated functions called `english`. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
