### PR TITLE
Release 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /.idea
+/.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
   - Renamed `Translations::WindowTranslations` to `Translations::LeafTranslations`.
   - Renamed `WindowTranslations::close_button_tooltip` to `LeafTranslations::close_button_disabled_tooltip`.
   - `Translations::LeafTranslations` now requires more fields to be constructed (see **Added** section).
+- Upgraded to egui 0.30.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # egui_dock changelog
 
+## 0.15.0 - Unreleased
+
+### Changed
+
+- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
+  - Each leaf can now be collapsed / closed individually. They are introduced as additional tab bar controls.
+  - Undocked windows are now more compact. The original undocked window controls are now accessible as "secondary buttons" from the tab bar.
+    - By default, the secondary buttons are activated from primary buttons either by holding the <kbd>Shift</kbd> key while clicking on them, or from a context menu by right-clicking them.
+  - A number of tooltip hints are on by default as guides to the new behavior, but they can be disabled.
+  - There has been an overhaul to the internal codebase to support the new features.
+
+### Added
+
+- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
+  - `DockArea::show_leaf_close_all_buttons` – shows a close all button which closes all open tabs in a leaf.
+  - `DockArea::show_leaf_collapse_buttons` – shows a collapsing button which collapses a leaf (no longer collapsing a window).
+  - `DockArea::show_secondary_button_hint` – sets whether tooltip hints are shown for secondary buttons on tab bars.
+  - `DockArea::show_leaf_collapse_buttons` – shows a collapsing button which collapses a leaf (no longer collapsing a window).
+  - `DockArea::secondary_button_on_modifier` – sets whether the secondary buttons on tab bars are activated by the modifier key.
+  - `DockArea::secondary_button_context_menu` – sets whether the secondary buttons on tab bars are activated from a context value by right-clicking primary buttons.
+  - Added the following translations:
+    - `LeafTranslations::close_all_button`
+    - `LeafTranslations::close_all_button_menu_hint`
+    - `LeafTranslations::close_all_button_modifier_hint`
+    - `LeafTranslations::close_all_button_modifier_menu_hint`
+    - `LeafTranslations::close_all_button_disabled_tooltip`
+    - `LeafTranslations::minimize_button`
+    - `LeafTranslations::minimize_button_menu_hint`
+    - `LeafTranslations::minimize_button_modifier_hint`
+    - `LeafTranslations::minimize_button_modifier_menu_hint`
+  - `Node::is_collapsed` – returns whether the `Node` is collapsed.
+  - `Node::collapsed_leaf_count` – returns the number of collapsed layers of leaf subnodes.
+  - `Node::set_collapsed` – set the collapsing state of the `Node`.
+  - `Node::set_collapsed_leaf_count` – sets the number of collapsed layers of leaf subnodes.
+  - `WindowState::minimized` field – records whether a window is minimized.
+  - `WindowState::expanded_height` field – records the height of the window before it was fully collapsed.
+  - Added style configuration for the two buttons:
+    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_color`
+    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_active_color`
+    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_bg_fill`
+    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_border_color`
+    - `ButtonsStyle::close_all_tabs_disabled_color`
+    - `Style::TAB_CLOSE_ALL_BUTTON_SIZE`
+    - `Style::TAB_CLOSE_ALL_SIZE`
+    - `Style::TAB_COLLAPSE_BUTTON_SIZE`
+    - `Style::TAB_COLLAPSE_ARROW_SIZE`
+    - `Style::TAB_EXPAND_BUTTON_SIZE`
+    - `Style::TAB_EXPAND_ARROW_SIZE`
+
+### Breaking changes
+
+- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
+  - Renamed `Translations::WindowTranslations` to `Translations::LeafTranslations`.
+  - Renamed `WindowTranslations::close_button_tooltip` to `LeafTranslations::close_button_disabled_tooltip`.
+  - `Translations::LeafTranslations` now requires more fields to be constructed (see **Added** section).
+
+### Deprecated
+
+- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
+    - `DockArea::show_window_close_buttons` – no longer has any effect; consider using `DockArea::show_leaf_close_all_buttons`
+      instead.
+    - `DockArea::show_window_collapse_buttons` – no longer has any effect; consider using `DockArea::show_leaf_collapse_buttons`
+      instead.
+
 ## 0.14.0 - 2024-09-02
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
@@ -18,14 +18,15 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.29", default-features = false }
+egui = { version = "0.30", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.29", default-features = false, features = [
+eframe = { version = "0.30", default-features = false, features = [
+    "default",
     "default_fonts",
     "glow",
 ] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
 [![Crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.29-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.30-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
@@ -32,8 +32,8 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.29"
-egui_dock = "0.14"
+egui = "0.30"
+egui_dock = "0.15"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -74,8 +74,11 @@ struct MyContext {
     draggable_tabs: bool,
     show_tab_name_on_hover: bool,
     allowed_splits: AllowedSplits,
-    show_window_close: bool,
-    show_window_collapse: bool,
+    show_leaf_close_all: bool,
+    show_leaf_collapse: bool,
+    show_secondary_button_hint: bool,
+    secondary_button_on_modifier: bool,
+    secondary_button_context_menu: bool,
 }
 
 struct MyApp {
@@ -156,10 +159,25 @@ impl MyContext {
             ui.checkbox(&mut self.show_add_buttons, "Show add buttons");
             ui.checkbox(&mut self.draggable_tabs, "Draggable tabs");
             ui.checkbox(&mut self.show_tab_name_on_hover, "Show tab name on hover");
-            ui.checkbox(&mut self.show_window_close, "Show close button on windows");
             ui.checkbox(
-                &mut self.show_window_collapse,
-                "Show collaspse button on windows",
+                &mut self.show_leaf_close_all,
+                "Show close all button on tab bars",
+            );
+            ui.checkbox(
+                &mut self.show_leaf_collapse,
+                "Show collaspse button on tab bars",
+            );
+            ui.checkbox(
+                &mut self.secondary_button_on_modifier,
+                "Enable secondary buttons when modifiers (Shift by default) are pressed",
+            );
+            ui.checkbox(
+                &mut self.secondary_button_context_menu,
+                "Enable secondary buttons in right-click context menus",
+            );
+            ui.checkbox(
+                &mut self.show_secondary_button_hint,
+                "Show tooltip hints for secondary buttons",
             );
             ComboBox::new("cbox:allowed_splits", "Split direction(s)")
                 .selected_text(format!("{:?}", self.allowed_splits))
@@ -540,8 +558,11 @@ impl Default for MyApp {
             style: None,
             open_tabs,
 
-            show_window_close: true,
-            show_window_collapse: true,
+            show_leaf_close_all: true,
+            show_leaf_collapse: true,
+            show_secondary_button_hint: true,
+            secondary_button_on_modifier: true,
+            secondary_button_context_menu: true,
             show_close_buttons: true,
             show_add_buttons: false,
             draggable_tabs: true,
@@ -599,8 +620,11 @@ impl eframe::App for MyApp {
                     .draggable_tabs(self.context.draggable_tabs)
                     .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
                     .allowed_splits(self.context.allowed_splits)
-                    .show_window_close_buttons(self.context.show_window_close)
-                    .show_window_collapse_buttons(self.context.show_window_collapse)
+                    .show_leaf_close_all_buttons(self.context.show_leaf_close_all)
+                    .show_leaf_collapse_buttons(self.context.show_leaf_collapse)
+                    .show_secondary_button_hint(self.context.show_secondary_button_hint)
+                    .secondary_button_on_modifier(self.context.secondary_button_on_modifier)
+                    .secondary_button_context_menu(self.context.secondary_button_context_menu)
                     .show_inside(ui, &mut self.context);
             });
     }

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -146,7 +146,7 @@ impl<Tab> DockState<Tab> {
     pub fn is_surface_valid(&self, surface_index: SurfaceIndex) -> bool {
         self.surfaces
             .get(surface_index.0)
-            .map_or(false, |surface| !surface.is_empty())
+            .is_some_and(|surface| !surface.is_empty())
     }
 
     /// Returns a list of all valid [`SurfaceIndex`]es.

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -5,7 +5,7 @@ pub struct Translations {
     /// Text overrides for buttons in tab context menus.
     pub tab_context_menu: TabContextMenuTranslations,
     /// Text overrides for buttons in windows.
-    pub window: WindowTranslations,
+    pub leaf: LeafTranslations,
 }
 
 /// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
@@ -18,13 +18,38 @@ pub struct TabContextMenuTranslations {
     pub eject_button: String,
 }
 
-/// Specifies text in buttons displayed in the context menu displayed upon right-clicking on a tab.
+/// Specifies text displayed in the primary buttons on a tab bar.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct WindowTranslations {
-    /// Message in the tooltip shown while hovering over a grayed out X button of a window
+pub struct LeafTranslations {
+    /// Message in the tooltip shown while hovering over a grayed out X button of a leaf
     /// containing non-closable tabs.
-    pub close_button_tooltip: String,
+    pub close_button_disabled_tooltip: String,
+    /// Button that closes the entire window.
+    pub close_all_button: String,
+    /// Message in the tooltip shown while hovering over an X button of a window.
+    /// Used when the secondary buttons are accessible from the context menu.
+    pub close_all_button_menu_hint: String,
+    /// Message in the tooltip shown while hovering over an X button of a window.
+    /// Used when the secondary buttons are accessible using modifiers.
+    pub close_all_button_modifier_hint: String,
+    /// Message in the tooltip shown while hovering over an X button of a window.
+    /// Used when the secondary buttons are accessible using modifiers and from the context menu.
+    pub close_all_button_modifier_menu_hint: String,
+    /// Message in the tooltip shown while hovering over a grayed out close window button of a window
+    /// containing non-closable tabs.
+    pub close_all_button_disabled_tooltip: String,
+    /// Button that minimizes the window.
+    pub minimize_button: String,
+    /// Message in the tooltip shown while hovering over a collapse button of a leaf.
+    /// Used when the secondary buttons are accessible from the context menu.
+    pub minimize_button_menu_hint: String,
+    /// Message in the tooltip shown while hovering over a collapse button of a leaf.
+    /// Used when the secondary buttons are accessible using modifiers.
+    pub minimize_button_modifier_hint: String,
+    /// Message in the tooltip shown while hovering over a collapse button of a leaf.
+    /// Used when the secondary buttons are accessible using modifiers and from the context menu.
+    pub minimize_button_modifier_menu_hint: String,
 }
 
 impl Translations {
@@ -32,7 +57,7 @@ impl Translations {
     pub fn english() -> Self {
         Self {
             tab_context_menu: TabContextMenuTranslations::english(),
-            window: WindowTranslations::english(),
+            leaf: LeafTranslations::english(),
         }
     }
 }
@@ -47,11 +72,30 @@ impl TabContextMenuTranslations {
     }
 }
 
-impl WindowTranslations {
+impl LeafTranslations {
     /// Default English translations.
     pub fn english() -> Self {
         Self {
-            close_button_tooltip: String::from("This window contains non-closable tabs."),
+            close_button_disabled_tooltip: String::from("This leaf contains non-closable tabs."),
+            close_all_button: String::from("Close window"),
+            close_all_button_menu_hint: String::from("Right click to close this window."),
+            close_all_button_modifier_hint: String::from(
+                "Press modifier keys (Shift by default) to close this window.",
+            ),
+            close_all_button_modifier_menu_hint: String::from(
+                "Press modifier keys (Shift by default) or right click to close this window.",
+            ),
+            close_all_button_disabled_tooltip: String::from(
+                "This window contains non-closable tabs.",
+            ),
+            minimize_button: String::from("Minimize window"),
+            minimize_button_menu_hint: String::from("Right click to minimize this window."),
+            minimize_button_modifier_hint: String::from(
+                "Press modifier keys (Shift by default) to minimize this window.",
+            ),
+            minimize_button_modifier_menu_hint: String::from(
+                "Press modifier keys (Shift by default) or right click to minimize this window.",
+            ),
         }
     }
 }

--- a/src/dock_state/tree/tab_iter.rs
+++ b/src/dock_state/tree/tab_iter.rs
@@ -42,7 +42,7 @@ impl<'a, Tab> Iterator for TabIter<'a, Tab> {
     }
 }
 
-impl<'a, Tab> std::fmt::Debug for TabIter<'a, Tab> {
+impl<Tab> std::fmt::Debug for TabIter<'_, Tab> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TabIter").finish_non_exhaustive()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,15 +192,24 @@
 //! Example usage:
 //!
 //! ```rust
-//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations, WindowTranslations};
+//! # use egui_dock::{DockState, TabContextMenuTranslations, Translations, LeafTranslations};
 //! # type Tab = ();
 //! let translations_pl = Translations {
 //!     tab_context_menu: TabContextMenuTranslations {
 //!         close_button: "Zamknij zakładkę".to_string(),
 //!         eject_button: "Przenieś zakładkę do nowego okna".to_string(),
 //!     },
-//!     window: WindowTranslations {
-//!         close_button_tooltip: "To okno zawiera zakładki, których nie można zamknąć.".to_string(),
+//!     leaf: LeafTranslations {
+//!         close_button_disabled_tooltip: "Ten węzeł zawiera niezamykalne zakładki.".to_string(),
+//!         close_all_button: "Zamknij okno".to_string(),
+//!         close_all_button_menu_hint: "Kliknij prawym przyciskiem myszy, aby zamknąć to okno.".to_string(),
+//!         close_all_button_modifier_hint: "Naciśnij klawisze modyfikujące (domyślnie Shift), aby zamknąć to okno.".to_string(),
+//!         close_all_button_modifier_menu_hint: "Naciśnij klawisze modyfikujące (domyślnie Shift) lub kliknij prawym przyciskiem myszy, aby zamknąć to okno.".to_string(),
+//!         close_all_button_disabled_tooltip: "To okno zawiera zakładki, których nie można zamknąć.".to_string(),
+//!         minimize_button: "Zminimalizuj okno".to_string(),
+//!         minimize_button_menu_hint: "Kliknij prawym przyciskiem myszy, aby zminimalizować to okno.".to_string(),
+//!         minimize_button_modifier_hint: "Naciśnij klawisze modyfikujące (domyślnie Shift), aby zminimalizować to okno.".to_string(),
+//!         minimize_button_modifier_menu_hint: "Naciśnij klawisze modyfikujące (domyślnie Shift) lub kliknij prawym przyciskiem myszy, aby zminimalizować to okno.".to_string(),
 //!     }
 //! };
 //! let dock_state = DockState::<Tab>::new(vec![]).with_translations(translations_pl);
@@ -209,7 +218,16 @@
 //! let mut dock_state = DockState::<Tab>::new(vec![]);
 //! dock_state.translations.tab_context_menu.close_button = "タブを閉じる".to_string();
 //! dock_state.translations.tab_context_menu.eject_button = "タブを新しいウィンドウへ移動".to_string();
-//! dock_state.translations.window.close_button_tooltip = "このウィンドウは閉じられないタブがある。".to_string();
+//! dock_state.translations.leaf.close_button_disabled_tooltip = "このノードは閉じられないタブがある".to_string();
+//! dock_state.translations.leaf.close_all_button = "ウィンドウを閉じる".to_string();
+//! dock_state.translations.leaf.close_all_button_menu_hint = "右クリックでこのウィンドウを閉じる".to_string();
+//! dock_state.translations.leaf.close_all_button_modifier_hint = "修飾キー（デフォルトではShift）を押して、このウィンドウを閉じます".to_string();
+//! dock_state.translations.leaf.close_all_button_modifier_menu_hint = "修飾キー（デフォルトではShift）を押すか、右クリックしてこのウィンドウを閉じます".to_string();
+//! dock_state.translations.leaf.close_all_button_disabled_tooltip = "このウィンドウは閉じられないタブがある".to_string();
+//! dock_state.translations.leaf.minimize_button = "ウィンドウを最小化する".to_string();
+//! dock_state.translations.leaf.minimize_button_menu_hint = "右クリックでウィンドウを最小化する".to_string();
+//! dock_state.translations.leaf.minimize_button_modifier_hint = "修飾キー（デフォルトではShift）を押すと、このウィンドウが最小化されます".to_string();
+//! dock_state.translations.leaf.minimize_button_modifier_menu_hint = "修飾キー（デフォルトではShift）を押すか、右クリックしてこのウィンドウを最小化する".to_string();
 //! ```
 
 #![warn(missing_docs)]

--- a/src/style.rs
+++ b/src/style.rs
@@ -89,6 +89,45 @@ pub struct ButtonsStyle {
 
     /// Color of the add tab button's left border.
     pub add_tab_border_color: Color32,
+
+    /// Color of the close all tabs button.
+    pub close_all_tabs_color: Color32,
+
+    /// Color of the active close all tabs button.
+    pub close_all_tabs_active_color: Color32,
+
+    /// Color of the close all tabs button's background.
+    pub close_all_tabs_bg_fill: Color32,
+
+    /// Color of the close all tabs button's left border.
+    pub close_all_tabs_border_color: Color32,
+
+    /// Color of disabled close all tabs button.
+    pub close_all_tabs_disabled_color: Color32,
+
+    /// Color of the collapse tabs button.
+    pub collapse_tabs_color: Color32,
+
+    /// Color of the active collapse tabs button.
+    pub collapse_tabs_active_color: Color32,
+
+    /// Color of the collapse tabs button's background.
+    pub collapse_tabs_bg_fill: Color32,
+
+    /// Color of the collapse tabs button's left border.
+    pub collapse_tabs_border_color: Color32,
+
+    /// Color of the minimize window button.
+    pub minimize_window_color: Color32,
+
+    /// Color of the active minimize window button.
+    pub minimize_window_active_color: Color32,
+
+    /// Color of the minimize window button's background.
+    pub minimize_window_bg_fill: Color32,
+
+    /// Color of the minimize window button's left border.
+    pub minimize_window_border_color: Color32,
 }
 
 /// Specifies the look and feel of node separators.
@@ -132,11 +171,12 @@ pub struct TabBarStyle {
     /// Tab rounding. By `Default` it's [`Rounding::default`].
     pub rounding: Rounding,
 
-    /// Color of th line separating the tab name area from the tab content area.
+    /// Color of the line separating the tab name area from the tab content area.
     /// By `Default` it's [`Color32::BLACK`].
     pub hline_color: Color32,
 
     /// Whether tab titles expand to fill the width of their tab bars.
+    /// By `Default` it's `false`.
     pub fill_tab_bar: bool,
 }
 
@@ -331,6 +371,22 @@ impl Default for ButtonsStyle {
             add_tab_active_color: Color32::WHITE,
             add_tab_bg_fill: Color32::GRAY,
             add_tab_border_color: Color32::BLACK,
+
+            close_all_tabs_color: Color32::WHITE,
+            close_all_tabs_active_color: Color32::WHITE,
+            close_all_tabs_bg_fill: Color32::GRAY,
+            close_all_tabs_border_color: Color32::BLACK,
+            close_all_tabs_disabled_color: Color32::LIGHT_GRAY,
+
+            collapse_tabs_color: Color32::WHITE,
+            collapse_tabs_active_color: Color32::WHITE,
+            collapse_tabs_bg_fill: Color32::GRAY,
+            collapse_tabs_border_color: Color32::BLACK,
+
+            minimize_window_color: Color32::WHITE,
+            minimize_window_active_color: Color32::WHITE,
+            minimize_window_bg_fill: Color32::GRAY,
+            minimize_window_border_color: Color32::BLACK,
         }
     }
 }
@@ -462,6 +518,12 @@ impl Style {
     pub(crate) const TAB_ADD_PLUS_SIZE: f32 = 12.0;
     pub(crate) const TAB_CLOSE_BUTTON_SIZE: f32 = 24.0;
     pub(crate) const TAB_CLOSE_X_SIZE: f32 = 9.0;
+    pub(crate) const TAB_CLOSE_ALL_BUTTON_SIZE: f32 = 24.0;
+    pub(crate) const TAB_CLOSE_ALL_SIZE: f32 = 10.0;
+    pub(crate) const TAB_COLLAPSE_BUTTON_SIZE: f32 = 24.0;
+    pub(crate) const TAB_COLLAPSE_ARROW_SIZE: f32 = 10.0;
+    pub(crate) const TAB_EXPAND_BUTTON_SIZE: f32 = 24.0;
+    pub(crate) const TAB_EXPAND_ARROW_SIZE: f32 = 10.0;
 }
 
 impl Style {
@@ -496,6 +558,15 @@ impl ButtonsStyle {
     /// - [`ButtonsStyle::add_tab_bg_fill`]
     /// - [`ButtonsStyle::add_tab_color`]
     /// - [`ButtonsStyle::add_tab_active_color`]
+    /// - [`ButtonsStyle::add_tab_border_color`]
+    /// - [`ButtonsStyle::close_all_tabs_bg_fill`]
+    /// - [`ButtonsStyle::close_all_tabs_color`]
+    /// - [`ButtonsStyle::close_all_tabs_active_color`]
+    /// - [`ButtonsStyle::close_all_tabs_border_color`]
+    /// - [`ButtonsStyle::collapse_tabs_bg_fill`]
+    /// - [`ButtonsStyle::collapse_tabs_color`]
+    /// - [`ButtonsStyle::collapse_tabs_active_color`]
+    /// - [`ButtonsStyle::collapse_tabs_border_color`]
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             close_tab_bg_fill: style.visuals.widgets.hovered.bg_fill,
@@ -505,6 +576,19 @@ impl ButtonsStyle {
             add_tab_color: style.visuals.text_color(),
             add_tab_active_color: style.visuals.strong_text_color(),
             add_tab_border_color: style.visuals.widgets.noninteractive.bg_fill,
+            close_all_tabs_bg_fill: style.visuals.widgets.hovered.bg_fill,
+            close_all_tabs_color: style.visuals.text_color(),
+            close_all_tabs_active_color: style.visuals.strong_text_color(),
+            close_all_tabs_border_color: style.visuals.widgets.noninteractive.bg_fill,
+            close_all_tabs_disabled_color: style.visuals.widgets.inactive.bg_fill,
+            collapse_tabs_bg_fill: style.visuals.widgets.hovered.bg_fill,
+            collapse_tabs_color: style.visuals.text_color(),
+            collapse_tabs_active_color: style.visuals.strong_text_color(),
+            collapse_tabs_border_color: style.visuals.widgets.noninteractive.bg_fill,
+            minimize_window_bg_fill: style.visuals.widgets.hovered.bg_fill,
+            minimize_window_color: style.visuals.text_color(),
+            minimize_window_active_color: style.visuals.strong_text_color(),
+            minimize_window_border_color: style.visuals.widgets.noninteractive.bg_fill,
             ..ButtonsStyle::default()
         }
     }

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -349,7 +349,7 @@ impl DragDropState {
 
         self.update_lock(LockState::SoftLock, style, ui.ctx());
 
-        //Draw the overlay
+        // Draw the overlay
         match final_result {
             Some(TabDestination::Window(rect)) => {
                 let rect = self.window_preview_rect(rect);

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -13,7 +13,7 @@ use crate::{dock_state::DockState, NodeIndex, Style, SurfaceIndex, TabIndex};
 pub use allowed_splits::AllowedSplits;
 use tab_removal::TabRemoval;
 
-use egui::{emath::*, Id};
+use egui::{emath::*, Id, Modifiers};
 
 /// Displays a [`DockState`] in `egui`.
 pub struct DockArea<'tree, Tab> {
@@ -28,6 +28,12 @@ pub struct DockArea<'tree, Tab> {
     show_tab_name_on_hover: bool,
     show_window_close_buttons: bool,
     show_window_collapse_buttons: bool,
+    show_leaf_close_all_buttons: bool,
+    show_leaf_collapse_buttons: bool,
+    show_secondary_button_hint: bool,
+    secondary_button_modifiers: Modifiers,
+    secondary_button_on_modifier: bool,
+    secondary_button_context_menu: bool,
     allowed_splits: AllowedSplits,
     window_bounds: Option<Rect>,
 
@@ -60,6 +66,12 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             window_bounds: None,
             show_window_close_buttons: true,
             show_window_collapse_buttons: true,
+            show_leaf_close_all_buttons: true,
+            show_leaf_collapse_buttons: true,
+            show_secondary_button_hint: true,
+            secondary_button_modifiers: Modifiers::SHIFT,
+            secondary_button_on_modifier: true,
+            secondary_button_context_menu: true,
         }
     }
 
@@ -126,6 +138,34 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         self
     }
 
+    /// Whether tooltip hints are shown for secondary buttons on tab bars.
+    /// By default it's `true`.
+    pub fn show_secondary_button_hint(mut self, show_secondary_button_hint: bool) -> Self {
+        self.show_secondary_button_hint = show_secondary_button_hint;
+        self
+    }
+
+    /// The key combination used to activate secondary buttons on tab bars.
+    /// By default it's [`Modifiers::SHIFT`].
+    pub fn secondary_button_modifiers(mut self, secondary_button_modifiers: Modifiers) -> Self {
+        self.secondary_button_modifiers = secondary_button_modifiers;
+        self
+    }
+
+    /// Whether the secondary buttons on tab bars are activated by the modifier key.
+    /// By default it's `true`.
+    pub fn secondary_button_on_modifier(mut self, secondary_button_on_modifier: bool) -> Self {
+        self.secondary_button_on_modifier = secondary_button_on_modifier;
+        self
+    }
+
+    /// Whether the secondary buttons on tab bars are activated from a context value by right-clicking primary buttons.
+    /// By default it's `true`.
+    pub fn secondary_button_context_menu(mut self, secondary_button_context_menu: bool) -> Self {
+        self.secondary_button_context_menu = secondary_button_context_menu;
+        self
+    }
+
     /// The bounds for any windows inside the [`DockArea`]. Defaults to the screen rect.
     /// By default it's set to [`egui::Context::screen_rect`].
     #[inline(always)]
@@ -137,16 +177,34 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     /// Enables or disables the close button on windows.
     /// By default it's `true`.
     #[inline(always)]
+    #[deprecated = "consider using `show_leaf_close_buttons` instead."]
     pub fn show_window_close_buttons(mut self, show_window_close_buttons: bool) -> Self {
         self.show_window_close_buttons = show_window_close_buttons;
         self
     }
 
-    /// Enables or disables the collapsing header  on windows.
+    /// Enables or disables the collapsing header on windows.
     /// By default it's `true`.
     #[inline(always)]
+    #[deprecated = "consider using `show_leaf_collapse_buttons` instead."]
     pub fn show_window_collapse_buttons(mut self, show_window_collapse_buttons: bool) -> Self {
         self.show_window_collapse_buttons = show_window_collapse_buttons;
+        self
+    }
+
+    /// Enables or disables the close all tabs button on tab bars.
+    /// By default it's `true`.
+    #[inline(always)]
+    pub fn show_leaf_close_all_buttons(mut self, show_leaf_close_all_buttons: bool) -> Self {
+        self.show_leaf_close_all_buttons = show_leaf_close_all_buttons;
+        self
+    }
+
+    /// Enables or disables the collapse tabs button on tab bars.
+    /// By default it's `true`.
+    #[inline(always)]
+    pub fn show_leaf_collapse_buttons(mut self, show_leaf_collapse_buttons: bool) -> Self {
+        self.show_leaf_collapse_buttons = show_leaf_collapse_buttons;
         self
     }
 }

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -209,7 +209,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     }
 }
 
-impl<'tree, Tab> std::fmt::Debug for DockArea<'tree, Tab> {
+impl<Tab> std::fmt::Debug for DockArea<'_, Tab> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DockArea").finish_non_exhaustive()
     }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1,12 +1,12 @@
+use egui::{
+    emath::TSTransform, epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, Color32,
+    CursorIcon, Frame, Id, Key, LayerId, Layout, NumExt, Order, Rect, Response, Rounding,
+    ScrollArea, Sense, Shape, Stroke, TextStyle, Ui, UiBuilder, Vec2, WidgetText,
+};
+use std::convert::identity;
 use std::ops::RangeInclusive;
 
-use egui::emath::TSTransform;
-use egui::{
-    epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, CursorIcon, Frame, Id, Key,
-    LayerId, Layout, NumExt, Order, Rect, Response, Rounding, ScrollArea, Sense, Stroke, TextStyle,
-    Ui, UiBuilder, Vec2, WidgetText,
-};
-
+use crate::dock_area::tab_removal::TabRemoval;
 use crate::{
     dock_area::{
         drag_and_drop::{DragData, DragDropState, HoverData, TreeComponent},
@@ -28,6 +28,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         fade_style: Option<(&Style, f32)>,
     ) {
         assert!(self.dock_state[surface_index][node_index].is_leaf());
+        let collapsed = self.dock_state[surface_index][node_index].is_collapsed();
 
         let rect = self.dock_state[surface_index][node_index]
             .rect()
@@ -42,12 +43,16 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         ui.spacing_mut().item_spacing = Vec2::ZERO;
         ui.set_clip_rect(rect);
 
+        if self.dock_state[surface_index][node_index].tabs_count() == 0 {
+            return;
+        }
         let tabbar_rect = self.tab_bar(
             ui,
             state,
             (surface_index, node_index),
             tab_viewer,
             fade_style.map(|(style, _)| style),
+            collapsed,
         );
         self.tab_body(
             ui,
@@ -57,6 +62,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             spacing,
             tabbar_rect,
             fade_style,
+            collapsed,
         );
 
         let tabs = self.dock_state[surface_index][node_index]
@@ -77,6 +83,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         (surface_index, node_index): (SurfaceIndex, NodeIndex),
         tab_viewer: &mut impl TabViewer<Tab = Tab>,
         fade_style: Option<&Style>,
+        collapsed: bool,
     ) -> Rect {
         assert!(self.dock_state[surface_index][node_index].is_leaf());
 
@@ -92,13 +99,23 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         );
 
         let mut available_width = tabbar_outer_rect.width();
+        let scroll_bar_width = available_width;
         if available_width == 0.0 {
             return tabbar_outer_rect;
         }
 
-        // Reserve space for the add button at the end of the tab bar.
+        // Reserve space for the buttons at the ends of the tab bar.
+
         if self.show_add_buttons {
             available_width -= Style::TAB_ADD_BUTTON_SIZE;
+        }
+
+        if self.show_leaf_close_all_buttons {
+            available_width -= Style::TAB_CLOSE_ALL_BUTTON_SIZE;
+        }
+
+        if self.show_leaf_collapse_buttons {
+            available_width -= Style::TAB_COLLAPSE_BUTTON_SIZE;
         }
 
         let actual_width = {
@@ -108,7 +125,16 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             };
 
             let tabbar_inner_rect = Rect::from_min_size(
-                (tabbar_outer_rect.min - pos2(-*scroll, 0.0)).to_pos2(),
+                (tabbar_outer_rect.min - pos2(-*scroll, 0.0)
+                    + vec2(
+                        if self.show_leaf_collapse_buttons {
+                            Style::TAB_COLLAPSE_BUTTON_SIZE
+                        } else {
+                            0.0
+                        },
+                        0.0,
+                    ))
+                .to_pos2(),
                 vec2(tabbar_outer_rect.width(), tabbar_outer_rect.height()),
             );
 
@@ -121,6 +147,9 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
 
             let mut clip_rect = tabbar_outer_rect;
             clip_rect.set_width(available_width);
+            if self.show_leaf_collapse_buttons {
+                clip_rect = clip_rect.translate(vec2(Style::TAB_COLLAPSE_BUTTON_SIZE, 0.0));
+            }
             tabs_ui.set_clip_rect(clip_rect);
 
             // Desired size for tabs in "expanded" mode.
@@ -149,13 +178,17 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 (px, style.tab_bar.hline_color),
             );
 
-            // Add button at the end of the tab bar.
+            // Add button at the ends of the tab bar.
             if self.show_add_buttons {
                 let offset = match style.buttons.add_tab_align {
                     TabAddAlign::Left => {
                         (clip_rect.width() - tabs_ui.min_rect().width()).at_least(0.0)
                     }
                     TabAddAlign::Right => 0.0,
+                } + if self.show_leaf_close_all_buttons {
+                    Style::TAB_CLOSE_ALL_BUTTON_SIZE
+                } else {
+                    0.0
                 };
                 self.tab_plus(
                     ui,
@@ -168,6 +201,56 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 );
             }
 
+            if self.show_leaf_close_all_buttons {
+                // Current leaf contains non-closable tabs.
+                let disabled = if let Node::Leaf { tabs, .. } =
+                    &mut self.dock_state[surface_index][node_index]
+                {
+                    !tabs
+                        .iter_mut()
+                        .map(|tab| tab_viewer.closeable(tab))
+                        .all(identity)
+                } else {
+                    unreachable!()
+                };
+
+                // Current window contains non-closable tabs.
+                let close_window_disabled = disabled
+                    || !self.dock_state[surface_index]
+                        .iter_mut()
+                        .map(|node| {
+                            if let Node::Leaf { tabs, .. } = node {
+                                tabs.iter_mut()
+                                    .map(|tab| tab_viewer.closeable(tab))
+                                    .all(identity)
+                            } else {
+                                true
+                            }
+                        })
+                        .all(identity);
+
+                self.tab_close_all(
+                    ui,
+                    surface_index,
+                    node_index,
+                    tabbar_outer_rect,
+                    fade_style,
+                    disabled,
+                    close_window_disabled,
+                )
+            }
+
+            if self.show_leaf_collapse_buttons {
+                self.tab_collapse(
+                    ui,
+                    surface_index,
+                    node_index,
+                    tabbar_outer_rect,
+                    fade_style,
+                    collapsed,
+                )
+            }
+
             tabs_ui.min_rect().width()
         };
 
@@ -177,6 +260,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             (surface_index, node_index),
             actual_width,
             available_width,
+            scroll_bar_width,
             &tabbar_response,
             fade_style,
         );
@@ -416,6 +500,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         }
     }
 
