### PR TITLE
Fix `filter_map_tabs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_dock changelog
 
+## 0.11.3 - 2024-03-06
+
+### Fixed
+- `filter_map_tabs` sometimes deleting nodes when it shouldn't.
+
 ## 0.11.2 - 2024-02-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.11.3 - 2024-03-06
 
 ### Fixed
-- `filter_map_tabs` sometimes deleting nodes when it shouldn't.
+- `filter_map_tabs` sometimes deleting nodes when it shouldn't. ([#230](https://github.com/Adanos020/egui_dock/pull/230))
 
 ## 0.11.2 - 2024-02-16
 

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -750,11 +750,11 @@ impl<Tab> Tree<Tab> {
             .iter()
             .enumerate()
             .map(|(index, node)| {
-                let node = node.filter_map_tabs(function.clone());
-                if node.is_empty() {
+                let filtered_node = node.filter_map_tabs(function.clone());
+                if filtered_node.is_empty() && !node.is_empty() {
                     emptied_nodes.insert(NodeIndex(index));
                 }
-                node
+                filtered_node
             })
             .collect();
         let mut new_tree = Tree {


### PR DESCRIPTION
`filter_map_tabs` sometimes deletes nodes when it shouldn't. This is a fix for that.