### PR TITLE
Make it so separators are always clamped between their bounds

### DIFF
--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -565,20 +565,12 @@ impl<Tab> DockArea<'_, Tab> {
                 // Update 'fraction' interaction after drawing separator,
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
-                if let Some(pos) = response.interact_pointer_pos().or(arrow_key_offset.map(|v| separator.center() + v)) {
-                    let dim_point = pos.dim_point;
-                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
-
-                    if (delta > 0. && dim_point > midpoint && dim_point < rect.max.dim_point)
-                        || (delta < 0. && dim_point < midpoint && dim_point > rect.min.dim_point)
-                    {
-                        let range = rect.max.dim_point - rect.min.dim_point;
-                        let min = (style.separator.extra / range).min(1.0);
-                        let max = 1.0 - min;
-                        let (min, max) = (min.min(max), max.max(min));
-                        split.fraction = (split.fraction + delta / range).clamp(min, max);
-                    }
-                }
+                let range = rect.max.dim_point - rect.min.dim_point;
+                let min = (style.separator.extra / range).min(1.0);
+                let max = 1.0 - min;
+                let (min, max) = (min.min(max), max.max(min));
+                let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
+                split.fraction = (split.fraction + delta / range).clamp(min, max);
 
                 if response.double_clicked() {
                     split.fraction = 0.5;


### PR DESCRIPTION
Fixes #282

As title says, splits are now clamped between their bounds on every frame. This makes it so weird split fractions which were created programmatically don't cause visual problems until the splits are interacted with by the user.