### PR TITLE
Add keywords to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 repository = "https://github.com/Adanos020/egui_dock"
 categories = ["gui", "game-development"]
 include = ["src/**/*.rs", "Cargo.toml", "LICENSE"]
+keywords = ["egui", "gui", "tile", "dock", "layout"]
 
 [features]
 default = []


### PR DESCRIPTION
I was comparing egui_dock with egui_tile and noticed that egui_dock doesn't have keywords set.