### PR TITLE
Update duplicate to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "egui/serde"]
 egui = { version = "0.28", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
-duplicate = "1.0"
+duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
After this change, `egui_dock` no will no longer have a duplicate dependency on syn (1.x and 2.x)