### PR TITLE
Use close_tab_bg_fill for close buttons

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -165,6 +165,9 @@ pub struct TabBarStyle {
     /// Height of the tab bar. By `Default` it's `24.0`.
     pub height: f32,
 
+    /// Inner margin of tab bar. By `Default` it's `Margin::ZERO`.
+    pub inner_margin: Margin,
+
     /// Show a scroll bar when tab bar overflows. By `Default` it's `true`.
     pub show_scroll_bar_on_overflow: bool,
 
@@ -409,6 +412,7 @@ impl Default for TabBarStyle {
         Self {
             bg_fill: Color32::WHITE,
             height: 24.0,
+            inner_margin: Margin::ZERO,
             show_scroll_bar_on_overflow: true,
             corner_radius: CornerRadius::default(),
             hline_color: Color32::BLACK,

--- a/src/style.rs
+++ b/src/style.rs
@@ -216,6 +216,9 @@ pub struct TabStyle {
     /// By `Default` it's `false`.
     pub hline_below_active_tab_name: bool,
 
+    /// Spacing between tabs.
+    pub spacing: f32,
+
     /// The minimum width of the tab.
     ///
     /// The tab title or [`TabBarStyle::fill_tab_bar`] may make the tab
@@ -446,6 +449,7 @@ impl Default for TabStyle {
                 text_color: Color32::BLACK,
                 ..Default::default()
             },
+            spacing: 0.0,
             tab_body: TabBodyStyle::default(),
             hline_below_active_tab_name: false,
             minimum_width: None,

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -362,6 +362,9 @@ impl<Tab> DockArea<'_, Tab> {
 
                 (response, title_id)
             } else {
+                if tab_index.0 != 0 {
+                    tabs_ui.allocate_space(vec2(tab_style.spacing, 0.0));
+                }
                 let (mut response, close_response) = self.tab_title(
                     tabs_ui,
                     &tab_style,

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1057,7 +1057,7 @@ impl<Tab> DockArea<'_, Tab> {
                 ui.painter().rect_filled(
                     close_button_rect,
                     corner_radius,
-                    style.buttons.add_tab_bg_fill,
+                    style.buttons.close_tab_bg_fill,
                 );
             }
 

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -97,6 +97,8 @@ impl<Tab> DockArea<'_, Tab> {
             style.tab_bar.bg_fill,
         );
 
+        let tabbar_outer_rect = tabbar_outer_rect - style.tab_bar.inner_margin;
+
         let mut available_width = tabbar_outer_rect.width();
         let scroll_bar_width = available_width;
         if available_width == 0.0 {


### PR DESCRIPTION
The close button was using the `style.buttons.add_tab_bg_fill` and while the associated `style.buttons.close_tab_bg_fill` was unused in the layout.