### PR TITLE
add overriding tab bar and allowed splits on a per node and surface basis

### DIFF
--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -42,13 +42,24 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         ui.spacing_mut().item_spacing = Vec2::ZERO;
         ui.set_clip_rect(rect);
 
-        let tabbar_rect = self.tab_bar(
-            ui,
-            state,
-            (surface_index, node_index),
-            tab_viewer,
-            fade_style.map(|(style, _)| style),
-        );
+        let Node::Leaf { tabs, .. } = &mut self.dock_state[surface_index][node_index] else {
+            unreachable!();
+        };
+
+        let should_show_tab_bar =
+            tab_viewer.should_show_tab_bar((surface_index, node_index), &tabs);
+        let tabbar_rect = if should_show_tab_bar {
+            self.tab_bar(
+                ui,
+                state,
+                (surface_index, node_index),
+                tab_viewer,
+                fade_style.map(|(style, _)| style),
+            )
+        } else {
+            Rect::ZERO
+        };
+
         self.tab_body(
             ui,
             state,

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -1,4 +1,4 @@
-use crate::{NodeIndex, SurfaceIndex, TabStyle};
+use crate::{AllowedSplits, NodeIndex, SurfaceIndex, TabStyle};
 use egui::{Id, Ui, WidgetText};
 
 /// Defines how a tab should behave and be rendered inside a [`Tree`](crate::Tree).
@@ -97,4 +97,25 @@ pub trait TabViewer {
     fn scroll_bars(&self, _tab: &Self::Tab) -> [bool; 2] {
         [true, true]
     }
+
+    fn allowed_splits(
+        &self,
+        _node_address: (SurfaceIndex, Option<NodeIndex>),
+    ) -> AllowedSplitsOverride {
+        AllowedSplitsOverride::Fallback
+    }
+
+    fn should_show_tab_bar(
+        &self,
+        _node_address: (SurfaceIndex, NodeIndex),
+        _tabs: &[Self::Tab],
+    ) -> bool {
+        true
+    }
+}
+
+pub enum AllowedSplitsOverride {
+    NoDock,
+    Override(AllowedSplits),
+    Fallback,
 }


### PR DESCRIPTION
these changes are made in a backwards compatible way.

i'm looking for feedback on naming, i think it could be more clear. maybe docking override?

also maybe the example could be made a bit more clear? maybe i should move it out of hello or put it behind a flag?