### PR TITLE
Update to egui 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.31", default-features = false }
+egui = { version = "0.31", default-features = false, git = "https://github.com/emilk/egui" }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.31", default-features = false, features = [
+eframe = { version = "0.31", default-features = false, git = "https://github.com/emilk/egui", features = [
     "default",
     "default_fonts",
     "glow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.31", default-features = false, git = "https://github.com/emilk/egui" }
+egui = { version = "0.32", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.31", default-features = false, git = "https://github.com/emilk/egui", features = [
+eframe = { version = "0.32", default-features = false, features = [
     "default",
     "default_fonts",
     "glow",

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -580,7 +580,7 @@ impl Default for MyApp {
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         TopBottomPanel::top("egui_dock::MenuBar").show(ctx, |ui| {
-            egui::menu::bar(ui, |ui| {
+            egui::containers::menu::Bar::new().ui(ui, |ui| {
                 ui.menu_button("View", |ui| {
                     // allow certain tabs to be toggled
                     for tab in &["File Browser", "Asset Manager"] {
@@ -596,7 +596,7 @@ impl eframe::App for MyApp {
                                     .push_to_focused_leaf(tab.to_string());
                             }
 
-                            ui.close_menu();
+                            ui.close();
                         }
                     }
                 });

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -580,7 +580,7 @@ impl Default for MyApp {
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         TopBottomPanel::top("egui_dock::MenuBar").show(ctx, |ui| {
-            egui::containers::menu::Bar::new().ui(ui, |ui| {
+            egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("View", |ui| {
                     // allow certain tabs to be toggled
                     for tab in &["File Browser", "Asset Manager"] {

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -406,7 +406,7 @@ impl<Tab> DockArea<'_, Tab> {
                             && ui.add(eject_button).clicked()
                         {
                             self.to_detach.push((surface_index, node_index, tab_index));
-                            ui.close_menu();
+                            ui.close();
                         }
                         if show_close_button && ui.add(close_button).clicked() {
                             if tab_viewer.on_close(tab) {
@@ -416,7 +416,7 @@ impl<Tab> DockArea<'_, Tab> {
                                 *active = tab_index;
                                 self.new_focused = Some((surface_index, node_index));
                             }
-                            ui.close_menu();
+                            ui.close();
                         }
                     });
                 }
@@ -782,7 +782,7 @@ impl<Tab> DockArea<'_, Tab> {
                     .button(&self.dock_state.translations.leaf.minimize_button)
                     .clicked()
                 {
-                    ui.close_menu();
+                    ui.close();
                     self.window_toggle_minimized(surface_index);
                 }
             });

--- a/src/widgets/popup.rs
+++ b/src/widgets/popup.rs
@@ -64,7 +64,7 @@ pub(crate) fn popup_under_widget<R>(
     ui.data_mut(|d| *d.get_temp_mut_or_default(popup_id) = state);
 
     if ui.input(|i| i.key_pressed(Key::Escape)) || widget_response.clicked_elsewhere() {
-        ui.memory_mut(|mem| mem.close_popup());
+        ui.memory_mut(|mem| mem.close_popup(popup_id));
     }
     Some(inner)
 }

--- a/src/widgets/popup.rs
+++ b/src/widgets/popup.rs
@@ -65,7 +65,10 @@ pub(crate) fn popup_under_widget<R>(
 
     if ui.input(|i| i.key_pressed(Key::Escape)) || widget_response.clicked_elsewhere() {
         ui.memory_mut(|mem| mem.close_popup(popup_id));
+    } else {
+        ui.memory_mut(|mem| mem.keep_popup_open(popup_id));
     }
+
     Some(inner)
 }
 


### PR DESCRIPTION
This bumps to `egui` 0.32, but doesn't update any of the internal to use the new APIs (other than changes as necessary to keep the popup from instantly closing)