### PR TITLE
fix: clamp tab index in move_tab to prevent out-of-bounds insert

### DIFF
--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -237,7 +237,13 @@ impl<Tab> DockState<Tab> {
                         self[dst_surface].split(dst_node, split, 0.5, Node::leaf(tab));
                     }
 
-                    TabInsert::Insert(index) => self[dst_surface][dst_node].insert_tab(index, tab),
+                    TabInsert::Insert(index) => {
+                        // Clamp index to valid range: after remove_tab the node may have fewer tabs
+                        // than the original index (e.g. when reordering within the same node).
+                        let count = self[dst_surface][dst_node].tabs_count();
+                        let clamped = if index.0 > count { TabIndex(count) } else { index };
+                        self[dst_surface][dst_node].insert_tab(clamped, tab);
+                    }
                     TabInsert::Append => self[dst_surface][dst_node].append_tab(tab),
                 }
             }

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -241,7 +241,7 @@ impl<Tab> DockState<Tab> {
                         // Clamp index to valid range: after remove_tab the node may have fewer tabs
                         // than the original index (e.g. when reordering within the same node).
                         let count = self[dst_surface][dst_node].tabs_count();
-                        let clamped = if index.0 > count { TabIndex(count) } else { index };
+                        let clamped = TabIndex(count.min(index.0));
                         self[dst_surface][dst_node].insert_tab(clamped, tab);
                     }
                     TabInsert::Append => self[dst_surface][dst_node].append_tab(tab),


### PR DESCRIPTION
## Summary

When reordering a tab within the same node via drag-and-drop, `DockState::move_tab` calls `remove_tab(src_tab)` **before** `insert_tab(index, tab)`. If the source and destination are the same node, this reduces the tab count by one — making the original destination `index` potentially out of bounds.

**Example:** A node has 3 tabs `[A, B, C]`. Dragging tab `B` (index 1) to position 3 (the end):
1. `remove_tab(1)` → node becomes `[A, C]` (count = 2)
2. `insert_tab(3, B)` → **panic**, index 3 > count 2

## Fix

Clamp the insertion index to the current tab count after removal. This is safe because inserting at `count` is equivalent to appending — which is the correct semantic for "move to the end".

## Test plan
- Drag a tab to the last position within its own node — no panic
- Drag tabs between different nodes — unchanged behavior
- Drag tabs to split positions — unchanged behavior
