### PR TITLE
Use close_tab_bg_fill for close buttons

### DIFF
--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1057,7 +1057,7 @@ impl<Tab> DockArea<'_, Tab> {
                 ui.painter().rect_filled(
                     close_button_rect,
                     corner_radius,
-                    style.buttons.add_tab_bg_fill,
+                    style.buttons.close_tab_bg_fill,
                 );
             }
 


### PR DESCRIPTION
The close button was using the `style.buttons.add_tab_bg_fill` and while the associated `style.buttons.close_tab_bg_fill` was unused in the layout.