### PR TITLE
feat: add on_rect_changed callback and example for dock state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ eframe = { version = "0.31", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }
+serde_json = { version = "1" }
+
+[[example]]
+name = "save_load_dock_state"
+required-features = ["serde"]

--- a/examples/save_load_dock_state.rs
+++ b/examples/save_load_dock_state.rs
@@ -1,0 +1,88 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use eframe::{egui, NativeOptions};
+use egui_dock::{DockArea, DockState, NodeIndex, Style};
+use std::fs;
+
+const DOCK_STATE_FILE: &str = "target/dock_state.json";
+
+fn main() -> eframe::Result<()> {
+    let options = NativeOptions::default();
+    eframe::run_native(
+        "My egui App",
+        options,
+        Box::new(|_cc| Ok(Box::<MyApp>::default())),
+    )
+}
+
+struct TabViewer {
+    modified: bool,
+}
+
+impl egui_dock::TabViewer for TabViewer {
+    type Tab = String;
+
+    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+        (&*tab).into()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+        ui.label(format!("Content of {tab}"));
+    }
+
+    fn on_rect_changed(&mut self, _tab: &mut Self::Tab) {
+        self.modified = true
+    }
+}
+
+struct MyApp {
+    tree: DockState<String>,
+}
+
+impl MyApp {
+    fn save_json(&self) {
+        if let Ok(json) = serde_json::to_string(&self.tree) {
+            let _ = fs::write(DOCK_STATE_FILE, json);
+        }
+    }
+
+    fn load_json() -> Option<Self> {
+        fs::read_to_string(DOCK_STATE_FILE)
+            .ok()
+            .and_then(|data| serde_json::from_str(&data).ok())
+            .map(|tree| Self { tree })
+    }
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        // Try loading from file, fallback to default layout
+        Self::load_json().unwrap_or_else(|| {
+            let mut tree = DockState::new(vec!["tab1".to_owned(), "tab2".to_owned()]);
+
+            let [a, b] =
+                tree.main_surface_mut()
+                    .split_left(NodeIndex::root(), 0.3, vec!["tab3".to_owned()]);
+            let [_, _] = tree
+                .main_surface_mut()
+                .split_below(a, 0.7, vec!["tab4".to_owned()]);
+            let [_, _] = tree
+                .main_surface_mut()
+                .split_below(b, 0.5, vec!["tab5".to_owned()]);
+
+            Self { tree }
+        })
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        let mut tab_viewer = TabViewer { modified: false };
+        DockArea::new(&mut self.tree)
+            .style(Style::from_egui(ctx.style().as_ref()))
+            .show(ctx, &mut tab_viewer);
+        if tab_viewer.modified {
+            self.save_json();
+        }
+    }
+}

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1193,7 +1193,10 @@ impl<Tab> DockArea<'_, Tab> {
 
         if !collapsed {
             if let Some(tab) = tabs.get_mut(active.0) {
-                *viewport = body_rect;
+                if *viewport != body_rect {
+                    *viewport = body_rect;
+                    tab_viewer.on_rect_changed(tab);
+                }
 
                 if ui.input(|i| i.pointer.any_click()) {
                     if let Some(pos) = state.last_hover_pos {

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -58,6 +58,16 @@ pub trait TabViewer {
     /// [`Node`](crate::Node) this particular add button was pressed.
     fn on_add(&mut self, _surface: SurfaceIndex, _node: NodeIndex) {}
 
+    /// Called when the rectangle of the tab content changes.
+    ///
+    /// This can happen when the window is resized, panels are docked or undocked,
+    /// or when the layout of the dock area is changed in any way that affects
+    /// the available space for the tab content.
+    ///
+    /// This is useful for tabs that need to adjust their content based on the
+    /// available space.
+    fn on_rect_changed(&mut self, _tab: &mut Self::Tab) {}
+
     /// Content of the popup under the add button. Useful for selecting what type of tab to add.
     ///
     /// This requires that [`DockArea::show_add_buttons`](crate::DockArea::show_add_buttons) and


### PR DESCRIPTION
### Summary
This PR introduces:
- `on_rect_changed` callback to `TabViewer` to allow users to track when the rect changes.
- An example demonstrating saving and loading the dock state.

### Changes
- Added `on_rect_changed` callback to `TabViewer`
- Implemented an example for persistent dock states

### Motivation
This feature is useful for handling layout changes and persisting user layouts.

### Testing
- Tested with the example provided.
