### PR TITLE
Prevent `DockState::retain_tabs` from deleting main surface

### DIFF
--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -585,3 +585,18 @@ where
         self[SurfaceIndex::main()].find_tab(needle_tab)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn retain_none_then_push() {
+        let mut t = DockState::new(vec![]);
+        t.push_to_focused_leaf(0);
+        let i = t.find_tab(&0).unwrap();
+        t.remove_tab(i);
+        t.retain_tabs(|_| false);
+        t.push_to_focused_leaf(0);
+    }
+}

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -543,9 +543,10 @@ impl<Tab> DockState<Tab> {
     where
         F: FnMut(&mut Tab) -> bool,
     {
+        let mut main_surface = true;
         self.surfaces.retain_mut(|surface| {
             surface.retain_tabs(&mut predicate);
-            !surface.is_empty()
+            std::mem::take(&mut main_surface) || !surface.is_empty()
         });
     }
 }


### PR DESCRIPTION
Fixes #276