### PR TITLE
Update egui to 0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # egui_dock changelog
 
-## 0.15.0 - 2024-12-28
+## egui_dock 0.16.0 - 2025-02-07
+
+### Breaking changes
+
+- Upgraded to egui 0.31.
+
+## egui_dock 0.15.0 - 2024-12-28
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.81"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/Adanos020/egui_dock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.30", default-features = false }
+egui = { version = "0.31", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.30", default-features = false, features = [
+eframe = { version = "0.31", default-features = false, features = [
     "default",
     "default_fonts",
     "glow",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # `egui_dock`: docking system for [egui](https://github.com/emilk/egui)
 
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
-[![Crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
+[![crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.30-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.31-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
@@ -32,8 +32,8 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.30"
-egui_dock = "0.15"
+egui = "0.31"
+egui_dock = "0.16"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use eframe::NativeOptions;
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    vec2, CentralPanel, ComboBox, Frame, Rounding, Slider, TopBottomPanel, Ui, ViewportBuilder,
+    vec2, CentralPanel, ComboBox, CornerRadius, Frame, Slider, TopBottomPanel, Ui, ViewportBuilder,
     WidgetText,
 };
 
@@ -216,8 +216,8 @@ impl MyContext {
                 );
                 ui.end_row();
 
-                ui.label("Rounding:");
-                rounding_ui(ui, &mut style.main_surface_border_rounding);
+                ui.label("Corner radius:");
+                corner_radius_ui(ui, &mut style.main_surface_border_rounding);
                 ui.end_row();
             });
         });
@@ -287,25 +287,25 @@ impl MyContext {
             fn tab_style_editor_ui(ui: &mut Ui, tab_style: &mut TabInteractionStyle) {
                 ui.separator();
 
-                ui.label("Rounding");
+                ui.label("Corner radius");
                 labeled_widget!(
                     ui,
-                    Slider::new(&mut tab_style.rounding.nw, 0.0..=15.0),
+                    Slider::new(&mut tab_style.corner_radius.nw, 0..=15),
                     "North-West"
                 );
                 labeled_widget!(
                     ui,
-                    Slider::new(&mut tab_style.rounding.ne, 0.0..=15.0),
+                    Slider::new(&mut tab_style.corner_radius.ne, 0..=15),
                     "North-East"
                 );
                 labeled_widget!(
                     ui,
-                    Slider::new(&mut tab_style.rounding.sw, 0.0..=15.0),
+                    Slider::new(&mut tab_style.corner_radius.sw, 0..=15),
                     "South-West"
                 );
                 labeled_widget!(
                     ui,
-                    Slider::new(&mut tab_style.rounding.se, 0.0..=15.0),
+                    Slider::new(&mut tab_style.corner_radius.se, 0..=15),
                     "South-East"
                 );
 
@@ -377,8 +377,8 @@ impl MyContext {
         ui.collapsing("Tab body", |ui| {
             ui.separator();
 
-            ui.label("Rounding");
-            rounding_ui(ui, &mut style.tab.tab_body.rounding);
+            ui.label("Corner radius");
+            corner_radius_ui(ui, &mut style.tab.tab_body.corner_radius);
 
             ui.label("Stroke width:");
             ui.add(Slider::new(
@@ -516,8 +516,8 @@ impl MyContext {
                     ui.add(Slider::new(&mut style.overlay.hovered_leaf_highlight.expansion, -50.0..=50.0));
                     ui.end_row();
                 });
-                ui.label("Rounding:");
-                rounding_ui(ui, &mut style.overlay.hovered_leaf_highlight.rounding);
+                ui.label("Corner radius:");
+                corner_radius_ui(ui, &mut style.overlay.hovered_leaf_highlight.corner_radius);
             })
         });
     }
@@ -630,9 +630,9 @@ impl eframe::App for MyApp {
     }
 }
 
-fn rounding_ui(ui: &mut Ui, rounding: &mut Rounding) {
-    labeled_widget!(ui, Slider::new(&mut rounding.nw, 0.0..=15.0), "North-West");
-    labeled_widget!(ui, Slider::new(&mut rounding.ne, 0.0..=15.0), "North-East");
-    labeled_widget!(ui, Slider::new(&mut rounding.sw, 0.0..=15.0), "South-West");
-    labeled_widget!(ui, Slider::new(&mut rounding.se, 0.0..=15.0), "South-East");
+fn corner_radius_ui(ui: &mut Ui, corner_radius: &mut CornerRadius) {
+    labeled_widget!(ui, Slider::new(&mut corner_radius.nw, 0..=15), "North-West");
+    labeled_widget!(ui, Slider::new(&mut corner_radius.ne, 0..=15), "North-East");
+    labeled_widget!(ui, Slider::new(&mut corner_radius.sw, 0..=15), "South-West");
+    labeled_widget!(ui, Slider::new(&mut corner_radius.se, 0..=15), "South-East");
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,4 +1,4 @@
-use egui::{ecolor::*, Margin, Rounding, Stroke};
+use egui::{ecolor::*, CornerRadius, Margin, Stroke};
 
 /// Left or right alignment for tab add button.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -53,7 +53,7 @@ pub struct Style {
     pub dock_area_padding: Option<Margin>,
 
     pub main_surface_border_stroke: Stroke,
-    pub main_surface_border_rounding: Rounding,
+    pub main_surface_border_rounding: CornerRadius,
 
     pub buttons: ButtonsStyle,
     pub separator: SeparatorStyle,
@@ -168,8 +168,8 @@ pub struct TabBarStyle {
     /// Show a scroll bar when tab bar overflows. By `Default` it's `true`.
     pub show_scroll_bar_on_overflow: bool,
 
-    /// Tab rounding. By `Default` it's [`Rounding::default`].
-    pub rounding: Rounding,
+    /// Tab corner_radius. By `Default` it's [`CornerRadius::default`].
+    pub corner_radius: CornerRadius,
 
     /// Color of the line separating the tab name area from the tab content area.
     /// By `Default` it's [`Color32::BLACK`].
@@ -227,8 +227,8 @@ pub struct TabInteractionStyle {
     /// Color of the outline around tabs. By `Default` it's [`Color32::BLACK`].
     pub outline_color: Color32,
 
-    /// Tab rounding. By `Default` it's [`Rounding::default`].
-    pub rounding: Rounding,
+    /// Tab corner radius. By `Default` it's [`CornerRadius::default`].
+    pub corner_radius: CornerRadius,
 
     /// Colour of the tab's background. By `Default` it's [`Color32::WHITE`].
     pub bg_fill: Color32,
@@ -247,8 +247,8 @@ pub struct TabBodyStyle {
     /// The stroke of the tabs border. By `Default` it's ['Stroke::default'].
     pub stroke: Stroke,
 
-    /// Tab rounding. By `Default` it's [`Rounding::default`].
-    pub rounding: Rounding,
+    /// Tab corner radius. By `Default` it's [`CornerRadius::default`].
+    pub corner_radius: CornerRadius,
 
     /// Colour of the tab's background. By `Default` it's [`Color32::WHITE`].
     pub bg_fill: Color32,
@@ -335,7 +335,7 @@ pub struct LeafHighlighting {
     pub color: Color32,
 
     /// Rounding of the resulting rectangle.
-    pub rounding: Rounding,
+    pub corner_radius: CornerRadius,
 
     /// Stroke.
     pub stroke: Stroke,
@@ -349,7 +349,7 @@ impl Default for Style {
         Self {
             dock_area_padding: None,
             main_surface_border_stroke: Stroke::new(f32::default(), Color32::BLACK),
-            main_surface_border_rounding: Rounding::default(),
+            main_surface_border_rounding: CornerRadius::default(),
             buttons: ButtonsStyle::default(),
             separator: SeparatorStyle::default(),
             tab_bar: TabBarStyle::default(),
@@ -410,7 +410,7 @@ impl Default for TabBarStyle {
             bg_fill: Color32::WHITE,
             height: 24.0,
             show_scroll_bar_on_overflow: true,
-            rounding: Rounding::default(),
+            corner_radius: CornerRadius::default(),
             hline_color: Color32::BLACK,
             fill_tab_bar: false,
         }
@@ -454,7 +454,7 @@ impl Default for TabInteractionStyle {
         Self {
             bg_fill: Color32::WHITE,
             outline_color: Color32::BLACK,
-            rounding: Rounding::default(),
+            corner_radius: CornerRadius::default(),
             text_color: Color32::DARK_GRAY,
         }
     }
@@ -463,9 +463,9 @@ impl Default for TabInteractionStyle {
 impl Default for TabBodyStyle {
     fn default() -> Self {
         Self {
-            inner_margin: Margin::same(4.0),
+            inner_margin: Margin::same(4),
             stroke: Stroke::default(),
-            rounding: Rounding::default(),
+            corner_radius: CornerRadius::default(),
             bg_fill: Color32::WHITE,
         }
     }
@@ -506,7 +506,7 @@ impl Default for LeafHighlighting {
     fn default() -> Self {
         Self {
             color: Color32::TRANSPARENT,
-            rounding: Rounding::same(0.0),
+            corner_radius: CornerRadius::same(0),
             stroke: Stroke::NONE,
             expansion: 0.0,
         }
@@ -537,7 +537,7 @@ impl Style {
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             main_surface_border_stroke: Stroke::NONE,
-            main_surface_border_rounding: Rounding::ZERO,
+            main_surface_border_rounding: CornerRadius::ZERO,
             buttons: ButtonsStyle::from_egui(style),
             separator: SeparatorStyle::from_egui(style),
             tab_bar: TabBarStyle::from_egui(style),
@@ -622,11 +622,11 @@ impl TabBarStyle {
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
             bg_fill: style.visuals.extreme_bg_color,
-            rounding: Rounding {
-                nw: style.visuals.widgets.inactive.rounding.nw + 2.0,
-                ne: style.visuals.widgets.inactive.rounding.ne + 2.0,
-                sw: 0.0,
-                se: 0.0,
+            corner_radius: CornerRadius {
+                nw: style.visuals.widgets.inactive.corner_radius.nw + 2,
+                ne: style.visuals.widgets.inactive.corner_radius.ne + 2,
+                sw: 0,
+                se: 0,
             },
             hline_color: style.visuals.widgets.noninteractive.bg_stroke.color,
             ..TabBarStyle::default()
@@ -667,10 +667,10 @@ impl TabInteractionStyle {
             outline_color: style.visuals.widgets.noninteractive.bg_stroke.color,
             bg_fill: style.visuals.window_fill(),
             text_color: style.visuals.text_color(),
-            rounding: Rounding {
-                sw: 0.0,
-                se: 0.0,
-                ..style.visuals.widgets.active.rounding
+            corner_radius: CornerRadius {
+                sw: 0,
+                se: 0,
+                ..style.visuals.widgets.active.corner_radius
             },
         }
     }
@@ -784,7 +784,7 @@ impl TabBodyStyle {
         Self {
             inner_margin: style.spacing.window_margin,
             stroke: style.visuals.widgets.noninteractive.bg_stroke,
-            rounding: style.visuals.widgets.active.rounding,
+            corner_radius: style.visuals.widgets.active.corner_radius,
             bg_fill: style.visuals.window_fill(),
         }
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -617,7 +617,6 @@ impl TabBarStyle {
     ///
     /// Fields overwritten by [`egui::Style`] are:
     /// - [`TabBarStyle::bg_fill`]
-    /// - [`TabBarStyle::rounding`]
     /// - [`TabBarStyle::hline_color`]
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {
@@ -661,7 +660,6 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_active(style: &egui::Style) -> Self {
         Self {
             outline_color: style.visuals.widgets.noninteractive.bg_stroke.color,
@@ -681,15 +679,11 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_inactive(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.text_color(),
-            bg_fill: egui::ecolor::tint_color_towards(
-                style.visuals.window_fill,
-                style.visuals.extreme_bg_color,
-            ),
-            outline_color: egui::ecolor::tint_color_towards(
+            bg_fill: tint_color_towards(style.visuals.window_fill, style.visuals.extreme_bg_color),
+            outline_color: tint_color_towards(
                 style.visuals.widgets.noninteractive.bg_stroke.color,
                 style.visuals.extreme_bg_color,
             ),
@@ -703,7 +697,6 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_focused(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
@@ -717,7 +710,6 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_hovered(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
@@ -732,7 +724,6 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_active_with_kb_focus(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
@@ -747,7 +738,6 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_inactive_with_kb_focus(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
@@ -762,7 +752,6 @@ impl TabInteractionStyle {
     /// - [`TabInteractionStyle::outline_color`]
     /// - [`TabInteractionStyle::bg_fill`]
     /// - [`TabInteractionStyle::text_color`]
-    /// - [`TabInteractionStyle::rounding`]
     pub fn from_egui_focused_with_kb_focus(style: &egui::Style) -> Self {
         Self {
             text_color: style.visuals.strong_text_color(),
@@ -778,7 +767,6 @@ impl TabBodyStyle {
     /// Fields overwritten by [`egui::Style`] are:
     /// - [`TabBodyStyle::inner_margin`]
     /// - [`TabBodyStyle::stroke]
-    /// - [`TabBodyStyle::rounding`]
     /// - [`TabBodyStyle::bg_fill`]
     pub fn from_egui(style: &egui::Style) -> Self {
         Self {

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use egui::{
     emath::inverse_lerp, vec2, Context, Id, LayerId, NumExt, Order, Painter, Pos2, Rect, Stroke,
-    Ui, Vec2,
+    StrokeKind, Ui, Vec2,
 };
 
 #[derive(Debug, Clone)]
@@ -78,9 +78,10 @@ fn draw_highlight_rect(rect: Rect, ui: &Ui, style: &Style) {
     let painter = make_overlay_painter(ui);
     painter.rect(
         rect.expand(style.overlay.hovered_leaf_highlight.expansion),
-        style.overlay.hovered_leaf_highlight.rounding,
+        style.overlay.hovered_leaf_highlight.corner_radius,
         style.overlay.hovered_leaf_highlight.color,
         style.overlay.hovered_leaf_highlight.stroke,
+        StrokeKind::Inside,
     );
 }
 
@@ -96,11 +97,17 @@ fn button_ui(
     let visuals = &style.overlay;
     let button_stroke = Stroke::new(1.0, visuals.button_color);
     let painter = make_overlay_painter(ui);
-    painter.rect_stroke(rect, 0.0, visuals.button_border_stroke);
+    painter.rect_stroke(rect, 0.0, visuals.button_border_stroke, StrokeKind::Inside);
     let rect = rect.shrink(rect.width() * 0.1);
-    painter.rect_stroke(rect, 0.0, button_stroke);
+    painter.rect_stroke(rect, 0.0, button_stroke, StrokeKind::Inside);
     let rim = { Rect::from_two_pos(rect.min, rect.lerp_inside(vec2(1.0, 0.1))) };
-    painter.rect(rim, 0.0, visuals.button_color, Stroke::NONE);
+    painter.rect(
+        rim,
+        0.0,
+        visuals.button_color,
+        Stroke::NONE,
+        StrokeKind::Inside,
+    );
 
     if let Some(split) = split {
         for line in DASHED_LINE_ALPHAS.chunks(2) {
@@ -436,6 +443,7 @@ fn draw_window_rect(rect: Rect, ui: &Ui, style: &Style) {
             style.overlay.selection_stroke_width,
             style.overlay.selection_color,
         ),
+        StrokeKind::Inside,
     );
 }
 

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -4,8 +4,8 @@ use crate::{
     AllowedSplits, NodeIndex, Split, Style, SurfaceIndex, TabDestination, TabIndex, TabInsert,
 };
 use egui::{
-    emath::inverse_lerp, vec2, Context, Id, LayerId, NumExt, Order, Painter, Pos2, Rect, Stroke,
-    StrokeKind, Ui, Vec2,
+    emath::{inverse_lerp, GuiRounding},
+    vec2, Context, Id, LayerId, NumExt, Order, Painter, Pos2, Rect, Stroke, StrokeKind, Ui, Vec2,
 };
 
 #[derive(Debug, Clone)]
@@ -471,7 +471,7 @@ fn constrain_rect_to_area(ui: &Ui, rect: Rect, mut bounds: Rect) -> Rect {
     pos.y = pos.y.at_most(bounds.bottom() + margin_y - rect.height()); // move right if needed
     pos.y = pos.y.at_least(bounds.top() - margin_y); // move down if needed
 
-    pos = ui.painter().round_pos_to_pixels(pos);
+    pos = pos.round_to_pixels(ui.painter().pixels_per_point());
 
     Rect::from_min_size(pos, rect.size())
 }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1,7 +1,7 @@
 use egui::{
     emath::TSTransform, epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, Color32,
-    CursorIcon, Frame, Id, Key, LayerId, Layout, NumExt, Order, Rect, Response, Rounding,
-    ScrollArea, Sense, Shape, Stroke, TextStyle, Ui, UiBuilder, Vec2, WidgetText,
+    CornerRadius, CursorIcon, Frame, Id, Key, LayerId, Layout, NumExt, Order, Rect, Response,
+    ScrollArea, Sense, Shape, Stroke, StrokeKind, TextStyle, Ui, UiBuilder, Vec2, WidgetText,
 };
 use std::ops::RangeInclusive;
 
@@ -93,7 +93,7 @@ impl<Tab> DockArea<'_, Tab> {
         );
         ui.painter().rect_filled(
             tabbar_outer_rect,
-            style.tab_bar.rounding,
+            style.tab_bar.corner_radius,
             style.tab_bar.bg_fill,
         );
 
@@ -522,7 +522,7 @@ impl<Tab> DockArea<'_, Tab> {
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let color = if response.hovered() || response.has_focus() {
             ui.painter()
-                .rect_filled(rect, Rounding::ZERO, style.buttons.add_tab_bg_fill);
+                .rect_filled(rect, CornerRadius::ZERO, style.buttons.add_tab_bg_fill);
             style.buttons.add_tab_active_color
         } else {
             style.buttons.add_tab_color
@@ -602,7 +602,7 @@ impl<Tab> DockArea<'_, Tab> {
             if !(close_window_disabled && on_secondary_button) {
                 ui.painter().rect_filled(
                     rect,
-                    Rounding::ZERO,
+                    CornerRadius::ZERO,
                     style.buttons.close_all_tabs_bg_fill,
                 );
             }
@@ -735,8 +735,11 @@ impl<Tab> DockArea<'_, Tab> {
         let on_secondary_button = self.is_on_secondary_button(surface_index, ui, &response);
 
         let color = if response.hovered() || response.has_focus() {
-            ui.painter()
-                .rect_filled(rect, Rounding::ZERO, style.buttons.collapse_tabs_bg_fill);
+            ui.painter().rect_filled(
+                rect,
+                CornerRadius::ZERO,
+                style.buttons.collapse_tabs_bg_fill,
+            );
             style.buttons.collapse_tabs_active_color
         } else {
             style.buttons.collapse_tabs_color
@@ -1000,19 +1003,20 @@ impl<Tab> DockArea<'_, Tab> {
         // Draw the full tab first and then the stroke on top to avoid the stroke
         // mixing with the background color.
         ui.painter()
-            .rect_filled(tab_rect, tab_style.rounding, tab_style.bg_fill);
+            .rect_filled(tab_rect, tab_style.corner_radius, tab_style.bg_fill);
         let stroke_rect = rect_stroke_box(tab_rect, 1.0);
         ui.painter().rect_stroke(
             stroke_rect,
-            tab_style.rounding,
+            tab_style.corner_radius,
             Stroke::new(1.0, tab_style.outline_color),
+            StrokeKind::Inside,
         );
         if !is_being_dragged {
             // Make the tab name area connect with the tab ui area.
             ui.painter().hline(
                 RangeInclusive::new(
-                    stroke_rect.min.x + f32::max(tab_style.rounding.sw, 1.5),
-                    stroke_rect.max.x - f32::max(tab_style.rounding.se, 1.5),
+                    stroke_rect.min.x + f32::max(tab_style.corner_radius.sw.into(), 1.5),
+                    stroke_rect.max.x - f32::max(tab_style.corner_radius.se.into(), 1.5),
                 ),
                 stroke_rect.bottom(),
                 Stroke::new(2.0, tab_style.bg_fill),
@@ -1046,13 +1050,13 @@ impl<Tab> DockArea<'_, Tab> {
             };
 
             if close_response.hovered() || close_response.has_focus() {
-                let mut rounding = tab_style.rounding;
-                rounding.nw = 0.0;
-                rounding.sw = 0.0;
+                let mut corner_radius = tab_style.corner_radius;
+                corner_radius.nw = 0;
+                corner_radius.sw = 0;
 
                 ui.painter().rect_filled(
                     close_button_rect,
-                    rounding,
+                    corner_radius,
                     style.buttons.add_tab_bg_fill,
                 );
             }
@@ -1210,7 +1214,7 @@ impl<Tab> DockArea<'_, Tab> {
                 if tab_viewer.clear_background(tab) {
                     ui.painter().rect_filled(
                         body_rect,
-                        tabs_style.tab_body.rounding,
+                        tabs_style.tab_body.corner_radius,
                         tabs_style.tab_body.bg_fill,
                     );
                 }
@@ -1242,12 +1246,13 @@ impl<Tab> DockArea<'_, Tab> {
                 );
                 ui.painter().rect_stroke(
                     rect_stroke_box(tab_body_rect, tabs_style.tab_body.stroke.width),
-                    tabs_style.tab_body.rounding,
+                    tabs_style.tab_body.corner_radius,
                     tabs_style.tab_body.stroke,
+                    StrokeKind::Inside,
                 );
 
                 ScrollArea::new(tab_viewer.scroll_bars(tab)).show(ui, |ui| {
-                    Frame::none()
+                    Frame::new()
                         .inner_margin(tabs_style.tab_body.inner_margin)
                         .show(ui, |ui| {
                             if fade_factor != 1.0 {

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -1,6 +1,6 @@
 use egui::{
-    CentralPanel, Color32, Context, CursorIcon, EventFilter, Frame, Key, Pos2, Rect, Rounding,
-    Sense, Ui, Vec2,
+    CentralPanel, Color32, Context, CornerRadius, CursorIcon, EventFilter, Frame, Key, Pos2, Rect,
+    Sense, StrokeKind, Ui, Vec2,
 };
 
 use duplicate::duplicate;
@@ -317,6 +317,7 @@ impl<Tab> DockArea<'_, Tab> {
             rect,
             style.main_surface_border_rounding,
             style.main_surface_border_stroke,
+            StrokeKind::Inside,
         );
         if surface == SurfaceIndex::main() {
             rect = rect.expand(-style.main_surface_border_stroke.width / 2.0);
@@ -523,7 +524,7 @@ impl<Tab> DockArea<'_, Tab> {
                     style.separator.color_idle
                 };
 
-                ui.painter().rect_filled(separator, Rounding::ZERO, color);
+                ui.painter().rect_filled(separator, CornerRadius::ZERO, color);
 
                 // Update 'fraction' interaction after drawing separator,
                 // otherwise it may overlap on other separator / bodies when

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -1,5 +1,5 @@
 use egui::{
-    vec2, Align, Color32, CursorIcon, Frame, Layout, Rect, Response, RichText, Rounding, Sense,
+    vec2, Align, Color32, CornerRadius, CursorIcon, Frame, Layout, Rect, Response, RichText, Sense,
     Shape, Stroke, Ui, UiBuilder, Vec2, WidgetText,
 };
 
@@ -137,7 +137,7 @@ impl<Tab> DockArea<'_, Tab> {
             );
             ui.painter().rect_filled(
                 tabbar_outer_rect,
-                style.tab_bar.rounding,
+                style.tab_bar.corner_radius,
                 style.tab_bar.bg_fill,
             );
             self.window_expand(ui, surface_index, tabbar_outer_rect, fade_style);
@@ -175,8 +175,11 @@ impl<Tab> DockArea<'_, Tab> {
 
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let color = if response.hovered() || response.has_focus() {
-            ui.painter()
-                .rect_filled(rect, Rounding::ZERO, style.buttons.minimize_window_bg_fill);
+            ui.painter().rect_filled(
+                rect,
+                CornerRadius::ZERO,
+                style.buttons.minimize_window_bg_fill,
+            );
             style.buttons.minimize_window_active_color
         } else {
             style.buttons.minimize_window_color


### PR DESCRIPTION
Things seems to work, but I've never used egui or this crate until today, but I needed a version that works with egui 0.31 so here we are...

* compilation errors 'fixed' - mostly due to changes for the missing stroke kind on rectangles, I used 'StrokeKind::Inside' everywhere.
* all 'deprecated' warnings removed.
* tests pass
* examples run
* changes formatted using `cargo fmt`.

Most of the changes are relating to CornerRadius changes.