+    /// Draws the tab add button.
     #[allow(clippy::too_many_arguments)]
     fn tab_plus(
         &mut self,
@@ -488,6 +573,378 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         }
     }
 
+    /// Draws the close all button.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(unused_assignments)]
+    fn tab_close_all(
+        &mut self,
+        ui: &mut Ui,
+        surface_index: SurfaceIndex,
+        node_index: NodeIndex,
+        tabbar_outer_rect: Rect,
+        fade_style: Option<&Style>,
+        disabled: bool,
+        close_window_disabled: bool,
+    ) {
+        let rect = Rect::from_min_max(
+            tabbar_outer_rect.right_top() - vec2(Style::TAB_CLOSE_ALL_BUTTON_SIZE, 0.0),
+            tabbar_outer_rect.right_bottom() - vec2(0.0, 2.0),
+        );
+
+        let ui = &mut ui.new_child(
+            UiBuilder::new()
+                .max_rect(rect)
+                .layout(Layout::left_to_right(Align::Center))
+                .id_salt((node_index, "tab_close_all")),
+        );
+
+        let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
+
+        let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
+
+        // Whether we're on "secondary button mode" due to modifier keys
+        let on_secondary_button = self.is_on_secondary_button(surface_index, ui, &response);
+
+        let mut stroke_color = if disabled {
+            style.buttons.close_all_tabs_disabled_color
+        } else if response.hovered() || response.has_focus() {
+            if !(close_window_disabled && on_secondary_button) {
+                ui.painter().rect_filled(
+                    rect,
+                    Rounding::ZERO,
+                    style.buttons.close_all_tabs_bg_fill,
+                );
+            }
+            style.buttons.close_all_tabs_active_color
+        } else {
+            style.buttons.close_all_tabs_color
+        };
+
+        let mut close_all_rect = rect;
+
+        rect_set_size_centered(&mut close_all_rect, Vec2::splat(Style::TAB_CLOSE_ALL_SIZE));
+
+        if !disabled {
+            response = response.on_hover_cursor(CursorIcon::PointingHand);
+        }
+
+        if on_secondary_button {
+            // Close the entire window
+            if close_window_disabled {
+                stroke_color = style.buttons.close_all_tabs_disabled_color;
+                response = response
+                    .on_hover_cursor(CursorIcon::NotAllowed)
+                    .on_hover_text(
+                        self.dock_state
+                            .translations
+                            .leaf
+                            .close_all_button_disabled_tooltip
+                            .as_str(),
+                    );
+            }
+            Self::draw_close_window_symbol(ui, stroke_color, close_all_rect);
+        } else {
+            // Close all tabs in this leaf
+            if !disabled {
+                if !surface_index.is_main() && self.secondary_button_context_menu {
+                    response.context_menu(|ui| {
+                        ui.add_enabled_ui(!close_window_disabled, |ui| {
+                            if ui
+                                .button(&self.dock_state.translations.leaf.close_all_button)
+                                .on_disabled_hover_text(
+                                    self.dock_state
+                                        .translations
+                                        .leaf
+                                        .close_all_button_disabled_tooltip
+                                        .as_str(),
+                                )
+                                .clicked()
+                            {
+                                self.to_remove.push(TabRemoval::Window(surface_index));
+                            }
+                        });
+                    });
+                }
+            } else {
+                response = response
+                    .on_hover_cursor(CursorIcon::NotAllowed)
+                    .on_hover_text(
+                        self.dock_state
+                            .translations
+                            .leaf
+                            .close_button_disabled_tooltip
+                            .as_str(),
+                    );
+            }
+
+            if response.clicked() {
+                if on_secondary_button {
+                    if !close_window_disabled {
+                        self.to_remove.push(TabRemoval::Window(surface_index));
+                    }
+                } else if !disabled {
+                    self.to_remove.push((surface_index, node_index).into());
+                }
+            }
+
+            ui.painter().line_segment(
+                [close_all_rect.left_top(), close_all_rect.right_bottom()],
+                Stroke::new(1.0, stroke_color),
+            );
+            ui.painter().line_segment(
+                [close_all_rect.right_top(), close_all_rect.left_bottom()],
+                Stroke::new(1.0, stroke_color),
+            );
+        }
+
+        // Draw button left border.
+        ui.painter().vline(
+            rect.left(),
+            rect.y_range(),
+            Stroke::new(
+                ui.ctx().pixels_per_point().recip(),
+                style.buttons.close_all_tabs_border_color,
+            ),
+        );
+
+        if !disabled && !on_secondary_button {
+            response = self.show_tooltip_hints(surface_index, response);
+        }
+    }
+
+    /// Draws the collapse button.
+    fn tab_collapse(
+        &mut self,
+        ui: &mut Ui,
+        surface_index: SurfaceIndex,
+        node_index: NodeIndex,
+        tabbar_outer_rect: Rect,
+        fade_style: Option<&Style>,
+        collapsed: bool,
+    ) {
+        let rect = Rect::from_min_max(
+            tabbar_outer_rect.left_top(),
+            tabbar_outer_rect.left_bottom() + vec2(Style::TAB_COLLAPSE_BUTTON_SIZE, 0.0),
+        );
+
+        let ui = &mut ui.new_child(
+            UiBuilder::new()
+                .max_rect(rect)
+                .layout(Layout::left_to_right(Align::Center))
+                .id_salt((node_index, "tab_collapse")),
+        );
+
+        let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
+
+        response = response.on_hover_cursor(CursorIcon::PointingHand);
+
+        let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
+
+        // Whether we're on "secondary button mode" due to modifier keys
+        let on_secondary_button = self.is_on_secondary_button(surface_index, ui, &response);
+
+        let color = if response.hovered() || response.has_focus() {
+            ui.painter()
+                .rect_filled(rect, Rounding::ZERO, style.buttons.collapse_tabs_bg_fill);
+            style.buttons.collapse_tabs_active_color
+        } else {
+            style.buttons.collapse_tabs_color
+        };
+
+        let mut arrow_rect = rect;
+        rect_set_size_centered(&mut arrow_rect, Vec2::splat(Style::TAB_COLLAPSE_ARROW_SIZE));
+
+        if on_secondary_button {
+            // Collapse the entire window
+            Self::draw_chevron_down(ui, style, color, arrow_rect);
+        } else {
+            // Draw arrow.
+            Self::draw_arrow(collapsed, ui, color, arrow_rect);
+        }
+
+        // Draw button right border.
+        ui.painter().vline(
+            rect.right(),
+            rect.y_range(),
+            Stroke::new(
+                ui.ctx().pixels_per_point().recip(),
+                style.buttons.collapse_tabs_border_color,
+            ),
+        );
+
+        if response.clicked() {
+            if on_secondary_button {
+                self.window_toggle_minimized(surface_index);
+            } else {
+                self.dock_state[surface_index][node_index].set_collapsed(!collapsed);
+                self.dock_state[surface_index].node_update_collapsed(node_index);
+                self.window_update_collapsed(surface_index, node_index);
+            }
+        }
+
+        if !surface_index.is_main() && self.secondary_button_context_menu {
+            response.context_menu(|ui| {
+                if ui
+                    .button(&self.dock_state.translations.leaf.minimize_button)
+                    .clicked()
+                {
+                    ui.close_menu();
+                    self.window_toggle_minimized(surface_index);
+                }
+            });
+        }
+
+        if !on_secondary_button {
+            self.show_tooltip_hints(surface_index, response);
+        }
+    }
+
+    fn show_tooltip_hints(&mut self, surface_index: SurfaceIndex, response: Response) -> Response {
+        if !surface_index.is_main()
+            && self.show_secondary_button_hint
+            && (self.secondary_button_context_menu || self.secondary_button_on_modifier)
+        {
+            let hint = if self.secondary_button_context_menu && self.secondary_button_on_modifier {
+                &self
+                    .dock_state
+                    .translations
+                    .leaf
+                    .minimize_button_modifier_menu_hint
+            } else if self.secondary_button_context_menu {
+                &self.dock_state.translations.leaf.minimize_button_menu_hint
+            } else {
+                &self
+                    .dock_state
+                    .translations
+                    .leaf
+                    .minimize_button_modifier_hint
+            };
+            return response.on_hover_text(hint);
+        }
+        response
+    }
+
+    fn is_on_secondary_button(
+        &self,
+        surface_index: SurfaceIndex,
+        ui: &mut Ui,
+        response: &Response,
+    ) -> bool {
+        !surface_index.is_main()
+            && self.secondary_button_on_modifier
+            && ui.input(|i| {
+                i.modifiers
+                    .matches_logically(self.secondary_button_modifiers)
+            })
+            && (response.hovered() || response.has_focus() || response.is_pointer_button_down_on())
+    }
+
+    fn draw_close_window_symbol(ui: &mut Ui, stroke_color: Color32, close_all_rect: Rect) {
+        ui.painter().add(Shape::line(
+            vec![
+                close_all_rect
+                    .right_center()
+                    .lerp(close_all_rect.right_bottom(), 0.5),
+                close_all_rect.right_bottom(),
+                close_all_rect.left_bottom(),
+                close_all_rect.left_top(),
+                close_all_rect
+                    .center_top()
+                    .lerp(close_all_rect.left_top(), 0.5),
+            ],
+            Stroke::new(1.0, stroke_color),
+        ));
+        ui.painter().line_segment(
+            [close_all_rect.center_top(), close_all_rect.right_center()],
+            Stroke::new(1.0, stroke_color),
+        );
+        ui.painter().line_segment(
+            [close_all_rect.center(), close_all_rect.right_top()],
+            Stroke::new(1.0, stroke_color),
+        );
+    }
+
+    fn draw_arrow(collapsed: bool, ui: &mut Ui, color: Color32, arrow_rect: Rect) {
+        ui.painter().add(Shape::convex_polygon(
+            if collapsed {
+                // Arrow pointing rightwards.
+                vec![
+                    arrow_rect.left_top(),
+                    arrow_rect.right_center(),
+                    arrow_rect.left_bottom(),
+                ]
+            } else {
+                // Arrow pointing downwards.
+                vec![
+                    arrow_rect.left_top(),
+                    arrow_rect.right_top(),
+                    arrow_rect.center_bottom(),
+                ]
+            },
+            color,
+            Stroke::NONE,
+        ));
+    }
+
+    fn draw_chevron_down(ui: &mut Ui, style: &Style, color: Color32, arrow_rect: Rect) {
+        ui.painter().add(Shape::convex_polygon(
+            // Arrow pointing downwards.
+            vec![
+                arrow_rect.left_top(),
+                arrow_rect.right_top(),
+                arrow_rect.center(),
+            ],
+            color,
+            Stroke::NONE,
+        ));
+
+        // Chevron pointing downwards.
+        ui.painter().add(Shape::convex_polygon(
+            vec![
+                arrow_rect.left_center(),
+                arrow_rect.right_center(),
+                arrow_rect.center_bottom(),
+            ],
+            color,
+            Stroke::NONE,
+        ));
+        let color = style.buttons.minimize_window_bg_fill;
+        ui.painter().add(Shape::convex_polygon(
+            vec![
+                arrow_rect
+                    .left_center()
+                    .lerp(arrow_rect.right_center(), 0.25),
+                arrow_rect
+                    .left_center()
+                    .lerp(arrow_rect.right_center(), 0.75),
+                arrow_rect.center().lerp(arrow_rect.center_bottom(), 0.5),
+            ],
+            color,
+            Stroke::NONE,
+        ));
+    }
+
+    /// Updates the collapsed state of the node and its parents.
+    fn window_update_collapsed(&mut self, surface_index: SurfaceIndex, node_index: NodeIndex) {
+        let surface = &mut self.dock_state[surface_index];
+        let collapsed = surface[node_index].is_collapsed();
+        if !collapsed {
+            if let Some(window_state) = self.dock_state.get_window_state_mut(surface_index) {
+                window_state.set_new(true);
+            }
+        } else if surface.root_node().is_some_and(|root| root.is_collapsed()) {
+            let root_index = NodeIndex::root();
+            let surface_height = if surface.root_node().is_some() {
+                surface[root_index].rect().unwrap().height()
+            } else {
+                0.0
+            };
+            if let Some(window_state) = self.dock_state.get_window_state_mut(surface_index) {
+                window_state.set_expanded_height(surface_height);
+            }
+        }
+    }
+
     /// * `active` means "the tab that is opened in the parent panel".
     /// * `focused` means "the tab that was last interacted with".
     ///
