### PR TITLE
Upgrade egui to 0.26. TODO: fix drag&drop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - `filter_map_tabs`, `filter_tabs`, and `retain_tabs` ([#217](https://github.com/Adanos020/egui_dock/pull/217))
 
+### Breaking changes
+- Upgraded to egui 0.26
+
 ## 0.10.0 - 2024-01-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.25", default-features = false }
+egui = { version = "0.26", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "1.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.25", default-features = false, features = [
+eframe = { version = "0.26", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
 [![Crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.25-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.26-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
@@ -32,8 +32,8 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.25"
-egui_dock = "0.10"
+egui = "0.26"
+egui_dock = "0.11"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -73,7 +73,7 @@ fn draw_highlight_rect(rect: Rect, ui: &Ui, style: &Style) {
         style.overlay.hovered_leaf_highlight.rounding,
         style.overlay.hovered_leaf_highlight.color,
         style.overlay.hovered_leaf_highlight.stroke,
-    )
+    );
 }
 
 // Draws one of the Tab drop destination icons inside `rect`, which one you get is specified by `is_top_bottom`.

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -691,7 +691,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
                 if let Some(pos) = state.last_hover_pos {
                     if scroll_bar_rect.contains(pos) {
-                        *scroll += ui.input(|i| i.scroll_delta.y + i.scroll_delta.x)
+                        *scroll += ui.input(|i| i.smooth_scroll_delta.y + i.smooth_scroll_delta.x)
                             * points_to_scroll_coefficient;
                     }
                 }
@@ -712,7 +712,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
             // Handle user input.
             if tabbar_response.hovered() {
-                *scroll += ui.input(|i| i.scroll_delta.y + i.scroll_delta.x);
+                *scroll += ui.input(|i| i.smooth_scroll_delta.y + i.smooth_scroll_delta.x);
             }
         }
 


### PR DESCRIPTION
## 0.11.0 - TBD

### Added
- `filter_map_tabs`, `filter_tabs`, and `retain_tabs` ([#217](https://github.com/Adanos020/egui_dock/pull/217))

### Breaking changes
- Upgraded to egui 0.26

Fixing drag&drop of tabs is WIP.