### PR TITLE
Remove `Clone` bound on `map_tabs` and `filter_map_tabs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Changed
 
 - `{DockState,Surface,Tree,Node}::{filter_map_tabs,map_tabs,filter_tabs,retain_tabs}` no longer require the predicate to
-  implement `Clone` ([#241](https://github.com/Adanos020/egui_dock/pull/241))
+  implement `Clone`. ([#241](https://github.com/Adanos020/egui_dock/pull/241))
 
 ## 0.13.0 - 2024-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # egui_dock changelog
 
+## 0.14.0 - Unreleased
+
+## Changed
+
+- `{DockState,Surface,Tree,Node}::{filter_map_tabs,map_tabs,filter_tabs,retain_tabs}` no longer require the predicate to
+  implement `Clone` ([#241](https://github.com/Adanos020/egui_dock/pull/241))
+
 ## 0.13.0 - 2024-07-03
 
 ### Breaking changes

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -522,7 +522,7 @@ impl<Tab> DockState<Tab> {
     /// ```
     pub fn filter_tabs<F>(&self, mut predicate: F) -> DockState<Tab>
     where
-        F: Clone + FnMut(&Tab) -> bool,
+        F: FnMut(&Tab) -> bool,
         Tab: Clone,
     {
         self.filter_map_tabs(move |tab| predicate(tab).then(|| tab.clone()))
@@ -539,12 +539,12 @@ impl<Tab> DockState<Tab> {
     /// let tabs: Vec<_> = dock_state.iter_all_tabs().map(|(_, tab)| tab.to_owned()).collect();
     /// assert_eq!(tabs, vec!["tab1".to_string(), "tab2".to_string()]);
     /// ```
-    pub fn retain_tabs<F>(&mut self, predicate: F)
+    pub fn retain_tabs<F>(&mut self, mut predicate: F)
     where
-        F: Clone + FnMut(&mut Tab) -> bool,
+        F: FnMut(&mut Tab) -> bool,
     {
         self.surfaces.retain_mut(|surface| {
-            surface.retain_tabs(predicate.clone());
+            surface.retain_tabs(&mut predicate);
             !surface.is_empty()
         });
     }

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -469,9 +469,9 @@ impl<Tab> DockState<Tab> {
     /// let tabs: Vec<_> = mapped_dock_state.iter_all_tabs().map(|(_, tab)| tab.to_owned()).collect();
     /// assert_eq!(tabs, vec!["1".to_string(), "3".to_string()]);
     /// ```
-    pub fn filter_map_tabs<F, NewTab>(&self, function: F) -> DockState<NewTab>
+    pub fn filter_map_tabs<F, NewTab>(&self, mut function: F) -> DockState<NewTab>
     where
-        F: Clone + FnMut(&Tab) -> Option<NewTab>,
+        F: FnMut(&Tab) -> Option<NewTab>,
     {
         let DockState {
             surfaces,
@@ -481,7 +481,7 @@ impl<Tab> DockState<Tab> {
         let surfaces = surfaces
             .iter()
             .filter_map(|surface| {
-                let surface = surface.filter_map_tabs(function.clone());
+                let surface = surface.filter_map_tabs(&mut function);
                 (!surface.is_empty()).then_some(surface)
             })
             .collect();
@@ -504,7 +504,7 @@ impl<Tab> DockState<Tab> {
     /// ```
     pub fn map_tabs<F, NewTab>(&self, mut function: F) -> DockState<NewTab>
     where
-        F: Clone + FnMut(&Tab) -> NewTab,
+        F: FnMut(&Tab) -> NewTab,
     {
         self.filter_map_tabs(move |tab| Some(function(tab)))
     }

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -100,7 +100,7 @@ impl<Tab> Surface<Tab> {
     /// Returns a new [`Surface`] while mapping the tab type.
     pub fn map_tabs<F, NewTab>(&self, mut function: F) -> Surface<NewTab>
     where
-        F: Clone + FnMut(&Tab) -> NewTab,
+        F: FnMut(&Tab) -> NewTab,
     {
         self.filter_map_tabs(move |tab| Some(function(tab)))
     }
@@ -110,7 +110,7 @@ impl<Tab> Surface<Tab> {
     /// it'll change to [`Surface::Empty`].
     pub fn filter_tabs<F>(&self, mut predicate: F) -> Surface<Tab>
     where
-        F: Clone + FnMut(&Tab) -> bool,
+        F: FnMut(&Tab) -> bool,
         Tab: Clone,
     {
         self.filter_map_tabs(move |tab| predicate(tab).then(|| tab.clone()))
@@ -121,7 +121,7 @@ impl<Tab> Surface<Tab> {
     /// it'll change to [`Surface::Empty`].
     pub fn retain_tabs<F>(&mut self, predicate: F)
     where
-        F: Clone + FnMut(&mut Tab) -> bool,
+        F: FnMut(&mut Tab) -> bool,
     {
         if let Surface::Main(tree) | Surface::Window(tree, _) = self {
             tree.retain_tabs(predicate);

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -81,7 +81,7 @@ impl<Tab> Surface<Tab> {
     /// it'll change to [`Surface::Empty`].
     pub fn filter_map_tabs<F, NewTab>(&self, function: F) -> Surface<NewTab>
     where
-        F: Clone + FnMut(&Tab) -> Option<NewTab>,
+        F: FnMut(&Tab) -> Option<NewTab>,
     {
         match self {
             Surface::Empty => Surface::Empty,

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -737,9 +737,9 @@ impl<Tab> Tree<Tab> {
 
     /// Returns a new [`Tree`] while mapping and filtering the tab type.
     /// Any remaining empty [`Node`]s are removed.
-    pub fn filter_map_tabs<F, NewTab>(&self, function: F) -> Tree<NewTab>
+    pub fn filter_map_tabs<F, NewTab>(&self, mut function: F) -> Tree<NewTab>
     where
-        F: Clone + FnMut(&Tab) -> Option<NewTab>,
+        F: FnMut(&Tab) -> Option<NewTab>,
     {
         let Tree {
             focused_node,
@@ -750,7 +750,7 @@ impl<Tab> Tree<Tab> {
             .iter()
             .enumerate()
             .map(|(index, node)| {
-                let filtered_node = node.filter_map_tabs(function.clone());
+                let filtered_node = node.filter_map_tabs(&mut function);
                 if filtered_node.is_empty() && !node.is_empty() {
                     emptied_nodes.insert(NodeIndex(index));
                 }

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -768,7 +768,7 @@ impl<Tab> Tree<Tab> {
     /// Returns a new [`Tree`] while mapping the tab type.
     pub fn map_tabs<F, NewTab>(&self, mut function: F) -> Tree<NewTab>
     where
-        F: Clone + FnMut(&Tab) -> NewTab,
+        F: FnMut(&Tab) -> NewTab,
     {
         self.filter_map_tabs(move |tab| Some(function(tab)))
     }
@@ -777,7 +777,7 @@ impl<Tab> Tree<Tab> {
     /// Any remaining empty [`Node`]s are removed.
     pub fn filter_tabs<F>(&self, mut predicate: F) -> Tree<Tab>
     where
-        F: Clone + FnMut(&Tab) -> bool,
+        F: FnMut(&Tab) -> bool,
         Tab: Clone,
     {
         self.filter_map_tabs(move |tab| predicate(tab).then(|| tab.clone()))
@@ -785,13 +785,13 @@ impl<Tab> Tree<Tab> {
 
     /// Removes all tabs for which `predicate` returns `false`.
     /// Any remaining empty [`Node`]s are also removed.
-    pub fn retain_tabs<F>(&mut self, predicate: F)
+    pub fn retain_tabs<F>(&mut self, mut predicate: F)
     where
-        F: Clone + FnMut(&mut Tab) -> bool,
+        F: FnMut(&mut Tab) -> bool,
     {
         let mut emptied_nodes = HashSet::default();
         for (index, node) in self.nodes.iter_mut().enumerate() {
-            node.retain_tabs(predicate.clone());
+            node.retain_tabs(&mut predicate);
             if node.is_empty() {
                 emptied_nodes.insert(NodeIndex(index));
             }

--- a/src/dock_state/tree/node.rs
+++ b/src/dock_state/tree/node.rs
@@ -340,7 +340,7 @@ impl<Tab> Node<Tab> {
     /// If this [`Node`] remains empty, it will change to [`Node::Empty`].
     pub fn filter_tabs<F>(&self, mut predicate: F) -> Node<Tab>
     where
-        F: Clone + FnMut(&Tab) -> bool,
+        F: FnMut(&Tab) -> bool,
         Tab: Clone,
     {
         self.filter_map_tabs(move |tab| predicate(tab).then(|| tab.clone()))
@@ -350,7 +350,7 @@ impl<Tab> Node<Tab> {
     /// If this [`Node`] remains empty, it will change to [`Node::Empty`].
     pub fn retain_tabs<F>(&mut self, predicate: F)
     where
-        F: Clone + FnMut(&mut Tab) -> bool,
+        F: FnMut(&mut Tab) -> bool,
     {
         if let Node::Leaf { tabs, .. } = self {
             tabs.retain_mut(predicate);


### PR DESCRIPTION
No point of having a FnMut if it can't mutably reference stuff outside