### PR TITLE
Update egui/eframe to 0.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.33", default-features = false }
+egui = { version = "0.34", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
 
 [dev-dependencies]
-eframe = { version = "0.33", default-features = false, features = [
+eframe = { version = "0.34", default-features = false, features = [
     "default",
     "default_fonts",
     "glow",

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use eframe::NativeOptions;
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    vec2, CentralPanel, ComboBox, CornerRadius, Frame, Slider, TopBottomPanel, Ui, ViewportBuilder,
+    vec2, ComboBox, CornerRadius, Panel, Slider, Ui, ViewportBuilder,
     WidgetText,
 };
 
@@ -579,8 +579,8 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        TopBottomPanel::top("egui_dock::MenuBar").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        Panel::top("egui_dock::MenuBar").show_inside(ui, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("View", |ui| {
                     // allow certain tabs to be toggled
@@ -603,31 +603,26 @@ impl eframe::App for MyApp {
                 });
             })
         });
-        CentralPanel::default()
-            // When displaying a DockArea in another UI, it looks better
-            // to set inner margins to 0.
-            .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
-            .show(ctx, |ui| {
-                let style = self
-                    .context
-                    .style
-                    .get_or_insert(Style::from_egui(ui.style()))
-                    .clone();
 
-                DockArea::new(&mut self.tree)
-                    .style(style)
-                    .show_close_buttons(self.context.show_close_buttons)
-                    .show_add_buttons(self.context.show_add_buttons)
-                    .draggable_tabs(self.context.draggable_tabs)
-                    .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
-                    .allowed_splits(self.context.allowed_splits)
-                    .show_leaf_close_all_buttons(self.context.show_leaf_close_all)
-                    .show_leaf_collapse_buttons(self.context.show_leaf_collapse)
-                    .show_secondary_button_hint(self.context.show_secondary_button_hint)
-                    .secondary_button_on_modifier(self.context.secondary_button_on_modifier)
-                    .secondary_button_context_menu(self.context.secondary_button_context_menu)
-                    .show_inside(ui, &mut self.context);
-            });
+        let style = self
+            .context
+            .style
+            .get_or_insert(Style::from_egui(ui.style()))
+            .clone();
+
+        DockArea::new(&mut self.tree)
+            .style(style)
+            .show_close_buttons(self.context.show_close_buttons)
+            .show_add_buttons(self.context.show_add_buttons)
+            .draggable_tabs(self.context.draggable_tabs)
+            .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
+            .allowed_splits(self.context.allowed_splits)
+            .show_leaf_close_all_buttons(self.context.show_leaf_close_all)
+            .show_leaf_collapse_buttons(self.context.show_leaf_collapse)
+            .show_secondary_button_hint(self.context.show_secondary_button_hint)
+            .secondary_button_on_modifier(self.context.secondary_button_on_modifier)
+            .secondary_button_context_menu(self.context.secondary_button_context_menu)
+            .show_inside(ui, &mut self.context);
     }
 }
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,8 +5,7 @@ use std::collections::HashSet;
 use eframe::NativeOptions;
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    vec2, ComboBox, CornerRadius, Panel, Slider, Ui, ViewportBuilder,
-    WidgetText,
+    vec2, ComboBox, CornerRadius, Panel, Slider, Ui, ViewportBuilder, WidgetText,
 };
 
 use egui_dock::tab_viewer::OnCloseResponse;

--- a/examples/reject_windows.rs
+++ b/examples/reject_windows.rs
@@ -107,9 +107,9 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut TabViewer {});
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut TabViewer {});
     }
 }

--- a/examples/save_load_dock_state.rs
+++ b/examples/save_load_dock_state.rs
@@ -76,11 +76,11 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let mut tab_viewer = TabViewer { modified: false };
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut tab_viewer);
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut tab_viewer);
         if tab_viewer.modified {
             self.save_json();
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -57,9 +57,9 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut TabViewer {});
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut TabViewer {});
     }
 }

--- a/examples/tab_add.rs
+++ b/examples/tab_add.rs
@@ -54,17 +54,17 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let mut added_nodes = Vec::new();
         DockArea::new(&mut self.tree)
             .show_add_buttons(true)
             .style({
-                let mut style = Style::from_egui(ctx.style().as_ref());
+                let mut style = Style::from_egui(ui.style().as_ref());
                 style.tab_bar.fill_tab_bar = true;
                 style
             })
