### PR TITLE
Release 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui_dock changelog
 
+## egui_dock 0.18.0 - unreleased
+
+### Changed
+
+- Node separators are always clamped between their bounds. ([#289](https://github.com/Adanos020/egui_dock/pull/289))
+
 ## egui_dock 0.17.0 - 2025/07/13
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # egui_dock changelog
 
-## egui_dock 0.18.0 - unreleased
+## egui_dock 0.18.0 - 2025/10/31
+
+### Breaking changes
+
+- Upgraded to egui 0.33 ([#293](https://github.com/Adanos020/egui_dock/pull/293))
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.32", default-features = false }
+egui = { version = "0.33", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.32", default-features = false, features = [
+eframe = { version = "0.33", default-features = false, features = [
     "default",
     "default_fonts",
     "glow",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
 [![crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.32-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.33-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
@@ -32,8 +32,8 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.32"
-egui_dock = "0.17"
+egui = "0.33"
+egui_dock = "0.18"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -297,8 +297,8 @@ impl<Tab> Tree<Tab> {
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node
     /// inherits content of the `parent` from before the split, and the second (new) gets the `tabs`.
     ///
-    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will occupy after the
-    /// split.
+    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will attempt to occupy
+    /// after the split.
     ///
     /// The new node is placed relatively to the old node, in the direction specified by `split`.
     ///
@@ -341,8 +341,8 @@ impl<Tab> Tree<Tab> {
     ///
     /// This is a shorthand for using `split_tabs` with [`Split::Above`].
     ///
-    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will occupy after the
-    /// split.
+    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will attempt to occupy
+    /// after the split.
     ///
     /// The new node is placed *above* the old node.
     ///
@@ -366,8 +366,8 @@ impl<Tab> Tree<Tab> {
     ///
     /// This is a shorthand for using `split_tabs` with [`Split::Below`].
     ///
-    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will occupy after the
-    /// split.
+    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will attempt to occupy
+    /// after the split.
     ///
     /// The new node is placed *below* the old node.
     ///
@@ -391,8 +391,8 @@ impl<Tab> Tree<Tab> {
     ///
     /// This is a shorthand for using `split_tabs` with [`Split::Left`].
     ///
-    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will occupy after the
-    /// split.
+    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will attempt to occupy
+    /// after the split.
     ///
     /// The new node is placed to the *left* of the old node.
     ///
@@ -416,8 +416,8 @@ impl<Tab> Tree<Tab> {
     ///
     /// This is a shorthand for using `split_tabs` with [`Split::Right`].
     ///
-    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will occupy after the
-    /// split.
+    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will attempt to occupy
+    /// after the split.
     ///
     /// The new node is placed to the *right* of the old node.
     ///
@@ -439,8 +439,8 @@ impl<Tab> Tree<Tab> {
     /// Creates two new nodes by splitting a given `parent` node and assigns them as its children. The first (old) node
     /// inherits content of the `parent` from before the split, and the second (new) uses `new`.
     ///
-    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will occupy after the
-    /// split.
+    /// `fraction` (in range 0..=1) specifies how much of the `parent` node's area the old node will attempt to occupy
+    /// after the split.
     ///
     /// The new node is placed relatively to the old node, in the direction specified by `split`.
     ///

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -153,7 +153,7 @@ enum LockState {
     /// Lock remains locked, but can be unlocked.
     SoftLock,
 
-    /// Lock is locked forever.  
+    /// Lock is locked forever.
     HardLock,
 }
 
@@ -451,12 +451,12 @@ fn draw_window_rect(rect: Rect, ui: &Ui, style: &Style) {
 fn constrain_rect_to_area(ui: &Ui, rect: Rect, mut bounds: Rect) -> Rect {
     if rect.width() > bounds.width() {
         // Allow overlapping side bars.
-        let screen_rect = ui.ctx().screen_rect();
+        let screen_rect = ui.ctx().content_rect();
         (bounds.min.x, bounds.max.x) = (screen_rect.min.x, screen_rect.max.x);
     }
     if rect.height() > bounds.height() {
         // Allow overlapping top/bottom bars:
-        let screen_rect = ui.ctx().screen_rect();
+        let screen_rect = ui.ctx().content_rect();
         (bounds.min.y, bounds.max.y) = (screen_rect.min.y, screen_rect.max.y);
     }
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -565,20 +565,12 @@ impl<Tab> DockArea<'_, Tab> {
                 // Update 'fraction' interaction after drawing separator,
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
-                if let Some(pos) = response.interact_pointer_pos().or(arrow_key_offset.map(|v| separator.center() + v)) {
-                    let dim_point = pos.dim_point;
-                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
-
-                    if (delta > 0. && dim_point > midpoint && dim_point < rect.max.dim_point)
-                        || (delta < 0. && dim_point < midpoint && dim_point > rect.min.dim_point)
-                    {
-                        let range = rect.max.dim_point - rect.min.dim_point;
-                        let min = (style.separator.extra / range).min(1.0);
-                        let max = 1.0 - min;
-                        let (min, max) = (min.min(max), max.max(min));
-                        split.fraction = (split.fraction + delta / range).clamp(min, max);
-                    }
-                }
+                let range = rect.max.dim_point - rect.min.dim_point;
+                let min = (style.separator.extra / range).min(1.0);
+                let max = 1.0 - min;
+                let (min, max) = (min.min(max), max.max(min));
+                let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
+                split.fraction = (split.fraction + delta / range).clamp(min, max);
 
                 if response.double_clicked() {
                     split.fraction = 0.5;

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -66,7 +66,7 @@ impl<Tab> DockArea<'_, Tab> {
     pub fn show_inside(mut self, ui: &mut Ui, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
         self.style
             .get_or_insert(Style::from_egui(ui.style().as_ref()));
-        self.window_bounds.get_or_insert(ui.ctx().screen_rect());
+        self.window_bounds.get_or_insert(ui.ctx().content_rect());
 
         let mut state = State::load(ui.ctx(), self.id);
 


### PR DESCRIPTION
## egui_dock 0.18.0 - 2025/10/31

### Breaking changes

- Upgraded to egui 0.33 ([#293](https://github.com/Adanos020/egui_dock/pull/293))

### Changed

- Node separators are always clamped between their bounds. ([#289](https://github.com/Adanos020/egui_dock/pull/289))