### PR TITLE
Fix `TabViewer::on_close`

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -120,7 +120,7 @@ impl TabViewer for MyContext {
         }
     }
 
-    fn is_closeable(&self, tab: &mut Self::Tab) -> bool {
+    fn is_closeable(&self, tab: &Self::Tab) -> bool {
         ["Inspector", "Style Editor"].contains(&tab.as_str())
     }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,7 +29,7 @@ impl egui_dock::TabViewer for TabViewer {
 
     fn on_close(&mut self, _tab: &mut Self::Tab) -> OnCloseResponse {
         println!("Closed tab: {_tab}");
-        OnCloseResponse::Focus
+        OnCloseResponse::Close
     }
 }
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -304,6 +304,14 @@ impl<Tab> DockState<Tab> {
         removed_tab
     }
 
+    /// Remove a leaf at the specified surface, and node index.
+    pub fn remove_leaf(&mut self, (surface_index, node_index): (SurfaceIndex, NodeIndex)) {
+        self[surface_index].remove_leaf(node_index);
+        if !surface_index.is_main() && self[surface_index].is_empty() {
+            self.remove_surface(surface_index);
+        }
+    }
+
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node
     /// inherits content of the `parent` from before the split, and the second (new) has `tabs`.
     ///

--- a/src/widgets/dock_area/tab_removal.rs
+++ b/src/widgets/dock_area/tab_removal.rs
@@ -3,25 +3,10 @@ use crate::{NodeIndex, SurfaceIndex, TabIndex};
 /// An enum expressing an entry in the `to_remove` field in [`DockArea`].
 #[derive(Debug, Clone, Copy)]
 pub(super) enum TabRemoval {
-    Node(SurfaceIndex, NodeIndex, TabIndex),
-    Leaf(SurfaceIndex, NodeIndex),
+    Tab(SurfaceIndex, NodeIndex, TabIndex, ForcedRemoval),
+    Node(SurfaceIndex, NodeIndex),
     Window(SurfaceIndex),
 }
 
-impl From<SurfaceIndex> for TabRemoval {
-    fn from(index: SurfaceIndex) -> Self {
-        TabRemoval::Window(index)
-    }
-}
-
-impl From<(SurfaceIndex, NodeIndex)> for TabRemoval {
-    fn from((si, ni): (SurfaceIndex, NodeIndex)) -> TabRemoval {
-        TabRemoval::Leaf(si, ni)
-    }
-}
-
-impl From<(SurfaceIndex, NodeIndex, TabIndex)> for TabRemoval {
-    fn from((si, ni, ti): (SurfaceIndex, NodeIndex, TabIndex)) -> TabRemoval {
-        TabRemoval::Node(si, ni, ti)
-    }
-}
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ForcedRemoval(pub bool);

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -45,7 +45,7 @@ pub trait TabViewer {
     /// Returns `true` if the user of your app should be able to close a given `_tab`.
     ///
     /// By default, `true` is always returned.
-    fn is_closeable(&self, _tab: &mut Self::Tab) -> bool {
+    fn is_closeable(&self, _tab: &Self::Tab) -> bool {
         true
     }
 


### PR DESCRIPTION
Ensures that `TabViewer::on_close` is always called on all closable tabs when the user tries to close them. The only exception where `on_close` is not called is when a tab is closed forcefully via `TabViewer::force_close`.