-            .show(
-                ctx,
+            .show_inside(
+                ui,
                 &mut TabViewer {
                     added_nodes: &mut added_nodes,
                 },

--- a/examples/tab_add_popup.rs
+++ b/examples/tab_add_popup.rs
@@ -131,14 +131,14 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let mut added_nodes = Vec::new();
         DockArea::new(&mut self.dock_state)
             .show_add_buttons(true)
             .show_add_popup(true)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(
-                ctx,
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(
+                ui,
                 &mut TabViewer {
                     added_nodes: &mut added_nodes,
                 },

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -64,8 +64,8 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::SidePanel::left("documents").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::Panel::left("documents").show_inside(ui, |ui| {
             for title in self.buffers.buffers.keys() {
                 let tab_location = self.tree.find_tab(title);
                 let is_open = tab_location.is_some();
@@ -81,7 +81,7 @@ impl eframe::App for MyApp {
         });
 
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut self.buffers);
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut self.buffers);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //!
 //! # let mut my_tabs = MyTabs::new();
 //! # egui::__run_test_ctx(|ctx| {
+//! #     #[allow(deprecated)]
 //! #     egui::CentralPanel::default().show(ctx, |ui| my_tabs.ui(ui));
 //! # });
 //! ```
@@ -93,6 +94,7 @@
 //! #     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {}
 //! # }
 //! # egui::__run_test_ctx(|ctx| {
+//! # #[allow(deprecated)]
 //! # egui::CentralPanel::default().show(ctx, |ui| {
 //! # let mut dock_state = DockState::new(vec![]);
 //! // Inherit the look and feel from egui.

--- a/src/style.rs
+++ b/src/style.rs
@@ -28,6 +28,7 @@ pub enum TabAddAlign {
 /// #     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {}
 /// # }
 /// # egui::__run_test_ctx(|ctx| {
+/// # #[allow(deprecated)]
 /// # egui::CentralPanel::default().show(ctx, |ui| {
 /// # let mut dock_state = DockState::new(vec![]);
 /// // Inherit the look and feel from egui.

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -22,36 +22,23 @@ mod window_surface;
 impl<Tab> DockArea<'_, Tab> {
     /// Show the `DockArea` at the top level.
     ///
-    /// This is the same as doing:
+    /// Deprecated: use [`show_inside`](Self::show_inside) instead.
+    /// With eframe 0.34+, implement `App::ui` and call `show_inside` directly:
     ///
+    /// ```ignore
+    /// fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    ///     DockArea::new(&mut self.tree)
+    ///         .style(Style::from_egui(ui.style().as_ref()))
+    ///         .show_inside(ui, &mut tab_viewer);
+    /// }
     /// ```
-    /// # use egui_dock::{DockArea, DockState};
-    /// # use egui::{CentralPanel, Frame};
-    /// # struct TabViewer {}
-    /// # impl egui_dock::TabViewer for TabViewer {
-    /// #     type Tab = String;
-    /// #     fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText { (&*tab).into() }
-    /// #     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {}
-    /// # }
-    /// # let mut tree: DockState<String> = DockState::new(vec![]);
-    /// # let mut tab_viewer = TabViewer {};
-    /// # egui::__run_test_ctx(|ctx| {
-    /// CentralPanel::default()
-    ///     .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
-    ///     .show(ctx, |ui| {
-    ///         DockArea::new(&mut tree).show_inside(ui, &mut tab_viewer);
-    ///     });
-    /// # });
-    /// ```
-    ///
-    /// So you can't use the [`CentralPanel::show`] when using `DockArea`'s one.
-    ///
-    /// See also [`show_inside`](Self::show_inside).
     #[inline]
+    #[deprecated = "Use show_inside() instead — with eframe 0.34+, implement App::ui which gives &mut Ui directly"]
+    #[allow(deprecated)]
     pub fn show(self, ctx: &Context, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
         CentralPanel::default()
             .frame(
-                Frame::central_panel(&ctx.style())
+                Frame::central_panel(&ctx.global_style())
                     .inner_margin(0.)
                     .fill(Color32::TRANSPARENT),
             )


### PR DESCRIPTION
## Summary
- Bump `egui` dependency from 0.33 to 0.34
- Bump `eframe` dev-dependency from 0.33 to 0.34
- Deprecate `DockArea::show(ctx)` — users should use `show_inside(ui)` instead
- Migrate all examples to eframe 0.34's new `App::ui(&mut Ui)` API (replacing deprecated `App::update(&Context)`)
- Replace deprecated `ctx.style()` with `ctx.global_style()`

## Test plan
- [x] `cargo check --all-features --examples` — no warnings
- [x] `cargo test --doc` — 20 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)