@@ -526,7 +983,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let (_, tab_rect) = ui.allocate_space(vec2(tab_width, ui.available_height()));
         let mut response = ui.interact(tab_rect, id, Sense::click_and_drag());
         if ui.ctx().dragged_id().is_none() && self.draggable_tabs {
-            response = response.on_hover_cursor(CursorIcon::PointingHand);
+            response = response.on_hover_cursor(CursorIcon::Grab);
         }
 
         let tab_style = if focused || is_being_dragged {
@@ -634,6 +1091,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         (surface_index, node_index): (SurfaceIndex, NodeIndex),
         actual_width: f32,
         available_width: f32,
+        scroll_bar_width: f32,
         tabbar_response: &Response,
         fade_style: Option<&Style>,
     ) {
@@ -652,7 +1110,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 // Draw scroll bar
                 let bar_height = 7.5;
                 let (scroll_bar_rect, _scroll_bar_response) = ui.allocate_exact_size(
-                    vec2(available_width, bar_height),
+                    vec2(scroll_bar_width, bar_height),
                     Sense::click_and_drag(),
                 );
 
@@ -722,6 +1180,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         spacing: Vec2,
         tabbar_rect: Rect,
         fade: Option<(&Style, f32)>,
+        collapsed: bool,
     ) {
         let (body_rect, _body_response) =
             ui.allocate_exact_size(ui.available_size_before_wrap(), Sense::hover());
@@ -737,74 +1196,79 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             unreachable!();
         };
 
