### PR TITLE
Fix `TabViewer::on_close`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui_dock changelog
 
+## egui_dock 0.16.1 - 2025-02-14
+
+### Fixed
+
+- `TabViewer::on_close` is now called when a whole leaf is closed at once.
+
 ## egui_dock 0.16.0 - 2025-02-07
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 rust-version = "1.81"
 license = "MIT"

--- a/src/widgets/dock_area/tab_removal.rs
+++ b/src/widgets/dock_area/tab_removal.rs
@@ -7,21 +7,3 @@ pub(super) enum TabRemoval {
     Leaf(SurfaceIndex, NodeIndex),
     Window(SurfaceIndex),
 }
-
-impl From<SurfaceIndex> for TabRemoval {
-    fn from(index: SurfaceIndex) -> Self {
-        TabRemoval::Window(index)
-    }
-}
-
-impl From<(SurfaceIndex, NodeIndex)> for TabRemoval {
-    fn from((si, ni): (SurfaceIndex, NodeIndex)) -> TabRemoval {
-        TabRemoval::Leaf(si, ni)
-    }
-}
-
-impl From<(SurfaceIndex, NodeIndex, TabIndex)> for TabRemoval {
-    fn from((si, ni, ti): (SurfaceIndex, NodeIndex, TabIndex)) -> TabRemoval {
-        TabRemoval::Node(si, ni, ti)
-    }
-}


### PR DESCRIPTION
# egui_dock 0.16.1 - 2025-02-14

## Fixed

- `TabViewer::on_close` is now called when a whole leaf is closed at once.