### PR TITLE
Fix `retain_tabs` behavior with `Empty` nodes in the list

### DIFF
--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -929,3 +929,25 @@ where
         None
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    struct Tab(u64);
+
+    #[test]
+    fn retain() {
+        let mut tree: Tree<Tab> = Tree::new(vec![]);
+        tree.push_to_focused_leaf(Tab(0));
+        let (n0, _t0) = tree.find_tab(&Tab(0)).unwrap();
+        tree.split_below(n0, 0.5, vec![Tab(1)]);
+
+        let i1 = tree.find_tab(&Tab(0)).unwrap();
+        tree.remove_tab(i1);
+
+        tree.retain_tabs(|_| true);
+        assert!(tree.find_tab(&Tab(0)).is_some());
+    }
+}

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -658,6 +658,16 @@ impl<Tab> Tree<Tab> {
                 level += 1;
             }
         }
+        // Ensure that there are no trailing `Node::Empty` items
+        while let Some(last_index) = self.nodes.len().checked_sub(1).map(NodeIndex) {
+            if self[last_index].is_empty()
+                && last_index.parent().is_some_and(|pi| !self[pi].is_parent())
+            {
+                self.nodes.pop();
+            } else {
+                break;
+            }
+        }
     }
 
     /// Pushes a tab to the first `Leaf` it finds or create a new leaf if an `Empty` node is encountered.
@@ -835,7 +845,10 @@ impl<Tab> Tree<Tab> {
     fn balance(&mut self, emptied_nodes: HashSet<NodeIndex>) {
         let mut emptied_parents = HashSet::default();
         for parent_index in emptied_nodes.into_iter().filter_map(|ni| ni.parent()) {
-            if self[parent_index.left()].is_empty() && self[parent_index.right()].is_empty() {
+            if !self[parent_index].is_parent() {
+                continue;
+            } else if self[parent_index.left()].is_empty() && self[parent_index.right()].is_empty()
+            {
                 self[parent_index] = Node::Empty;
                 emptied_parents.insert(parent_index);
             } else if self[parent_index.left()].is_empty() {
@@ -937,15 +950,29 @@ mod test {
     #[derive(Copy, Clone, Debug, PartialEq)]
     struct Tab(u64);
 
+    /// Checks that `retain` works after removing a node
     #[test]
-    fn retain() {
+    fn remove_and_retain() {
         let mut tree: Tree<Tab> = Tree::new(vec![]);
         tree.push_to_focused_leaf(Tab(0));
         let (n0, _t0) = tree.find_tab(&Tab(0)).unwrap();
         tree.split_below(n0, 0.5, vec![Tab(1)]);
 
-        let i1 = tree.find_tab(&Tab(0)).unwrap();
+        let i1 = tree.find_tab(&Tab(1)).unwrap();
         tree.remove_tab(i1);
+        assert_eq!(tree.nodes.len(), 1);
+
+        tree.retain_tabs(|_| true);
+        assert!(tree.find_tab(&Tab(0)).is_some());
+    }
+
+    /// Tests whether `retain_tabs` works correctly with trailing `Empty` nodes
+    #[test]
+    fn retain_trailing_empty() {
+        let mut tree: Tree<Tab> = Tree::new(vec![]);
+        tree.push_to_focused_leaf(Tab(0));
+        tree.nodes.push(Node::Empty);
+        tree.nodes.push(Node::Empty);
 
         tree.retain_tabs(|_| true);
         assert!(tree.find_tab(&Tab(0)).is_some());


### PR DESCRIPTION
There is a subtle bug, either in `remove_leaf` or `retain_tabs` depending on how you look at it.

When removing leafs, it's possible to leave trailing `Node::Empty` items in the list.  For example, after shuffling tabs around, I found a node list of
```json
"nodes": [
    {
      "Leaf": { "(elided)" }
    },
    "Empty",
    "Empty",
    "Empty",
    "Empty",
    "Empty",
    "Empty"
],
```

I'm not sure if this is a bug or not; it depends on the invariants associated with the `nodes` list.

However, it interacts poorly with the call to `balance` at the end of `retain_tabs`: when `balance` deletes an emptied node, it marks that node's parent for deletion if the node's children are both empty.  Both children of the `Leaf` are empty, so it deletes the leaf as well, even if it should be retained!

This PR updates `remove_leaf` to remove unused `Node::Empty` items from the back of the tree.  This should prevent us from constructing a tree with problematic state.

However, there may be serialized dock states in the wild with these spurious `Empty` values, so I also updated `balance` to correctly handle the situation: if a parent node is a `Leaf`, it should not be removed!

I believe this is #264, and it may also be #262.