### PR TITLE
fix: prevent panics when shrinking window to zero space (#307)

### DIFF
--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -34,6 +34,11 @@ impl<Tab> DockArea<'_, Tab> {
         let rect = self.dock_state[surface_index][node_index]
             .rect()
             .expect("This node must be a leaf");
+
+        if rect.width() <= 0.0 || rect.height() <= 0.0 {
+            return;
+        }
+
         let ui = &mut ui.new_child(
             UiBuilder::new()
                 .max_rect(rect)
@@ -1101,7 +1106,9 @@ impl<Tab> DockArea<'_, Tab> {
         tab_hovered: bool,
         fade_style: Option<&Style>,
     ) {
-        assert_ne!(available_width, 0.0);
+        if available_width <= 0.0 {
+            return;
+        }
 
         let leaf = self.dock_state[surface_index][node_index]
             .get_leaf_mut()

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -448,7 +448,13 @@ impl<Tab> DockArea<'_, Tab> {
                 debug_assert!(!rect.any_nan() && rect.is_finite());
                 let rect = expand_to_pixel(rect, pixels_per_point);
 
-                let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
+                let dim_size = rect.dim_size();
+                let midpoint = if dim_size > 0.0 {
+                    rect.min.dim_point + dim_size * split.fraction
+                } else {
+                    rect.min.dim_point
+                };
+
                 let left_separator_border = map_to_pixel(
                     midpoint - style.separator.width * 0.5,
                     pixels_per_point,
@@ -566,11 +572,13 @@ impl<Tab> DockArea<'_, Tab> {
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
                 let range = rect.max.dim_point - rect.min.dim_point;
-                let min = (style.separator.extra / range).min(1.0);
-                let max = 1.0 - min;
-                let (min, max) = (min.min(max), max.max(min));
-                let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
-                split.fraction = (split.fraction + delta / range).clamp(min, max);
+                if range > 0.0 {
+                    let min = (style.separator.extra / range).min(1.0);
+                    let max = 1.0 - min;
+                    let (min, max) = (min.min(max), max.max(min));
+                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
+                    split.fraction = (split.fraction + delta / range).clamp(min, max);
+                }
 
                 if response.double_clicked() {
                     split.fraction = 0.5;


### PR DESCRIPTION
Fixes #307

### Description
When the window is shrunk to extreme sizes, the available space drops to `0.0`, triggering two panics:
1. `rect is nan in advance_cursor_after_rect` (caused by division by zero when calculating separator fractions).
2. `assertion left != right failed` (caused by `assert_ne!(available_width, 0.0);` in the tab bar scroll logic).

### Solution
Instead of panicking or propagating `NaN` boundaries, the layout now simply skips drawing if there's no space.

* Added an early return in `show_leaf` and `tab_bar_scroll` if `available_width` or `height` is `<= 0.0`.
* Guarded the `split.fraction` math behind `if range > 0.0` to prevent `delta / 0.0`.

Tested locally with `cargo run --example hello`. The window can now be shrunk to zero without crashing.