### PR TITLE
Add window tooltip translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,18 @@
 ## 0.10.0 - 2024-01-08
 
 ### Added
-From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
+- From ([#211](https://github.com/Adanos020/egui_dock/pull/211)):
   - Tabs, the close tab buttons and the add tab buttons are now focusable with the keyboard and interactable with the enter key and space bar.
   - Separators are now focusable with the keyboard and movable using the arrow keys while control or shift is held.
   - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for style of tabs that are focused with the keyboard.
+- Missing translation for the tooltip showing when you hover on a grayed out window close button. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
 
 ### Fixed
 - Widgets inside tabs are now focusable with the tab key on the keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
 
 ### Breaking changes
 - Upgraded to egui 0.25
+- Replaced `Default` implementations for `{TabContextMenu,Window,}Translations` with associated functions called `english`. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
 
 ## 0.9.1 - 2023-12-10
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -67,7 +67,7 @@ impl<Tab> DockState<Tab> {
         Self {
             surfaces: vec![Surface::Main(Tree::new(tabs))],
             focused_surface: None,
-            translations: Translations::default(),
+            translations: Translations::english(),
         }
     }
 

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -1,9 +1,11 @@
 /// Groups together labels from different elements of the [`DockArea`](crate::DockArea).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Translations {
     /// Text overrides for buttons in tab context menus.
     pub tab_context_menu: TabContextMenuTranslations,
+    /// Text overrides for buttons in windows.
+    pub window: WindowTranslations,
 }
 
 /// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
@@ -16,13 +18,13 @@ pub struct TabContextMenuTranslations {
     pub eject_button: String,
 }
 
-impl Default for Translations {
-    /// Default English translations.
-    fn default() -> Self {
-        Self {
-            tab_context_menu: TabContextMenuTranslations::default(),
-        }
-    }
+/// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct WindowTranslations {
+    /// Message in the tooltip shown while hovering over a grayed out X button of a window
+    /// containing non-closable tabs.
+    pub close_button_tooltip: String,
 }
 
 impl Default for TabContextMenuTranslations {
@@ -31,6 +33,15 @@ impl Default for TabContextMenuTranslations {
         Self {
             close_button: String::from("Close"),
             eject_button: String::from("Eject"),
+        }
+    }
+}
+
+impl Default for WindowTranslations {
+    /// Default English translations.
+    fn default() -> Self {
+        Self {
+            close_button_tooltip: String::from("This window contains non-closable tabs."),
         }
     }
 }

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -1,5 +1,5 @@
 /// Groups together labels from different elements of the [`DockArea`](crate::DockArea).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Translations {
     /// Text overrides for buttons in tab context menus.
@@ -27,9 +27,19 @@ pub struct WindowTranslations {
     pub close_button_tooltip: String,
 }
 
-impl Default for TabContextMenuTranslations {
+impl Translations {
     /// Default English translations.
-    fn default() -> Self {
+    pub fn english() -> Self {
+        Self {
+            tab_context_menu: TabContextMenuTranslations::english(),
+            window: WindowTranslations::english(),
+        }
+    }
+}
+
+impl TabContextMenuTranslations {
+    /// Default English translations.
+    pub fn english() -> Self {
         Self {
             close_button: String::from("Close"),
             eject_button: String::from("Eject"),
@@ -37,9 +47,9 @@ impl Default for TabContextMenuTranslations {
     }
 }
 
-impl Default for WindowTranslations {
+impl WindowTranslations {
     /// Default English translations.
-    fn default() -> Self {
+    pub fn english() -> Self {
         Self {
             close_button_tooltip: String::from("This window contains non-closable tabs."),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,13 +192,16 @@
 //! Example usage:
 //!
 //! ```rust
-//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations};
+//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations, WindowTranslations};
 //! # type Tab = ();
 //! let translations_pl = Translations {
 //!     tab_context_menu: TabContextMenuTranslations {
 //!         close_button: "Zamknij zakładkę".to_string(),
 //!         eject_button: "Przenieś zakładkę do nowego okna".to_string(),
 //!     },
+//!     window: WindowTranslations {
+//!         close_button_tooltip: "To okno zawiera zakładki, których nie można zamknąć.".to_string(),
+//!     }
 //! };
 //! let dock_state = DockState::<Tab>::new(vec![]).with_translations(translations_pl);
 //!
@@ -206,6 +209,7 @@
 //! let mut dock_state = DockState::<Tab>::new(vec![]);
 //! dock_state.translations.tab_context_menu.close_button = "タブを閉じる".to_string();
 //! dock_state.translations.tab_context_menu.eject_button = "タブを新しいウィンドウへ移動".to_string();
+//! dock_state.translations.window.close_button_tooltip = "このウィンドウは閉じられないタブがある。".to_string();
 //! ```
 
 #![warn(missing_docs)]

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -386,10 +386,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 unreachable!()
             };
             let tab = &mut tabs[tab_index.0];
-            let style = match fade {
-                Some(fade) => fade,
-                None => self.style.as_ref().unwrap(),
-            };
+            let style = fade.unwrap_or_else(|| self.style.as_ref().unwrap());
             let tab_style = tab_viewer.tab_style_override(tab, &style.tab);
             let tab_style = tab_style.as_ref().unwrap_or(&style.tab);
 
@@ -815,13 +812,13 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             });
         }
 
-        //change hover destination
+        // change hover destination
         if let Some(pointer) = state.last_hover_pos {
             // Prevent borrow checker issues.
             let rect = rect.to_owned();
 
-            //if the dragged tab isn't allowed in a window,
-            //it's unneccesary to change the hover state
+            // if the dragged tab isn't allowed in a window,
+            // it's unnecessary to change the hover state
             let is_dragged_valid = match &state.dnd {
                 Some(DragDropState {
                     drag: DragData { src, .. },

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -43,24 +43,6 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             None => (1.0, None),
         };
 
-        // Finds out if theres a reason for the close button to be disabled
-        // by iterating over the tree and finding if theres any non-closable nodes.
-        let disabled = (!self.dock_state[surf_index]
-            .iter_mut()
-            .filter_map(|node| {
-                if let Node::Leaf { tabs, .. } = node {
-                    Some(
-                        tabs.iter_mut()
-                            .map(|tab| tab_viewer.closeable(tab))
-                            .all(identity),
-                    )
-                } else {
-                    None
-                }
-            })
-            .all(identity))
-        .then_some("This window contains non-closable tabs.");
-
         // Get galley of currently selected node as a window title
         let title = {
             let node_id = self.dock_state[surf_index]
@@ -82,7 +64,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 .into_galley(ui, Some(false), 0.0, TextStyle::Button)
         };
 
-        // Fade window frame (if neccesary)
+        // Fade window frame (if necessary)
         let mut frame = Frame::window(ui.style());
         if fade_factor != 1.0 {
             frame.fill = frame.fill.linear_multiply(fade_factor);
@@ -94,7 +76,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             .frame(frame)
             .min_width(min_window_width(&title, ui.spacing().indent))
             .show(ui.ctx(), |ui| {
-                //fade inner ui (if neccesary)
+                //fade inner ui (if necessary)
                 if fade_factor != 1.0 {
                     fade_visuals(ui.visuals_mut(), fade_factor);
                 }
@@ -112,6 +94,23 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                     title,
                 );
                 if self.show_window_close_buttons {
+                    // Finds out if theres a reason for the close button to be disabled
+                    // by iterating over the tree and finding if theres any non-closable nodes.
+                    let disabled = !self.dock_state[surf_index]
+                        .iter_mut()
+                        .filter_map(|node| {
+                            if let Node::Leaf { tabs, .. } = node {
+                                Some(
+                                    tabs.iter_mut()
+                                        .map(|tab| tab_viewer.closeable(tab))
+                                        .all(identity),
+                                )
+                            } else {
+                                None
+                            }
+                        })
+                        .all(identity);
+
                     self.show_close_button(ui, &mut open, ch_res, disabled);
                 }
             });
@@ -174,7 +173,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         ui: &mut Ui,
         open: &mut bool,
         collapse_response: Option<CollapsingResponse<()>>,
-        disabled: Option<&'static str>,
+        disabled: bool,
     ) {
         let rect = {
             let (top_right, height) = match collapse_response {
@@ -191,10 +190,19 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
             Rect::from_min_size(top_right, Vec2::new(0.0, height))
         };
+        let close_button = close_button(
+            disabled.then_some(
+                self.dock_state
+                    .translations
+                    .window
+                    .close_button_tooltip
+                    .as_str(),
+            ),
+        );
         ui.allocate_ui_at_rect(rect, |ui| {
             ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
                 ui.set_height(rect.height());
-                if ui.add(close_button(disabled)).clicked() {
+                if ui.add(close_button).clicked() {
                     *open = false;
                 }
             });
@@ -206,7 +214,7 @@ fn min_window_width(title: &Galley, button_width: f32) -> f32 {
     (button_width * 2.) + title.size().x
 }
 
-fn close_button(disabled: Option<&'static str>) -> impl Widget {
+fn close_button(disabled: Option<&str>) -> impl Widget + '_ {
     move |ui: &mut Ui| -> Response {
         let sense = disabled.map_or(Sense::click(), |_disabled| Sense::hover());
 


### PR DESCRIPTION
Adds missing translation, and also replaces `Default` implementation for the translation types with associated functions called `english`.