-        if let Some(tab) = tabs.get_mut(active.0) {
-            *viewport = body_rect;
+        if !collapsed {
+            if let Some(tab) = tabs.get_mut(active.0) {
+                *viewport = body_rect;
 
-            if ui.input(|i| i.pointer.any_click()) {
-                if let Some(pos) = state.last_hover_pos {
-                    if body_rect.contains(pos) && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos) {
-                        self.new_focused = Some((surface_index, node_index));
+                if ui.input(|i| i.pointer.any_click()) {
+                    if let Some(pos) = state.last_hover_pos {
+                        if body_rect.contains(pos)
+                            && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
+                        {
+                            self.new_focused = Some((surface_index, node_index));
+                        }
                     }
                 }
-            }
 
-            let (style, fade_factor) = fade.unwrap_or_else(|| (self.style.as_ref().unwrap(), 1.0));
-            let tabs_styles = tab_viewer.tab_style_override(tab, &style.tab);
+                let (style, fade_factor) =
+                    fade.unwrap_or_else(|| (self.style.as_ref().unwrap(), 1.0));
+                let tabs_styles = tab_viewer.tab_style_override(tab, &style.tab);
 
-            let tabs_style = tabs_styles.as_ref().unwrap_or(&style.tab);
+                let tabs_style = tabs_styles.as_ref().unwrap_or(&style.tab);
 
-            if tab_viewer.clear_background(tab) {
-                ui.painter().rect_filled(
-                    body_rect,
-                    tabs_style.tab_body.rounding,
-                    tabs_style.tab_body.bg_fill,
+                if tab_viewer.clear_background(tab) {
+                    ui.painter().rect_filled(
+                        body_rect,
+                        tabs_style.tab_body.rounding,
+                        tabs_style.tab_body.bg_fill,
+                    );
+                }
+
+                // Construct a new ui with the correct tab id.
+                //
+                // We are forced to use `Ui::new` because other methods (eg: push_id) always mix
+                // the provided id with their own which would cause tabs to change id when moved
+                // from node to node.
+                let id = self.id.with(tab_viewer.id(tab));
+                ui.ctx().check_for_id_clash(id, body_rect, "a tab with id");
+                let ui = &mut Ui::new(
+                    ui.ctx().clone(),
+                    ui.layer_id(),
+                    id,
+                    UiBuilder::new().max_rect(body_rect),
                 );
+                ui.set_clip_rect(Rect::from_min_max(ui.cursor().min, ui.clip_rect().max));
+
+                // Use initial spacing for ui.
+                ui.spacing_mut().item_spacing = spacing;
+
+                // Offset the background rectangle up to hide the top border behind the clip rect.
+                // To avoid anti-aliasing lines when the stroke width is not divisible by two, we
+                // need to calculate the effective anti-aliased stroke width.
+                let effective_stroke_width = (tabs_style.tab_body.stroke.width / 2.0).ceil() * 2.0;
+                let tab_body_rect = Rect::from_min_max(
+                    ui.clip_rect().min - vec2(0.0, effective_stroke_width),
+                    ui.clip_rect().max,
+                );
+                ui.painter().rect_stroke(
+                    rect_stroke_box(tab_body_rect, tabs_style.tab_body.stroke.width),
+                    tabs_style.tab_body.rounding,
+                    tabs_style.tab_body.stroke,
+                );
+
+                ScrollArea::new(tab_viewer.scroll_bars(tab)).show(ui, |ui| {
+                    Frame::none()
+                        .inner_margin(tabs_style.tab_body.inner_margin)
+                        .show(ui, |ui| {
+                            if fade_factor != 1.0 {
+                                fade_visuals(ui.visuals_mut(), fade_factor);
+                            }
+                            let available_rect = ui.available_rect_before_wrap();
+                            ui.expand_to_include_rect(available_rect);
+                            tab_viewer.ui(ui, tab);
+                        });
+                });
             }
-
-            // Construct a new ui with the correct tab id.
-            //
-            // We are forced to use `Ui::new` because other methods (eg: push_id) always mix
-            // the provided id with their own which would cause tabs to change id when moved
-            // from node to node.
-            let id = self.id.with(tab_viewer.id(tab));
-            ui.ctx().check_for_id_clash(id, body_rect, "a tab with id");
-            let ui = &mut Ui::new(
-                ui.ctx().clone(),
-                ui.layer_id(),
-                id,
-                UiBuilder::new().max_rect(body_rect),
-            );
-            ui.set_clip_rect(Rect::from_min_max(ui.cursor().min, ui.clip_rect().max));
-
-            // Use initial spacing for ui.
-            ui.spacing_mut().item_spacing = spacing;
-
-            // Offset the background rectangle up to hide the top border behind the clip rect.
-            // To avoid anti-aliasing lines when the stroke width is not divisible by two, we
-            // need to calculate the effective anti-aliased stroke width.
-            let effective_stroke_width = (tabs_style.tab_body.stroke.width / 2.0).ceil() * 2.0;
-            let tab_body_rect = Rect::from_min_max(
-                ui.clip_rect().min - vec2(0.0, effective_stroke_width),
-                ui.clip_rect().max,
-            );
-            ui.painter().rect_stroke(
-                rect_stroke_box(tab_body_rect, tabs_style.tab_body.stroke.width),
-                tabs_style.tab_body.rounding,
-                tabs_style.tab_body.stroke,
-            );
-
-            ScrollArea::new(tab_viewer.scroll_bars(tab)).show(ui, |ui| {
-                Frame::none()
-                    .inner_margin(tabs_style.tab_body.inner_margin)
-                    .show(ui, |ui| {
-                        if fade_factor != 1.0 {
-                            fade_visuals(ui.visuals_mut(), fade_factor);
-                        }
-                        let available_rect = ui.available_rect_before_wrap();
-                        ui.expand_to_include_rect(available_rect);
-                        tab_viewer.ui(ui, tab);
-                    });
-            });
         }
 
         // change hover destination

--- a/src/widgets/dock_area/show/main_surface.rs
+++ b/src/widgets/dock_area/show/main_surface.rs
@@ -8,7 +8,7 @@ use crate::{
     DockArea, SurfaceIndex, TabViewer,
 };
 
-impl<'tree, Tab> DockArea<'tree, Tab> {
+impl<Tab> DockArea<'_, Tab> {
     pub(super) fn show_root_surface_inside(
         &mut self,
         ui: &mut Ui,

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -18,7 +18,7 @@ mod leaf;
 mod main_surface;
 mod window_surface;
 
-impl<'tree, Tab> DockArea<'tree, Tab> {
+impl<Tab> DockArea<'_, Tab> {
     /// Show the `DockArea` at the top level.
     ///
     /// This is the same as doing:

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -137,6 +137,12 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                         self.dock_state.remove_surface(surface);
                     }
                 }
+                TabRemoval::Leaf(surface, node) => {
+                    self.dock_state[surface].remove_leaf(node);
+                    if self.dock_state[surface].is_empty() && !surface.is_main() {
+                        self.dock_state.remove_surface(surface);
+                    }
+                }
                 TabRemoval::Window(index) => {
                     self.dock_state.remove_surface(index);
                 }
@@ -335,13 +341,74 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
         let style = self.style.as_ref().unwrap();
         let pixels_per_point = ui.ctx().pixels_per_point();
 
+        let left_collapsed_count =
+            self.dock_state[surface_index][node_index.left()].collapsed_leaf_count();
+        let right_collapsed_count =
+            self.dock_state[surface_index][node_index.right()].collapsed_leaf_count();
+        let left_collapsed = self.dock_state[surface_index][node_index.left()].is_collapsed();
+        let right_collapsed = self.dock_state[surface_index][node_index.right()].is_collapsed();
+
+        if left_collapsed || right_collapsed {
+            if let Node::Vertical { rect, .. } = &mut self.dock_state[surface_index][node_index] {
+                debug_assert!(!rect.any_nan() && rect.is_finite());
+                let rect = expand_to_pixel(*rect, pixels_per_point);
+
+                if left_collapsed {
+                    // EITHER only left collapsed OR left and right both collapsed
+                    let border_y =
+                        rect.min.y + (left_collapsed_count as f32) * style.tab_bar.height;
+                    let left_separator_border = map_to_pixel(
+                        border_y - style.separator.width * 0.5,
+                        pixels_per_point,
+                        f32::round,
+                    );
+                    let right_separator_border = map_to_pixel(
+                        border_y + style.separator.width * 0.5,
+                        pixels_per_point,
+                        f32::round,
+                    );
+                    let left = rect
+                        .intersect(Rect::everything_above(left_separator_border))
+                        .intersect(max_rect);
+                    let right = rect
+                        .intersect(Rect::everything_below(right_separator_border))
+                        .intersect(max_rect);
+                    self.dock_state[surface_index][node_index.left()].set_rect(left);
+                    self.dock_state[surface_index][node_index.right()].set_rect(right);
+                } else {
+                    // Only right collapsed
+                    let border_y =
+                        rect.max.y - (right_collapsed_count as f32) * style.tab_bar.height;
+                    let left_separator_border = map_to_pixel(
+                        border_y - style.separator.width * 0.5,
+                        pixels_per_point,
+                        f32::round,
+                    );
+                    let right_separator_border = map_to_pixel(
+                        border_y + style.separator.width * 0.5,
+                        pixels_per_point,
+                        f32::round,
+                    );
+                    let left = rect
+                        .intersect(Rect::everything_above(left_separator_border))
+                        .intersect(max_rect);
+                    let right = rect
+                        .intersect(Rect::everything_below(right_separator_border))
+                        .intersect(max_rect);
+                    self.dock_state[surface_index][node_index.left()].set_rect(left);
+                    self.dock_state[surface_index][node_index.right()].set_rect(right);
+                }
+                return;
+            }
+        }
+
         duplicate! {
             [
                 orientation   dim_point  dim_size  left_of    right_of;
                 [Horizontal]  [x]        [width]   [left_of]  [right_of];
                 [Vertical]    [y]        [height]  [above]    [below];
             ]
-            if let Node::orientation { fraction, rect } = &mut self.dock_state[surface_index][node_index] {
+            if let Node::orientation { fraction, rect, .. } = &mut self.dock_state[surface_index][node_index] {
                 debug_assert!(!rect.any_nan() && rect.is_finite());
                 let rect = expand_to_pixel(*rect, pixels_per_point);
 
@@ -376,6 +443,14 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     ) {
         assert!(self.dock_state[surface_index][node_index].is_parent());
 
+        // If either of the children is collapsed, we don't want the user to interact with the separator
+        if (self.dock_state[surface_index][node_index.left()].is_collapsed()
+            || self.dock_state[surface_index][node_index.right()].is_collapsed())
+            && self.dock_state[surface_index][node_index].is_vertical()
+        {
+            return;
+        }
+
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let pixels_per_point = ui.ctx().pixels_per_point();
 
@@ -385,7 +460,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
                 [Horizontal]  [x]        [width];
                 [Vertical]    [y]        [height];
             ]
-            if let Node::orientation { fraction, ref rect } = &mut self.dock_state[surface_index][node_index] {
+            if let Node::orientation { fraction, ref rect, .. } = &mut self.dock_state[surface_index][node_index] {
                 let mut separator = *rect;
 
                 let midpoint = rect.min.dim_point + rect.dim_size() * *fraction;

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -9,7 +9,7 @@ use crate::{
     DockArea, Node, NodeIndex, Style, SurfaceIndex, TabViewer,
 };
 
-impl<'tree, Tab> DockArea<'tree, Tab> {
+impl<Tab> DockArea<'_, Tab> {
     pub(super) fn show_window_surface(
         &mut self,
         ui: &Ui,

--- a/src/widgets/dock_area/tab_removal.rs
+++ b/src/widgets/dock_area/tab_removal.rs
@@ -4,12 +4,19 @@ use crate::{NodeIndex, SurfaceIndex, TabIndex};
 #[derive(Debug, Clone, Copy)]
 pub(super) enum TabRemoval {
     Node(SurfaceIndex, NodeIndex, TabIndex),
+    Leaf(SurfaceIndex, NodeIndex),
     Window(SurfaceIndex),
 }
 
 impl From<SurfaceIndex> for TabRemoval {
     fn from(index: SurfaceIndex) -> Self {
         TabRemoval::Window(index)
+    }
+}
+
+impl From<(SurfaceIndex, NodeIndex)> for TabRemoval {
+    fn from((si, ni): (SurfaceIndex, NodeIndex)) -> TabRemoval {
+        TabRemoval::Leaf(si, ni)
     }
 }
 


### PR DESCRIPTION
## 0.15.0 - 28-12-2024

### Changed

- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
  - Each leaf can now be collapsed / closed individually. They are introduced as additional tab bar controls.
  - Undocked windows are now more compact. The original undocked window controls are now accessible as "secondary buttons" from the tab bar.
    - By default, the secondary buttons are activated from primary buttons either by holding the <kbd>Shift</kbd> key while clicking on them, or from a context menu by right-clicking them.
  - A number of tooltip hints are on by default as guides to the new behavior, but they can be disabled.
  - There has been an overhaul to the internal codebase to support the new features.

### Added

- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
  - `DockArea::show_leaf_close_all_buttons` – shows a close all button which closes all open tabs in a leaf.
  - `DockArea::show_leaf_collapse_buttons` – shows a collapsing button which collapses a leaf (no longer collapsing a window).
  - `DockArea::show_secondary_button_hint` – sets whether tooltip hints are shown for secondary buttons on tab bars.
  - `DockArea::show_leaf_collapse_buttons` – shows a collapsing button which collapses a leaf (no longer collapsing a window).
  - `DockArea::secondary_button_on_modifier` – sets whether the secondary buttons on tab bars are activated by the modifier key.
  - `DockArea::secondary_button_context_menu` – sets whether the secondary buttons on tab bars are activated from a context value by right-clicking primary buttons.
  - Added the following translations:
    - `LeafTranslations::close_all_button`
    - `LeafTranslations::close_all_button_menu_hint`
    - `LeafTranslations::close_all_button_modifier_hint`
    - `LeafTranslations::close_all_button_modifier_menu_hint`
    - `LeafTranslations::close_all_button_disabled_tooltip`
    - `LeafTranslations::minimize_button`
    - `LeafTranslations::minimize_button_menu_hint`
    - `LeafTranslations::minimize_button_modifier_hint`
    - `LeafTranslations::minimize_button_modifier_menu_hint`
  - `Node::is_collapsed` – returns whether the `Node` is collapsed.
  - `Node::collapsed_leaf_count` – returns the number of collapsed layers of leaf subnodes.
  - `Node::set_collapsed` – set the collapsing state of the `Node`.
  - `Node::set_collapsed_leaf_count` – sets the number of collapsed layers of leaf subnodes.
  - `WindowState::minimized` field – records whether a window is minimized.
  - `WindowState::expanded_height` field – records the height of the window before it was fully collapsed.
  - Added style configuration for the two buttons:
    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_color`
    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_active_color`
    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_bg_fill`
    - `ButtonsStyle::{close_all_tabs, collapse_tabs, minimize_window}_border_color`
    - `ButtonsStyle::close_all_tabs_disabled_color`
    - `Style::TAB_CLOSE_ALL_BUTTON_SIZE`
    - `Style::TAB_CLOSE_ALL_SIZE`
    - `Style::TAB_COLLAPSE_BUTTON_SIZE`
    - `Style::TAB_COLLAPSE_ARROW_SIZE`
    - `Style::TAB_EXPAND_BUTTON_SIZE`
    - `Style::TAB_EXPAND_ARROW_SIZE`

### Breaking changes

- From ([#237](https://github.com/Adanos020/egui_dock/pull/237)):
  - Renamed `Translations::WindowTranslations` to `Translations::LeafTranslations`.
  - Renamed `WindowTranslations::close_button_tooltip` to `LeafTranslations::close_button_disabled_tooltip`.
  - `Translations::LeafTranslations` now requires more fields to be constructed (see **Added** section).
- Upgraded to egui 0.30.