### PR TITLE
Release 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,67 @@
 # egui_dock changelog
 
+## egui_dock 0.19.0 - 2026/03/29
+
+### Breaking changes
+
+- Upgraded to egui 0.34. ([#314](https://github.com/anhosh/egui_dock/pull/314))
+- Replaced all `SurfaceIndex`, `NodeIndex`, and `TabIndex` groupings with `NodePath` and `TabPath` in the argument lists
+  of the following functions ([#312](https://github.com/anhosh/egui_dock/pull/312)):
+    - `DockState::set_active_tab`,
+    - `DockState::set_focused_node_and_surface`,
+    - `DockState::move_tab`,
+    - `DockState::detach_tab`,
+    - `DockState::remove_tab`,
+    - `DockState::remove_leaf`,
+    - `DockState::split`,
+    - `DockState::focused_leaf`,
+    - `TabViewer::context_menu`,
+    - `TabViewer::on_add`,
+    - `TabViewer::add_popup`.
+- Changed the return type of some methods ([#312](https://github.com/anhosh/egui_dock/pull/312)):
+    - `DockState::iter_all_nodes` now returns `impl Iterator<Item = (NodePath, &Node<Tab>)>`,
+    - `DockState::iter_all_nodes_mut` now returns `impl Iterator<Item = (NodePath, &mut Node<Tab>)>`,
+    - `DockState::iter_all_tabs` now returns `impl Iterator<Item = (TabPath, &Tab)>`,
+    - `DockState::iter_all_tabs_mut` now returns `impl Iterator<Item = (TabPath, &mut Tab)>`,
+    - `DockState::iter_leaves` now returns `impl Iterator<Item = (NodePath, &LeafNode<Tab>)>`,
+    - `DockState::iter_leaves_mut` now returns `impl Iterator<Item = (NodePath, &mut LeafNode<Tab>)>`,
+    - `DockState::find_tab_from` now returns `Option<TabPath>`,
+    - `DockState::find_tab` now returns `Option<TabPath>`,
+    - `Surface::iter_all_tabs` now returns `impl Iterator<Item = ((NodeIndex, TabIndex), &Tab)>`,
+    - `Surface::iter_all_tabs_mut` now returns `impl Iterator<Item = ((NodeIndex, TabIndex), &mut Tab)>`,
+    - `Tree::set_active_tab` now returns `Result<()>` (`Err` if any of the indices are invalid),
+    - `LeafNode::::set_active_tab` now returns `Result<()>` (`Err` if the tab index is invalid).
+- `impl From<(SurfaceIndex, NodeIndex, TabInsert)> for TabDestination` was replaced with
+  `impl From<(NodePath, TabInsert)> for TabDestination`. ([#312](https://github.com/anhosh/egui_dock/pull/312))
+
+### Added
+
+- `NodePath` and `TabPath` structs, useful for more consistent and terse indexing of nodes and
+  tabs. ([#312](https://github.com/anhosh/egui_dock/pull/312))
+- Indexing `LeafNode` with `TabIndex`. ([#311](https://github.com/anhosh/egui_dock/pull/311/))
+- Indexing `DockState` using `NodePath`. ([#312](https://github.com/anhosh/egui_dock/pull/312))
+- New methods ([#312](https://github.com/anhosh/egui_dock/pull/312)):
+    - `DockState::node(_mut)`: returns a `Node` at a given `NodePath`,
+    - `DockState::leaf(_mut)`: returns a `LeafNode` at a given `NodePath`,
+    - `DockState::iter_surfaces(_mut)_indexed`: returns a `Surface` iterator paired with its `SurfaceIndex`,
+    - `Surface::iter_nodes(_mut)_indexed`: returns a `Node<Tab>` iterator paired with its `NodeIndex`,
+    - `Tree::leaf(_mut)`: returns a `Result<&LeafNode<Tab>>` at a given `NodeIndex`,
+    - `Node::iter_tabs(_mut)_indexed`: returns a `Tab` iterator paried with its `TabIndex`.
+
+### Fixed
+
+- No more panics when a window is shrunk to zero available space. ([#309](https://github.com/anhosh/egui_dock/pull/309))
+- No more panics while trying move a tab to the end of the list within the same leaf. ([#308](https://github.com/anhosh/egui_dock/pull/308))
+
+### Deprecated
+
+- `DockArea::show` - use `DockArea::show_inside` instead. ([#314](https://github.com/anhosh/egui_dock/pull/314))
+
 ## egui_dock 0.18.0 - 2025/10/31
 
 ### Breaking changes
 
-- Upgraded to egui 0.33 ([#293](https://github.com/Adanos020/egui_dock/pull/293))
+- Upgraded to egui 0.33. ([#293](https://github.com/Adanos020/egui_dock/pull/293))
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
 paste = "1.0"
+thiserror = "2.0.18"
 
 [dev-dependencies]
 eframe = { version = "0.33", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.33", default-features = false }
+egui = { version = "0.34", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
@@ -27,7 +27,7 @@ paste = "1.0"
 thiserror = "2.0.18"
 
 [dev-dependencies]
-eframe = { version = "0.33", default-features = false, features = [
+eframe = { version = "0.34", default-features = false, features = [
     "default",
     "default_fonts",
     "glow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.92"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/Adanos020/egui_dock"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![github](https://img.shields.io/badge/github-Adanos020/egui_dock-8da0cb?logo=github)](https://github.com/Adanos020/egui_dock)
 [![crates.io](https://img.shields.io/crates/v/egui_dock)](https://crates.io/crates/egui_dock)
 [![docs.rs](https://img.shields.io/docsrs/egui_dock)](https://docs.rs/egui_dock/)
-[![egui_version](https://img.shields.io/badge/egui-0.33-blue)](https://github.com/emilk/egui)
+[![egui_version](https://img.shields.io/badge/egui-0.34-blue)](https://github.com/emilk/egui)
 
 Originally created by [@lain-dono](https://github.com/lain-dono), this library provides a docking system for `egui`.
 
@@ -32,8 +32,8 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.33"
-egui_dock = "0.18"
+egui = "0.34"
+egui_dock = "0.19"
 ```
 
 Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,11 +8,9 @@ use egui::{
     vec2, CentralPanel, ComboBox, CornerRadius, Frame, Slider, TopBottomPanel, Ui, ViewportBuilder,
     WidgetText,
 };
-
-use egui_dock::tab_viewer::OnCloseResponse;
 use egui_dock::{
-    AllowedSplits, DockArea, DockState, NodeIndex, OverlayType, Style, SurfaceIndex,
-    TabInteractionStyle, TabViewer,
+    tab_viewer::OnCloseResponse, AllowedSplits, DockArea, DockState, NodeIndex, NodePath,
+    OverlayType, Style, SurfaceIndex, TabInteractionStyle, TabViewer,
 };
 
 /// Adds a widget with a label next to it, can be given an extra parameter in order to show a hover text
@@ -104,13 +102,7 @@ impl TabViewer for MyContext {
         }
     }
 
-    fn context_menu(
-        &mut self,
-        ui: &mut Ui,
-        tab: &mut Self::Tab,
-        _surface: SurfaceIndex,
-        _node: NodeIndex,
-    ) {
+    fn context_menu(&mut self, ui: &mut Ui, tab: &mut Self::Tab, _path: NodePath) {
         match tab.as_str() {
             "Simple Demo" => self.simple_demo_menu(ui),
             _ => {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -5,8 +5,7 @@ use std::collections::HashSet;
 use eframe::NativeOptions;
 use egui::{
     color_picker::{color_edit_button_srgba, Alpha},
-    vec2, CentralPanel, ComboBox, CornerRadius, Frame, Slider, TopBottomPanel, Ui, ViewportBuilder,
-    WidgetText,
+    vec2, ComboBox, CornerRadius, Panel, Slider, Ui, ViewportBuilder, WidgetText,
 };
 use egui_dock::{
     tab_viewer::OnCloseResponse, AllowedSplits, DockArea, DockState, NodeIndex, NodePath,
@@ -571,8 +570,8 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        TopBottomPanel::top("egui_dock::MenuBar").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        Panel::top("egui_dock::MenuBar").show_inside(ui, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("View", |ui| {
                     // allow certain tabs to be toggled
@@ -595,31 +594,26 @@ impl eframe::App for MyApp {
                 });
             })
         });
-        CentralPanel::default()
-            // When displaying a DockArea in another UI, it looks better
-            // to set inner margins to 0.
-            .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
-            .show(ctx, |ui| {
-                let style = self
-                    .context
-                    .style
-                    .get_or_insert(Style::from_egui(ui.style()))
-                    .clone();
 
-                DockArea::new(&mut self.tree)
-                    .style(style)
-                    .show_close_buttons(self.context.show_close_buttons)
-                    .show_add_buttons(self.context.show_add_buttons)
-                    .draggable_tabs(self.context.draggable_tabs)
-                    .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
-                    .allowed_splits(self.context.allowed_splits)
-                    .show_leaf_close_all_buttons(self.context.show_leaf_close_all)
-                    .show_leaf_collapse_buttons(self.context.show_leaf_collapse)
-                    .show_secondary_button_hint(self.context.show_secondary_button_hint)
-                    .secondary_button_on_modifier(self.context.secondary_button_on_modifier)
-                    .secondary_button_context_menu(self.context.secondary_button_context_menu)
-                    .show_inside(ui, &mut self.context);
-            });
+        let style = self
+            .context
+            .style
+            .get_or_insert(Style::from_egui(ui.style()))
+            .clone();
+
+        DockArea::new(&mut self.tree)
+            .style(style)
+            .show_close_buttons(self.context.show_close_buttons)
+            .show_add_buttons(self.context.show_add_buttons)
+            .draggable_tabs(self.context.draggable_tabs)
+            .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
+            .allowed_splits(self.context.allowed_splits)
+            .show_leaf_close_all_buttons(self.context.show_leaf_close_all)
+            .show_leaf_collapse_buttons(self.context.show_leaf_collapse)
+            .show_secondary_button_hint(self.context.show_secondary_button_hint)
+            .secondary_button_on_modifier(self.context.secondary_button_on_modifier)
+            .secondary_button_context_menu(self.context.secondary_button_context_menu)
+            .show_inside(ui, &mut self.context);
     }
 }
 

--- a/examples/reject_windows.rs
+++ b/examples/reject_windows.rs
@@ -106,9 +106,9 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut TabViewer {});
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut TabViewer {});
     }
 }

--- a/examples/reject_windows.rs
+++ b/examples/reject_windows.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::{egui, NativeOptions};
-
 use egui_dock::{DockArea, DockState, NodeIndex, Style};
 
 fn main() -> eframe::Result<()> {

--- a/examples/save_load_dock_state.rs
+++ b/examples/save_load_dock_state.rs
@@ -1,8 +1,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use std::fs;
+
 use eframe::{egui, NativeOptions};
 use egui_dock::{DockArea, DockState, NodeIndex, Style};
-use std::fs;
 
 const DOCK_STATE_FILE: &str = "target/dock_state.json";
 

--- a/examples/save_load_dock_state.rs
+++ b/examples/save_load_dock_state.rs
@@ -77,11 +77,11 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let mut tab_viewer = TabViewer { modified: false };
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut tab_viewer);
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut tab_viewer);
         if tab_viewer.modified {
             self.save_json();
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::{egui, NativeOptions};
-
 use egui_dock::tab_viewer::OnCloseResponse;
 use egui_dock::{DockArea, DockState, NodeIndex, Style};
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -56,9 +56,9 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut TabViewer {});
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut TabViewer {});
     }
 }

--- a/examples/tab_add.rs
+++ b/examples/tab_add.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::{egui, NativeOptions};
-
-use egui_dock::{DockArea, DockState, NodeIndex, Style, SurfaceIndex};
+use egui_dock::{DockArea, DockState, NodeIndex, NodePath, Style};
 
 fn main() -> eframe::Result<()> {
     let options = NativeOptions::default();
@@ -14,7 +13,7 @@ fn main() -> eframe::Result<()> {
 }
 
 struct TabViewer<'a> {
-    added_nodes: &'a mut Vec<(SurfaceIndex, NodeIndex)>,
+    added_nodes: &'a mut Vec<NodePath>,
 }
 
 impl egui_dock::TabViewer for TabViewer<'_> {
@@ -28,8 +27,8 @@ impl egui_dock::TabViewer for TabViewer<'_> {
         ui.label(format!("Content of tab {tab}"));
     }
 
-    fn on_add(&mut self, surface: SurfaceIndex, node: NodeIndex) {
-        self.added_nodes.push((surface, node));
+    fn on_add(&mut self, path: NodePath) {
+        self.added_nodes.push(path);
     }
 }
 
@@ -70,8 +69,8 @@ impl eframe::App for MyApp {
                 },
             );
 
-        added_nodes.drain(..).for_each(|(surface, node)| {
-            self.tree.set_focused_node_and_surface((surface, node));
+        added_nodes.drain(..).for_each(|path| {
+            self.tree.set_focused_node_and_surface(path);
             self.tree.push_to_focused_leaf(self.counter);
             self.counter += 1;
         });

--- a/examples/tab_add.rs
+++ b/examples/tab_add.rs
@@ -53,17 +53,17 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let mut added_nodes = Vec::new();
         DockArea::new(&mut self.tree)
             .show_add_buttons(true)
             .style({
-                let mut style = Style::from_egui(ctx.style().as_ref());
+                let mut style = Style::from_egui(ui.style().as_ref());
                 style.tab_bar.fill_tab_bar = true;
                 style
             })
-            .show(
-                ctx,
+            .show_inside(
+                ui,
                 &mut TabViewer {
                     added_nodes: &mut added_nodes,
                 },

--- a/examples/tab_add_popup.rs
+++ b/examples/tab_add_popup.rs
@@ -1,9 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::{egui, NativeOptions};
-
 use egui::{Color32, RichText};
-use egui_dock::{DockArea, DockState, NodeIndex, Style, SurfaceIndex};
+use egui_dock::{DockArea, DockState, NodeIndex, NodePath, Style, SurfaceIndex};
 
 fn main() -> eframe::Result<()> {
     let options = NativeOptions::default();
@@ -21,31 +20,28 @@ enum MyTabKind {
 
 struct MyTab {
     kind: MyTabKind,
-    surface: SurfaceIndex,
-    node: NodeIndex,
+    path: NodePath,
 }
 
 impl MyTab {
-    fn regular(surface: SurfaceIndex, node: NodeIndex) -> Self {
+    fn regular(node: NodePath) -> Self {
         Self {
             kind: MyTabKind::Regular,
-            surface,
-            node,
+            path: node,
         }
     }
 
-    fn fancy(surface: SurfaceIndex, node: NodeIndex) -> Self {
+    fn fancy(node: NodePath) -> Self {
         Self {
             kind: MyTabKind::Fancy,
-            surface,
-            node,
+            path: node,
         }
     }
 
     fn title(&self) -> String {
         match self.kind {
-            MyTabKind::Regular => format!("Regular Tab {}", self.node.0),
-            MyTabKind::Fancy => format!("Fancy Tab {}", self.node.0),
+            MyTabKind::Regular => format!("Regular Tab {}", self.path.node.0),
+            MyTabKind::Fancy => format!("Fancy Tab {}", self.path.node.0),
         }
     }
 
@@ -80,16 +76,16 @@ impl egui_dock::TabViewer for TabViewer<'_> {
         ui.label(tab.content());
     }
 
-    fn add_popup(&mut self, ui: &mut egui::Ui, surface: SurfaceIndex, node: NodeIndex) {
+    fn add_popup(&mut self, ui: &mut egui::Ui, path: NodePath) {
         ui.set_min_width(120.0);
         ui.style_mut().visuals.button_frame = false;
 
         if ui.button("Regular tab").clicked() {
-            self.added_nodes.push(MyTab::regular(surface, node));
+            self.added_nodes.push(MyTab::regular(path));
         }
 
         if ui.button("Fancy tab").clicked() {
-            self.added_nodes.push(MyTab::fancy(surface, node));
+            self.added_nodes.push(MyTab::fancy(path));
         }
     }
 }
@@ -102,25 +98,40 @@ struct MyApp {
 impl Default for MyApp {
     fn default() -> Self {
         let mut tree = DockState::new(vec![
-            MyTab::regular(SurfaceIndex::main(), NodeIndex(1)),
-            MyTab::fancy(SurfaceIndex::main(), NodeIndex(2)),
+            MyTab::regular(NodePath {
+                surface: SurfaceIndex::main(),
+                node: NodeIndex(1),
+            }),
+            MyTab::fancy(NodePath {
+                surface: SurfaceIndex::main(),
+                node: NodeIndex(2),
+            }),
         ]);
 
         // You can modify the tree before constructing the dock
         let [a, b] = tree.main_surface_mut().split_left(
             NodeIndex::root(),
             0.3,
-            vec![MyTab::fancy(SurfaceIndex::main(), NodeIndex(3))],
+            vec![MyTab::fancy(NodePath {
+                surface: SurfaceIndex::main(),
+                node: NodeIndex(3),
+            })],
         );
         let [_, _] = tree.main_surface_mut().split_below(
             a,
             0.7,
-            vec![MyTab::fancy(SurfaceIndex::main(), NodeIndex(4))],
+            vec![MyTab::fancy(NodePath {
+                surface: SurfaceIndex::main(),
+                node: NodeIndex(4),
+            })],
         );
         let [_, _] = tree.main_surface_mut().split_below(
             b,
             0.5,
-            vec![MyTab::regular(SurfaceIndex::main(), NodeIndex(5))],
+            vec![MyTab::regular(NodePath {
+                surface: SurfaceIndex::main(),
+                node: NodeIndex(5),
+            })],
         );
 
         Self {
@@ -145,12 +156,13 @@ impl eframe::App for MyApp {
             );
 
         added_nodes.drain(..).for_each(|node| {
-            self.dock_state
-                .set_focused_node_and_surface((node.surface, node.node));
+            self.dock_state.set_focused_node_and_surface(node.path);
             self.dock_state.push_to_focused_leaf(MyTab {
                 kind: node.kind,
-                surface: node.surface,
-                node: NodeIndex(self.counter),
+                path: NodePath {
+                    surface: node.path.surface,
+                    node: NodeIndex(self.counter),
+                },
             });
             self.counter += 1;
         });

--- a/examples/tab_add_popup.rs
+++ b/examples/tab_add_popup.rs
@@ -142,14 +142,14 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let mut added_nodes = Vec::new();
         DockArea::new(&mut self.dock_state)
             .show_add_buttons(true)
             .show_add_popup(true)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(
-                ctx,
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(
+                ui,
                 &mut TabViewer {
                     added_nodes: &mut added_nodes,
                 },

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -64,8 +64,8 @@ impl Default for MyApp {
 }
 
 impl eframe::App for MyApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::SidePanel::left("documents").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::Panel::left("documents").show_inside(ui, |ui| {
             for title in self.buffers.buffers.keys() {
                 let tab_location = self.tree.find_tab(title);
                 let is_open = tab_location.is_some();
@@ -83,7 +83,7 @@ impl eframe::App for MyApp {
         });
 
         DockArea::new(&mut self.tree)
-            .style(Style::from_egui(ctx.style().as_ref()))
-            .show(ctx, &mut self.buffers);
+            .style(Style::from_egui(ui.style().as_ref()))
+            .show_inside(ui, &mut self.buffers);
     }
 }

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -71,7 +71,9 @@ impl eframe::App for MyApp {
                 let is_open = tab_location.is_some();
                 if ui.selectable_label(is_open, title).clicked() {
                     if let Some(tab_location) = tab_location {
-                        self.tree.set_active_tab(tab_location);
+                        self.tree
+                            .set_active_tab(tab_location)
+                            .expect("path returned by find_tab is valid");
                     } else {
                         // Open the file for editing:
                         self.tree.push_to_focused_leaf(title.clone());

--- a/src/dock_state/error.rs
+++ b/src/dock_state/error.rs
@@ -1,0 +1,22 @@
+/// Dock access errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Invalid surface that does not exist in the dock
+    #[error("Invalid surface that does not exist in the dock")]
+    InvalidSurface,
+    /// Surface has no nodes
+    #[error("Surface has no nodes")]
+    EmptySurface,
+    /// Invalid node that does not exist in the surface
+    #[error("Invalid node that does not exist in the surface")]
+    InvalidNode,
+    /// The node exists but is not a leaf
+    #[error("The node exists but is not a leaf")]
+    NonLeafNode,
+    /// Invalid tab that does not exist in the node
+    #[error("Invalid tab that does not exist in the node")]
+    InvalidTab,
+}
+
+/// Type alias for `Result` on [`egui_dock::Error`](Error).
+pub type Result<T = (), E = Error> = std::result::Result<T, E>;

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -1,3 +1,10 @@
+use std::ops;
+
+use egui::Rect;
+
+mod error;
+pub use error::{Error, Result};
+
 /// Wrapper around indices to the collection of surfaces inside a [`DockState`].
 pub mod surface_index;
 
@@ -15,9 +22,10 @@ pub use surface_index::SurfaceIndex;
 use tree::node::LeafNode;
 pub use window_state::WindowState;
 
-use egui::Rect;
-
-use crate::{Node, NodeIndex, Split, TabDestination, TabIndex, TabInsert, Translations, Tree};
+use crate::{
+    Node, NodeIndex, NodePath, Split, TabDestination, TabIndex, TabInsert, TabPath, Translations,
+    Tree,
+};
 
 /// The heart of `egui_dock`.
 ///
@@ -36,7 +44,7 @@ pub struct DockState<Tab> {
     pub translations: Translations,
 }
 
-impl<Tab> std::ops::Index<SurfaceIndex> for DockState<Tab> {
+impl<Tab> ops::Index<SurfaceIndex> for DockState<Tab> {
     type Output = Tree<Tab>;
 
     #[inline(always)]
@@ -50,13 +58,45 @@ impl<Tab> std::ops::Index<SurfaceIndex> for DockState<Tab> {
     }
 }
 
-impl<Tab> std::ops::IndexMut<SurfaceIndex> for DockState<Tab> {
+impl<Tab> ops::IndexMut<SurfaceIndex> for DockState<Tab> {
     #[inline(always)]
     fn index_mut(&mut self, index: SurfaceIndex) -> &mut Self::Output {
         match self.surfaces[index.0].node_tree_mut() {
             Some(tree) => tree,
             None => {
                 panic!("There did not exist a tree at surface index {}", index.0);
+            }
+        }
+    }
+}
+
+impl<Tab> ops::Index<NodePath> for DockState<Tab> {
+    type Output = Node<Tab>;
+
+    #[inline(always)]
+    fn index(&self, index: NodePath) -> &Self::Output {
+        match self.surfaces[index.surface.0].node_tree() {
+            Some(tree) => &tree[index.node],
+            None => {
+                panic!(
+                    "There did not exist a tree at surface index {}",
+                    index.surface.0
+                );
+            }
+        }
+    }
+}
+
+impl<Tab> ops::IndexMut<NodePath> for DockState<Tab> {
+    #[inline(always)]
+    fn index_mut(&mut self, index: NodePath) -> &mut Self::Output {
+        match self.surfaces[index.surface.0].node_tree_mut() {
+            Some(tree) => &mut tree[index.node],
+            None => {
+                panic!(
+                    "There did not exist a tree at surface index {}",
+                    index.surface.0
+                );
             }
         }
     }
@@ -165,8 +205,6 @@ impl<Tab> DockState<Tab> {
     ///
     /// Returns the removed surface or `None` if it didn't exist.
     ///
-    /// # Panics
-    ///
     /// Panics if you try to remove the main surface: `SurfaceIndex::main()`.
     pub fn remove_surface(&mut self, surface_index: SurfaceIndex) -> Option<Surface<Tab>> {
         assert!(!surface_index.is_main());
@@ -182,140 +220,169 @@ impl<Tab> DockState<Tab> {
     }
 
     /// Sets which is the active tab within a specific node on a given surface.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if `path.surface` is not a valid surface,
+    /// if the node at `path.node` is not a leaf or doesn't exist,
+    /// or if the tab index at `path.tab` doesn't exist within the leaf node.
     #[inline]
-    pub fn set_active_tab(
-        &mut self,
-        (surface_index, node_index, tab_index): (SurfaceIndex, NodeIndex, TabIndex),
-    ) {
-        if let Some(Node::Leaf(leaf)) = self[surface_index].nodes.get_mut(node_index.0) {
-            leaf.active = tab_index;
-        }
+    pub fn set_active_tab(&mut self, path: TabPath) -> Result {
+        let leaf = self.leaf_mut(path.node_path())?;
+        leaf.set_active_tab(path.tab)?;
+        Ok(())
+    }
+
+    /// Immutably borrows a node at the given path.
+    ///
+    /// This is the same as `&self[path]` but never panics.
+    pub fn node(&self, path: NodePath) -> Result<&Node<Tab>> {
+        self.surfaces
+            .get(path.surface.0)
+            .ok_or(Error::InvalidSurface)?
+            .node_tree()
+            .ok_or(Error::EmptySurface)?
+            .nodes
+            .get(path.node.0)
+            .ok_or(Error::InvalidNode)
+    }
+
+    /// Mutably borrows a node at the given path.
+    ///
+    /// This is the same as `&mut self[path]` but never panics.
+    pub fn node_mut(&mut self, path: NodePath) -> Result<&mut Node<Tab>> {
+        self.surfaces
+            .get_mut(path.surface.0)
+            .ok_or(Error::InvalidSurface)?
+            .node_tree_mut()
+            .ok_or(Error::EmptySurface)?
+            .nodes
+            .get_mut(path.node.0)
+            .ok_or(Error::InvalidNode)
+    }
+
+    /// Immutably borrows a leaf node at the given path.
+    ///
+    /// Returns `Err` if the path is invalid or the node at the path is not a leaf.
+    pub fn leaf(&self, path: NodePath) -> Result<&LeafNode<Tab>> {
+        self.node(path)?.get_leaf().ok_or(Error::NonLeafNode)
+    }
+
+    /// Mutably borrows a leaf node at the given path.
+    ///
+    /// Returns `Err` if the path is invalid or the node at the path is not a leaf.
+    pub fn leaf_mut(&mut self, path: NodePath) -> Result<&mut LeafNode<Tab>> {
+        self.node_mut(path)?
+            .get_leaf_mut()
+            .ok_or(Error::NonLeafNode)
     }
 
     /// Sets the currently focused leaf to `node_index` if the node at `node_index` is a leaf.
     #[inline]
-    pub fn set_focused_node_and_surface(
-        &mut self,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
-    ) {
-        if self.is_surface_valid(surface_index) && node_index.0 < self[surface_index].len() {
-            // I don't want this code to be evaluated until im absolutely sure the surface index is valid.
-            if self[surface_index][node_index].is_leaf() {
-                self.focused_surface = Some(surface_index);
-                self[surface_index].set_focused_node(node_index);
-                return;
-            }
+    pub fn set_focused_node_and_surface(&mut self, path: NodePath) {
+        if self.leaf(path).is_ok() {
+            self.focused_surface = Some(path.surface);
+            self[path.surface].set_focused_node(path.node);
+        } else {
+            self.focused_surface = None;
         }
-        self.focused_surface = None;
     }
 
     /// Moves a tab from a node to another node.
     /// You need to specify with [`TabDestination`] how the tab should be moved.
-    pub fn move_tab(
-        &mut self,
-        (src_surface, src_node, src_tab): (SurfaceIndex, NodeIndex, TabIndex),
-        dst_tab: impl Into<TabDestination>,
-    ) {
+    pub fn move_tab(&mut self, src: TabPath, dst_tab: impl Into<TabDestination>) {
         match dst_tab.into() {
             TabDestination::Window(position) => {
-                self.detach_tab((src_surface, src_node, src_tab), position);
+                self.detach_tab(src, position);
                 return;
             }
-            TabDestination::Node(dst_surface, dst_node, dst_tab) => {
+            TabDestination::Node(dst, dst_tab) => {
                 // Moving a single tab inside its own node is a no-op
-                if src_surface == dst_surface
-                    && src_node == dst_node
-                    && self[src_surface][src_node].tabs_count() == 1
-                {
+                if src.node_path() == dst && self[src.node_path()].tabs_count() == 1 {
                     return;
                 }
 
                 // Call `Node::remove_tab` to avoid auto remove of the node by `Tree::remove_tab` from Tree.
-                let tab = self[src_surface][src_node].remove_tab(src_tab).unwrap();
+                let tab = self[src.node_path()].remove_tab(src.tab).unwrap();
                 match dst_tab {
                     TabInsert::Split(split) => {
-                        self[dst_surface].split(dst_node, split, 0.5, Node::leaf(tab));
+                        self[dst.surface].split(dst.node, split, 0.5, Node::leaf(tab));
                     }
-
                     TabInsert::Insert(index) => {
                         // Clamp index to valid range: after remove_tab the node may have fewer tabs
                         // than the original index (e.g. when reordering within the same node).
-                        let count = self[dst_surface][dst_node].tabs_count();
+                        let count = self[dst.surface][dst.node].tabs_count();
                         let clamped = TabIndex(count.min(index.0));
-                        self[dst_surface][dst_node].insert_tab(clamped, tab);
+                        self[dst.surface][dst.node].insert_tab(clamped, tab);
                     }
-                    TabInsert::Append => self[dst_surface][dst_node].append_tab(tab),
+                    TabInsert::Append => self[dst.surface][dst.node].append_tab(tab),
                 }
             }
             TabDestination::EmptySurface(dst_surface) => {
                 assert!(self[dst_surface].is_empty());
-                let tab = self[src_surface][src_node].remove_tab(src_tab).unwrap();
+                let tab = self[src.node_path()].remove_tab(src.tab).unwrap();
                 self[dst_surface] = Tree::new(vec![tab])
             }
         }
-        if self[src_surface][src_node].is_leaf() && self[src_surface][src_node].tabs_count() == 0 {
-            self[src_surface].remove_leaf(src_node);
+        if self[src.node_path()].is_leaf() && self[src.node_path()].tabs_count() == 0 {
+            self[src.surface].remove_leaf(src.node);
         }
-        if self[src_surface].is_empty() && !src_surface.is_main() {
-            self.remove_surface(src_surface);
+        if self[src.surface].is_empty() && !src.surface.is_main() {
+            self.remove_surface(src.surface);
         }
     }
 
     /// Takes a tab out of its current surface and puts it in a new window.
     /// Returns the surface index of the new window.
-    pub fn detach_tab(
-        &mut self,
-        (src_surface, src_node, src_tab): (SurfaceIndex, NodeIndex, TabIndex),
-        window_rect: Rect,
-    ) -> SurfaceIndex {
+    pub fn detach_tab(&mut self, src: TabPath, window_rect: Rect) -> SurfaceIndex {
         // Remove the tab from the tree and it add to a new window.
-        let tab = self[src_surface][src_node].remove_tab(src_tab).unwrap();
+        let tab = self[src.node_path()].remove_tab(src.tab).unwrap();
         let surface_index = self.add_window(vec![tab]);
 
         // Set the window size and position to match `window_rect`.
         let state = self.get_window_state_mut(surface_index).unwrap();
         state.set_position(window_rect.min);
-        if src_surface.is_main() {
+        if src.surface.is_main() {
             state.set_size(window_rect.size() * 0.8);
         } else {
             state.set_size(window_rect.size());
         }
 
         // Clean up any empty leaves and surfaces which may be left behind from the detachment.
-        if self[src_surface][src_node].is_leaf() && self[src_surface][src_node].tabs_count() == 0 {
-            self[src_surface].remove_leaf(src_node);
+        if self[src.node_path()].is_leaf() && self[src.node_path()].tabs_count() == 0 {
+            self[src.surface].remove_leaf(src.node);
         }
-        if self[src_surface].is_empty() && !src_surface.is_main() {
-            self.remove_surface(src_surface);
+        if self[src.surface].is_empty() && !src.surface.is_main() {
+            self.remove_surface(src.surface);
         }
         surface_index
     }
 
     /// Currently focused leaf.
     #[inline]
-    pub fn focused_leaf(&self) -> Option<(SurfaceIndex, NodeIndex)> {
+    pub fn focused_leaf(&self) -> Option<NodePath> {
         let surface = self.focused_surface?;
-        self[surface].focused_leaf().map(|leaf| (surface, leaf))
+        self[surface].focused_leaf().map(|leaf| NodePath {
+            surface,
+            node: leaf,
+        })
     }
 
     /// Remove a tab at the specified surface, node, and tab index.
     /// This method will yield the removed tab, or `None` if it doesn't exist.
-    pub fn remove_tab(
-        &mut self,
-        (surface_index, node_index, tab_index): (SurfaceIndex, NodeIndex, TabIndex),
-    ) -> Option<Tab> {
-        let removed_tab = self[surface_index].remove_tab((node_index, tab_index));
-        if !surface_index.is_main() && self[surface_index].is_empty() {
-            self.remove_surface(surface_index);
+    pub fn remove_tab(&mut self, path: TabPath) -> Option<Tab> {
+        let removed_tab = self[path.surface].remove_tab((path.node, path.tab));
+        if !path.surface.is_main() && self[path.surface].is_empty() {
+            self.remove_surface(path.surface);
         }
         removed_tab
     }
 
     /// Remove a leaf at the specified surface, and node index.
-    pub fn remove_leaf(&mut self, (surface_index, node_index): (SurfaceIndex, NodeIndex)) {
-        self[surface_index].remove_leaf(node_index);
-        if !surface_index.is_main() && self[surface_index].is_empty() {
-            self.remove_surface(surface_index);
+    pub fn remove_leaf(&mut self, path: NodePath) {
+        self[path.surface].remove_leaf(path.node);
+        if !path.surface.is_main() && self[path.surface].is_empty() {
+            self.remove_surface(path.surface);
         }
     }
 
@@ -330,13 +397,13 @@ impl<Tab> DockState<Tab> {
     /// Returns the indices of the old node and the new node.
     pub fn split(
         &mut self,
-        (surface, parent): (SurfaceIndex, NodeIndex),
+        parent_path: NodePath,
         split: Split,
         fraction: f32,
         new: Node<Tab>,
     ) -> [NodeIndex; 2] {
-        let index = self[surface].split(parent, split, fraction, new);
-        self.focused_surface = Some(surface);
+        let index = self[parent_path.surface].split(parent_path.node, split, fraction, new);
+        self.focused_surface = Some(parent_path.surface);
         index
     }
 
@@ -413,58 +480,102 @@ impl<Tab> DockState<Tab> {
         self.surfaces.iter()
     }
 
+    /// Returns an [`Iterator`] over all surfaces with their corresponding [`SurfaceIndex`].
+    pub fn iter_surfaces_indexed(&self) -> impl Iterator<Item = (SurfaceIndex, &Surface<Tab>)> {
+        self.surfaces
+            .iter()
+            .enumerate()
+            .map(|(index, surface)| (SurfaceIndex(index), surface))
+    }
+
     /// Returns a mutable [`Iterator`] over all surfaces.
     pub fn iter_surfaces_mut(&mut self) -> impl Iterator<Item = &mut Surface<Tab>> {
         self.surfaces.iter_mut()
     }
 
+    /// Returns a mutable [`Iterator`] over all surfaces with their corresponding [`SurfaceIndex`].
+    pub fn iter_surfaces_mut_indexed(
+        &mut self,
+    ) -> impl Iterator<Item = (SurfaceIndex, &mut Surface<Tab>)> {
+        self.surfaces
+            .iter_mut()
+            .enumerate()
+            .map(|(index, surface)| (SurfaceIndex(index), surface))
+    }
+
     /// Returns an [`Iterator`] of **all** underlying nodes in the dock state,
     /// and the indices of containing surfaces.
-    pub fn iter_all_nodes(&self) -> impl Iterator<Item = (SurfaceIndex, &Node<Tab>)> {
-        self.iter_surfaces()
-            .enumerate()
+    pub fn iter_all_nodes(&self) -> impl Iterator<Item = (NodePath, &Node<Tab>)> {
+        self.iter_surfaces_indexed()
             .flat_map(|(surface_index, surface)| {
-                surface
-                    .iter_nodes()
-                    .map(move |node| (surface_index.into(), node))
+                surface.iter_nodes_indexed().map(move |(node_index, node)| {
+                    (
+                        NodePath {
+                            surface: surface_index,
+                            node: node_index,
+                        },
+                        node,
+                    )
+                })
             })
     }
 
     /// Returns a mutable [`Iterator`] of **all** underlying nodes in the dock state,
     /// and the indices of containing surfaces.
-    pub fn iter_all_nodes_mut(&mut self) -> impl Iterator<Item = (SurfaceIndex, &mut Node<Tab>)> {
-        self.iter_surfaces_mut()
-            .enumerate()
+    pub fn iter_all_nodes_mut(&mut self) -> impl Iterator<Item = (NodePath, &mut Node<Tab>)> {
+        self.iter_surfaces_mut_indexed()
             .flat_map(|(surface_index, surface)| {
                 surface
-                    .iter_nodes_mut()
-                    .map(move |node| (surface_index.into(), node))
+                    .iter_nodes_mut_indexed()
+                    .map(move |(node_index, node)| {
+                        (
+                            NodePath {
+                                surface: surface_index,
+                                node: node_index,
+                            },
+                            node,
+                        )
+                    })
             })
     }
 
     /// Returns an [`Iterator`] of **all** tabs in the dock state,
     /// and the indices of containing surfaces and nodes.
-    pub fn iter_all_tabs(&self) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &Tab)> {
-        self.iter_surfaces()
-            .enumerate()
+    pub fn iter_all_tabs(&self) -> impl Iterator<Item = (TabPath, &Tab)> {
+        self.iter_surfaces_indexed()
             .flat_map(|(surface_index, surface)| {
                 surface
                     .iter_all_tabs()
-                    .map(move |(node_index, tab)| ((surface_index.into(), node_index), tab))
+                    .map(move |((node_index, tab_index), tab)| {
+                        (
+                            TabPath {
+                                surface: surface_index,
+                                node: node_index,
+                                tab: tab_index,
+                            },
+                            tab,
+                        )
+                    })
             })
     }
 
     /// Returns a mutable [`Iterator`] of **all** tabs in the dock state,
     /// and the indices of containing surfaces and nodes.
-    pub fn iter_all_tabs_mut(
-        &mut self,
-    ) -> impl Iterator<Item = ((SurfaceIndex, NodeIndex), &mut Tab)> {
-        self.iter_surfaces_mut()
-            .enumerate()
+    pub fn iter_all_tabs_mut(&mut self) -> impl Iterator<Item = (TabPath, &mut Tab)> {
+        self.iter_surfaces_mut_indexed()
             .flat_map(|(surface_index, surface)| {
                 surface
                     .iter_all_tabs_mut()
-                    .map(move |(node_index, tab)| ((surface_index.into(), node_index), tab))
+                    .map(move |((node_index, tab_index), tab)| {
+                        (
+                            TabPath {
+                                surface: surface_index,
+                                node: node_index,
+                                tab: tab_index,
+                            },
+                            tab,
+                        )
+                    })
             })
     }
 
@@ -490,13 +601,13 @@ impl<Tab> DockState<Tab> {
     }
 
     /// Returns an immutable [`Iterator`] of all [``LeafNode``]s in the dock state.
-    pub fn iter_leaves(&self) -> impl Iterator<Item = (SurfaceIndex, &LeafNode<Tab>)> {
+    pub fn iter_leaves(&self) -> impl Iterator<Item = (NodePath, &LeafNode<Tab>)> {
         self.iter_all_nodes()
             .filter_map(|(index, node)| node.get_leaf().map(|leaf| (index, leaf)))
     }
 
     /// Returns a mutable [`Iterator`] of all [``LeafNode``]s in the dock state.
-    pub fn iter_leaves_mut(&mut self) -> impl Iterator<Item = (SurfaceIndex, &mut LeafNode<Tab>)> {
+    pub fn iter_leaves_mut(&mut self) -> impl Iterator<Item = (NodePath, &mut LeafNode<Tab>)> {
         self.iter_all_nodes_mut()
             .filter_map(|(index, node)| node.get_leaf_mut().map(|leaf| (index, leaf)))
     }
@@ -600,16 +711,17 @@ impl<Tab> DockState<Tab> {
     /// The returned [`NodeIndex`] will always point to a [`Node::Leaf`].
     ///
     /// In case there are several hits, only the first is returned.
-    pub fn find_tab_from(
-        &self,
-        predicate: impl Fn(&Tab) -> bool,
-    ) -> Option<(SurfaceIndex, NodeIndex, TabIndex)> {
+    pub fn find_tab_from(&self, predicate: impl Fn(&Tab) -> bool) -> Option<TabPath> {
         for &surface_index in self.valid_surface_indices().iter() {
             if self.surfaces[surface_index.0].is_empty() {
                 continue;
             }
             if let Some((node_index, tab_index)) = self[surface_index].find_tab_from(&predicate) {
-                return Some((surface_index, node_index, tab_index));
+                return Some(TabPath {
+                    surface: surface_index,
+                    node: node_index,
+                    tab: tab_index,
+                });
             }
         }
         None
@@ -629,7 +741,7 @@ where
     /// In case there are several hits, only the first is returned.
     ///
     /// See also: [`find_main_surface_tab`](DockState::find_main_surface_tab)
-    pub fn find_tab(&self, needle_tab: &Tab) -> Option<(SurfaceIndex, NodeIndex, TabIndex)> {
+    pub fn find_tab(&self, needle_tab: &Tab) -> Option<TabPath> {
         self.find_tab_from(|tab| tab == needle_tab)
     }
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -717,11 +717,7 @@ impl<Tab> DockState<Tab> {
                 continue;
             }
             if let Some((node_index, tab_index)) = self[surface_index].find_tab_from(&predicate) {
-                return Some(TabPath {
-                    surface: surface_index,
-                    node: node_index,
-                    tab: tab_index,
-                });
+                return Some(TabPath::new(surface_index, node_index, tab_index));
             }
         }
         None

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -237,7 +237,13 @@ impl<Tab> DockState<Tab> {
                         self[dst_surface].split(dst_node, split, 0.5, Node::leaf(tab));
                     }
 
-                    TabInsert::Insert(index) => self[dst_surface][dst_node].insert_tab(index, tab),
+                    TabInsert::Insert(index) => {
+                        // Clamp index to valid range: after remove_tab the node may have fewer tabs
+                        // than the original index (e.g. when reordering within the same node).
+                        let count = self[dst_surface][dst_node].tabs_count();
+                        let clamped = TabIndex(count.min(index.0));
+                        self[dst_surface][dst_node].insert_tab(clamped, tab);
+                    }
                     TabInsert::Append => self[dst_surface][dst_node].append_tab(tab),
                 }
             }

--- a/src/dock_state/surface.rs
+++ b/src/dock_state/surface.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use crate::{Node, NodeIndex, Tree, WindowState};
+use crate::{Node, NodeIndex, TabIndex, Tree, WindowState};
 
 /// A [`Surface`] is the highest level component in a [`DockState`](crate::DockState). [`Surface`]s represent an area
 /// in which nodes are placed.
@@ -73,6 +73,14 @@ impl<Tab> Surface<Tab> {
         }
     }
 
+    /// Returns an [`Iterator`] of nodes in this surface's tree with their corresponding
+    /// [`NodeIndex`].
+    pub fn iter_nodes_indexed(&self) -> impl Iterator<Item = (NodeIndex, &Node<Tab>)> {
+        self.iter_nodes()
+            .enumerate()
+            .map(|(index, node)| (NodeIndex(index), node))
+    }
+
     /// Returns a mutable [`Iterator`] of nodes in this surface's tree.
     ///
     /// If the surface is [`Empty`](Self::Empty), then the returned [`Iterator`] will be empty.
@@ -83,20 +91,31 @@ impl<Tab> Surface<Tab> {
         }
     }
 
-    /// Returns an [`Iterator`] of **all** tabs in this surface's tree,
-    /// and indices of containing nodes.
-    pub fn iter_all_tabs(&self) -> impl Iterator<Item = (NodeIndex, &Tab)> {
-        self.iter_nodes()
-            .enumerate()
-            .flat_map(|(index, node)| node.iter_tabs().map(move |tab| (NodeIndex(index), tab)))
-    }
-
-    /// Returns a mutable [`Iterator`] of **all** tabs in this surface's tree,
-    /// and indices of containing nodes.
-    pub fn iter_all_tabs_mut(&mut self) -> impl Iterator<Item = (NodeIndex, &mut Tab)> {
+    /// Returns a mutable [`Iterator`] of nodes in this surface's tree with their corresponding
+    /// [`NodeIndex`].
+    pub fn iter_nodes_mut_indexed(&mut self) -> impl Iterator<Item = (NodeIndex, &mut Node<Tab>)> {
         self.iter_nodes_mut()
             .enumerate()
-            .flat_map(|(index, node)| node.iter_tabs_mut().map(move |tab| (NodeIndex(index), tab)))
+            .map(|(index, node)| (NodeIndex(index), node))
+    }
+
+    /// Returns an [`Iterator`] of **all** tabs in this surface's tree
+    /// and their corresponding paths within the surface.
+    pub fn iter_all_tabs(&self) -> impl Iterator<Item = ((NodeIndex, TabIndex), &Tab)> {
+        self.iter_nodes_indexed().flat_map(|(node_index, node)| {
+            node.iter_tabs_indexed()
+                .map(move |(tab_index, tab)| ((node_index, tab_index), tab))
+        })
+    }
+
+    /// Returns a mutable [`Iterator`] of **all** tabs in this surface's tree
+    /// and their corresponding paths within the surface.
+    pub fn iter_all_tabs_mut(&mut self) -> impl Iterator<Item = ((NodeIndex, TabIndex), &mut Tab)> {
+        self.iter_nodes_mut_indexed()
+            .flat_map(|(node_index, node)| {
+                node.iter_tabs_mut_indexed()
+                    .map(move |(tab_index, tab)| ((node_index, tab_index), tab))
+            })
     }
 
     /// Returns a new [`Surface`] while mapping and filtering the tab type.

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -20,15 +20,6 @@ pub mod node;
 /// Wrapper around indices to the collection of nodes inside a [`Tree`].
 pub mod node_index;
 
-pub use node::LeafNode;
-pub use node::Node;
-pub use node::SplitNode;
-pub use node_index::NodeIndex;
-pub use tab_index::TabIndex;
-pub use tab_iter::TabIter;
-
-use egui::ahash::HashSet;
-use egui::Rect;
 use std::{
     cmp::max,
     fmt,
@@ -36,7 +27,16 @@ use std::{
     slice::{Iter, IterMut},
 };
 
-use crate::SurfaceIndex;
+use egui::ahash::HashSet;
+use egui::Rect;
+pub use node::LeafNode;
+pub use node::Node;
+pub use node::SplitNode;
+pub use node_index::{NodeIndex, NodePath};
+pub use tab_index::{TabIndex, TabPath};
+pub use tab_iter::TabIter;
+
+use crate::{Error, Result, SurfaceIndex};
 
 // ----------------------------------------------------------------------------
 
@@ -79,16 +79,16 @@ pub enum TabDestination {
     /// Move to a new window with this rect.
     Window(Rect),
 
-    /// Move to a an existing node with this insertion.
-    Node(SurfaceIndex, NodeIndex, TabInsert),
+    /// Move to an existing node with this insertion.
+    Node(NodePath, TabInsert),
 
     /// Move to an empty surface.
     EmptySurface(SurfaceIndex),
 }
 
-impl From<(SurfaceIndex, NodeIndex, TabInsert)> for TabDestination {
-    fn from(value: (SurfaceIndex, NodeIndex, TabInsert)) -> TabDestination {
-        TabDestination::Node(value.0, value.1, value.2)
+impl From<(NodePath, TabInsert)> for TabDestination {
+    fn from(value: (NodePath, TabInsert)) -> TabDestination {
+        TabDestination::Node(value.0, value.1)
     }
 }
 
@@ -533,6 +533,28 @@ impl<Tab> Tree<Tab> {
         index
     }
 
+    /// Immutably borrows a leaf node at the given path.
+    ///
+    /// Returns `Err` if the path is invalid or the node at the path is not a leaf.
+    pub fn leaf(&self, node: NodeIndex) -> Result<&LeafNode<Tab>> {
+        self.nodes
+            .get(node.0)
+            .ok_or(Error::InvalidNode)?
+            .get_leaf()
+            .ok_or(Error::NonLeafNode)
+    }
+
+    /// Mutably borrows a leaf node at the given index.
+    ///
+    /// Returns `Err` if the index is invalid or if the node is not a leaf.
+    pub fn leaf_mut(&mut self, node: NodeIndex) -> Result<&mut LeafNode<Tab>> {
+        self.nodes
+            .get_mut(node.0)
+            .ok_or(Error::InvalidNode)?
+            .get_leaf_mut()
+            .ok_or(Error::NonLeafNode)
+    }
+
     fn first_leaf(&self, top: NodeIndex) -> Option<NodeIndex> {
         let left = top.left();
         let right = top.right();
@@ -689,15 +711,17 @@ impl<Tab> Tree<Tab> {
     }
 
     /// Sets which is the active tab within a specific node.
+    ///
+    /// # Errors
+    /// If the node is invalid, not a leaf or if the tab index is out of bounds.
     #[inline]
     pub fn set_active_tab(
         &mut self,
         node_index: impl Into<NodeIndex>,
         tab_index: impl Into<TabIndex>,
-    ) {
-        if let Some(Node::Leaf(leaf)) = self.nodes.get_mut(node_index.into().0) {
-            leaf.set_active_tab(tab_index);
-        };
+    ) -> Result {
+        self.leaf_mut(node_index.into())?
+            .set_active_tab(tab_index.into())
     }
 
     /// Pushes `tab` to the currently focused leaf.

--- a/src/dock_state/tree/node/leaf.rs
+++ b/src/dock_state/tree/node/leaf.rs
@@ -2,7 +2,7 @@ use std::ops;
 
 use egui::Rect;
 
-use crate::TabIndex;
+use crate::{Error, Result, TabIndex};
 
 /// The inner data of a [``Node::Leaf``](crate::Node), which contains tabs and can be collapsed.
 #[derive(Clone, Debug)]
@@ -42,12 +42,15 @@ impl<Tab> LeafNode<Tab> {
 
     /// Set the active tab of this [`LeafNode`]
     ///
-    /// If ``active_tab`` is out of bounds, it will be ignored and the active tab will not be changed.
+    /// If `active_tab` is out of bounds, an error is returned and the active tab is not changed.
     #[inline]
-    pub fn set_active_tab(&mut self, active_tab: impl Into<TabIndex>) {
+    pub fn set_active_tab(&mut self, active_tab: impl Into<TabIndex>) -> Result {
         let index = active_tab.into();
         if index.0 < self.len() {
             self.active = index;
+            Ok(())
+        } else {
+            Err(Error::InvalidTab)
         }
     }
 

--- a/src/dock_state/tree/node/leaf.rs
+++ b/src/dock_state/tree/node/leaf.rs
@@ -1,3 +1,5 @@
+use std::ops;
+
 use egui::Rect;
 
 use crate::TabIndex;
@@ -139,5 +141,19 @@ impl<Tab> LeafNode<Tab> {
         self.tabs
             .get_mut(self.active.0)
             .map(|tab| (self.viewport, tab))
+    }
+}
+
+impl<Tab> ops::Index<TabIndex> for LeafNode<Tab> {
+    type Output = Tab;
+
+    fn index(&self, index: TabIndex) -> &Tab {
+        &self.tabs[index.0]
+    }
+}
+
+impl<Tab> ops::IndexMut<TabIndex> for LeafNode<Tab> {
+    fn index_mut(&mut self, index: TabIndex) -> &mut Tab {
+        &mut self.tabs[index.0]
     }
 }

--- a/src/dock_state/tree/node/mod.rs
+++ b/src/dock_state/tree/node/mod.rs
@@ -1,5 +1,6 @@
-use crate::{Split, TabIndex};
 use egui::Rect;
+
+use crate::{Split, TabIndex};
 
 mod leaf;
 mod split;
@@ -219,6 +220,13 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Returns an [`Iterator`] of tabs in this node with their corresponding [`TabIndex`].
+    pub fn iter_tabs_indexed(&self) -> impl Iterator<Item = (TabIndex, &Tab)> {
+        self.iter_tabs()
+            .enumerate()
+            .map(|(index, tab)| (TabIndex(index), tab))
+    }
+
     /// Returns a mutable [`Iterator`] of tabs in this node.
     ///
     /// If this node is not a [`Leaf`](Self::Leaf), then the returned [`Iterator`] will be empty.
@@ -228,6 +236,13 @@ impl<Tab> Node<Tab> {
             Some(tabs) => tabs.iter_mut(),
             None => core::slice::IterMut::default(),
         }
+    }
+
+    /// Returns a mutable [`Iterator`] of tabs in this node with their corresponding [`TabIndex`].
+    pub fn iter_tabs_mut_indexed(&mut self) -> impl Iterator<Item = (TabIndex, &mut Tab)> {
+        self.iter_tabs_mut()
+            .enumerate()
+            .map(|(index, tab)| (TabIndex(index), tab))
     }
 
     /// Adds `tab` to the node and sets it as the active tab.

--- a/src/dock_state/tree/node_index.rs
+++ b/src/dock_state/tree/node_index.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use crate::SurfaceIndex;
+
 /// Wrapper around indices to the collection of nodes inside a [`Tree`](crate::Tree).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -92,5 +94,44 @@ impl NodeIndex {
         let s = (self.0 + 1) * base + (base / 2) - 1;
         let e = (self.0 + 2) * base - 1;
         s..e
+    }
+}
+
+/// A full path to locate a node in an entire dock state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct NodePath {
+    /// Index of the surface owning the node.
+    pub surface: SurfaceIndex,
+    /// Index of the node in the surface tree.
+    pub node: NodeIndex,
+}
+
+impl NodePath {
+    /// Points to the root node of the main surface.
+    pub const MAIN_ROOT: Self = Self {
+        surface: SurfaceIndex::main(),
+        node: NodeIndex::root(),
+    };
+
+    /// Creates a fully qualified new path to a node.
+    pub const fn new(surface: SurfaceIndex, node: NodeIndex) -> Self {
+        Self { surface, node }
+    }
+
+    /// Returns the path to the node to the left of the current one.
+    pub const fn left_node(self) -> Self {
+        Self {
+            surface: self.surface,
+            node: self.node.left(),
+        }
+    }
+
+    /// Returns the path to the node to the right of the current one.
+    pub const fn right_node(self) -> Self {
+        Self {
+            surface: self.surface,
+            node: self.node.right(),
+        }
     }
 }

--- a/src/dock_state/tree/node_index.rs
+++ b/src/dock_state/tree/node_index.rs
@@ -63,13 +63,13 @@ impl NodeIndex {
     /// Returns `true` if current node is the left child of its parent, otherwise `false`.
     #[inline(always)]
     pub const fn is_left(self) -> bool {
-        self.0 % 2 != 0
+        !self.0.is_multiple_of(2)
     }
 
     /// Returns `true` if current node is the right child of its parent, otherwise `false`.
     #[inline(always)]
     pub const fn is_right(self) -> bool {
-        self.0 % 2 == 0
+        self.0.is_multiple_of(2)
     }
 
     #[inline]

--- a/src/dock_state/tree/tab_index.rs
+++ b/src/dock_state/tree/tab_index.rs
@@ -1,4 +1,6 @@
-﻿/// Identifies a tab within a [`Node`](crate::Node).
+use crate::{NodeIndex, NodePath, SurfaceIndex};
+
+/// Identifies a tab within a [`Node`](crate::Node).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct TabIndex(pub usize);
@@ -7,5 +9,38 @@ impl From<usize> for TabIndex {
     #[inline]
     fn from(index: usize) -> Self {
         TabIndex(index)
+    }
+}
+
+/// A full path to locate a tab within an entire dock state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct TabPath {
+    /// Index of the surface owning the node for the tab.
+    pub surface: SurfaceIndex,
+    /// Index of the node for the tab in the surface tree.
+    pub node: NodeIndex,
+    /// Index of the tab in the node.
+    pub tab: TabIndex,
+}
+
+impl TabPath {
+    /// Creates a new fully qualified path to a tab.
+    pub const fn new(surface: SurfaceIndex, node: NodeIndex, tab: TabIndex) -> Self {
+        Self { surface, node, tab }
+    }
+
+    /// Get the node path components.
+    pub fn node_path(self) -> NodePath {
+        NodePath {
+            surface: self.surface,
+            node: self.node,
+        }
+    }
+}
+
+impl From<(NodePath, TabIndex)> for TabPath {
+    fn from((NodePath { surface, node }, tab): (NodePath, TabIndex)) -> Self {
+        TabPath { surface, node, tab }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //!
 //! # let mut my_tabs = MyTabs::new();
 //! # egui::__run_test_ctx(|ctx| {
+//! #     #[allow(deprecated)]
 //! #     egui::CentralPanel::default().show(ctx, |ui| my_tabs.ui(ui));
 //! # });
 //! ```
@@ -93,6 +94,7 @@
 //! #     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {}
 //! # }
 //! # egui::__run_test_ctx(|ctx| {
+//! # #[allow(deprecated)]
 //! # egui::CentralPanel::default().show(ctx, |ui| {
 //! # let mut dock_state = DockState::new(vec![]);
 //! // Inherit the look and feel from egui.

--- a/src/style.rs
+++ b/src/style.rs
@@ -28,6 +28,7 @@ pub enum TabAddAlign {
 /// #     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {}
 /// # }
 /// # egui::__run_test_ctx(|ctx| {
+/// # #[allow(deprecated)]
 /// # egui::CentralPanel::default().show(ctx, |ui| {
 /// # let mut dock_state = DockState::new(vec![]);
 /// // Inherit the look and feel from egui.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
 use egui::emath::*;
+use egui::style::{Visuals, WidgetVisuals, Widgets};
 
 use crate::{
     ButtonsStyle, SeparatorStyle, Style, TabBarStyle, TabBodyStyle, TabInteractionStyle, TabStyle,
 };
-use egui::style::{Visuals, WidgetVisuals, Widgets};
 
 #[inline(always)]
 pub fn expand_to_pixel(mut rect: Rect, ppi: f32) -> Rect {

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -1,11 +1,13 @@
 use std::ops::BitOrAssign;
 
-use crate::{
-    AllowedSplits, NodeIndex, Split, Style, SurfaceIndex, TabDestination, TabIndex, TabInsert,
-};
 use egui::{
     emath::{inverse_lerp, GuiRounding},
     vec2, Context, Id, LayerId, NumExt, Order, Painter, Pos2, Rect, Stroke, StrokeKind, Ui, Vec2,
+};
+
+use crate::{
+    AllowedSplits, NodeIndex, NodePath, Split, Style, SurfaceIndex, TabDestination, TabInsert,
+    TabPath,
 };
 
 #[derive(Debug, Clone)]
@@ -30,19 +32,17 @@ pub(super) struct DragData {
 #[derive(Debug, Clone)]
 pub(super) enum TreeComponent {
     Surface(SurfaceIndex),
-    Node(SurfaceIndex, NodeIndex),
-    Tab(SurfaceIndex, NodeIndex, TabIndex),
+    Node(NodePath),
+    Tab(TabPath),
 }
 
 impl TreeComponent {
     pub(super) fn as_tab_destination(&self) -> TabDestination {
         match *self {
             TreeComponent::Surface(surface) => TabDestination::EmptySurface(surface),
-            TreeComponent::Node(dst_surf, dst_node) => {
-                TabDestination::Node(dst_surf, dst_node, TabInsert::Append)
-            }
-            TreeComponent::Tab(dst_surf, dst_node, tab_index) => {
-                TabDestination::Node(dst_surf, dst_node, TabInsert::Insert(tab_index))
+            TreeComponent::Node(dst) => TabDestination::Node(dst, TabInsert::Append),
+            TreeComponent::Tab(dst) => {
+                TabDestination::Node(dst.node_path(), TabInsert::Insert(dst.tab))
             }
         }
     }
@@ -50,16 +50,16 @@ impl TreeComponent {
     pub(super) fn node_address(&self) -> (SurfaceIndex, Option<NodeIndex>) {
         match *self {
             TreeComponent::Surface(surface) => (surface, None),
-            TreeComponent::Node(dst_surf, dst_node) => (dst_surf, Some(dst_node)),
-            TreeComponent::Tab(dst_surf, dst_node, _) => (dst_surf, Some(dst_node)),
+            TreeComponent::Node(dst) => (dst.surface, Some(dst.node)),
+            TreeComponent::Tab(dst) => (dst.surface, Some(dst.node)),
         }
     }
 
     pub(super) fn surface_address(&self) -> SurfaceIndex {
         match *self {
             TreeComponent::Surface(surface)
-            | TreeComponent::Node(surface, _)
-            | TreeComponent::Tab(surface, _, _) => surface,
+            | TreeComponent::Node(NodePath { surface, .. })
+            | TreeComponent::Tab(TabPath { surface, .. }) => surface,
         }
     }
 
@@ -199,8 +199,8 @@ impl DragDropState {
 
         if button_ui(rect, ui, &mut hovering_buttons, pointer, style, None) {
             match self.hover.dst {
-                TreeComponent::Node(surface, node) => {
-                    destination = Some(TabDestination::Node(surface, node, TabInsert::Append))
+                TreeComponent::Node(path) => {
+                    destination = Some(TabDestination::Node(path, TabInsert::Append))
                 }
                 TreeComponent::Surface(surface) => {
                     destination = Some(TabDestination::EmptySurface(surface))
@@ -230,9 +230,8 @@ impl DragDropState {
                         style,
                         Some(split),
                     ) {
-                        if let TreeComponent::Node(surface, node) = self.hover.dst {
-                            destination =
-                                Some(TabDestination::Node(surface, node, TabInsert::Split(split)))
+                        if let TreeComponent::Node(path) = self.hover.dst {
+                            destination = Some(TabDestination::Node(path, TabInsert::Split(split)))
                         }
                     }
                 }
@@ -350,7 +349,7 @@ impl DragDropState {
             .then(|| TabDestination::Window(Rect::from_min_size(pointer, self.drag.rect.size())));
         let final_result = tab_insertion.map_or(default_value, |tab| match self.hover.dst {
             TreeComponent::Surface(surface) => Some(TabDestination::EmptySurface(surface)),
-            TreeComponent::Node(surface, node) => Some(TabDestination::Node(surface, node, tab)),
+            TreeComponent::Node(path) => Some(TabDestination::Node(path, tab)),
             _ => None,
         });
 

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -9,11 +9,11 @@ mod drag_and_drop;
 mod state;
 mod tab_removal;
 
-use crate::{dock_state::DockState, NodeIndex, Style, SurfaceIndex, TabIndex};
 pub use allowed_splits::AllowedSplits;
+use egui::{emath::*, Id, Modifiers};
 use tab_removal::TabRemoval;
 
-use egui::{emath::*, Id, Modifiers};
+use crate::{dock_state::DockState, NodePath, Style, TabIndex, TabPath};
 
 /// Displays a [`DockState`] in `egui`.
 pub struct DockArea<'tree, Tab> {
@@ -38,8 +38,8 @@ pub struct DockArea<'tree, Tab> {
     window_bounds: Option<Rect>,
 
     to_remove: Vec<TabRemoval>,
-    to_detach: Vec<(SurfaceIndex, NodeIndex, TabIndex)>,
-    new_focused: Option<(SurfaceIndex, NodeIndex)>,
+    to_detach: Vec<TabPath>,
+    new_focused: Option<NodePath>,
     tab_hover_rect: Option<(Rect, TabIndex)>,
 }
 

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -34,6 +34,11 @@ impl<Tab> DockArea<'_, Tab> {
         let rect = self.dock_state[surface_index][node_index]
             .rect()
             .expect("This node must be a leaf");
+
+        if rect.width() <= 0.0 || rect.height() <= 0.0 {
+            return;
+        }
+
         let ui = &mut ui.new_child(
             UiBuilder::new()
                 .max_rect(rect)
@@ -1101,7 +1106,9 @@ impl<Tab> DockArea<'_, Tab> {
         tab_hovered: bool,
         fade_style: Option<&Style>,
     ) {
-        assert_ne!(available_width, 0.0);
+        if available_width <= 0.0 {
+            return;
+        }
 
         let leaf = self.dock_state[surface_index][node_index]
             .get_leaf_mut()

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1,13 +1,16 @@
+use std::ops::RangeInclusive;
+
 use egui::{
     emath::TSTransform, epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, Color32,
     CornerRadius, CursorIcon, Frame, Id, Key, LayerId, Layout, NumExt, Order, Popup,
     PopupCloseBehavior, Rect, Response, ScrollArea, Sense, Shape, Stroke, StrokeKind, TextStyle,
     Ui, UiBuilder, Vec2, WidgetText,
 };
-use std::ops::RangeInclusive;
 
 use crate::dock_area::tab_removal::{ForcedRemoval, TabRemoval};
 use crate::node::LeafNode;
+use crate::tab_viewer::OnCloseResponse;
+use crate::NodePath;
 use crate::{
     dock_area::{
         drag_and_drop::{DragData, DragDropState, HoverData, TreeComponent},
@@ -17,21 +20,19 @@ use crate::{
     DockArea, Node, NodeIndex, Style, SurfaceIndex, TabAddAlign, TabIndex, TabStyle, TabViewer,
 };
 
-use crate::tab_viewer::OnCloseResponse;
-
 impl<Tab> DockArea<'_, Tab> {
     pub(super) fn show_leaf(
         &mut self,
         ui: &mut Ui,
         state: &mut State,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
+        path: NodePath,
         tab_viewer: &mut impl TabViewer<Tab = Tab>,
         fade_style: Option<(&Style, f32)>,
     ) {
-        assert!(self.dock_state[surface_index][node_index].is_leaf());
-        let collapsed = self.dock_state[surface_index][node_index].is_collapsed();
+        assert!(self.dock_state[path].is_leaf());
+        let collapsed = self.dock_state[path].is_collapsed();
 
-        let rect = self.dock_state[surface_index][node_index]
+        let rect = self.dock_state[path]
             .rect()
             .expect("This node must be a leaf");
 
@@ -43,19 +44,19 @@ impl<Tab> DockArea<'_, Tab> {
             UiBuilder::new()
                 .max_rect(rect)
                 .layout(Layout::top_down_justified(Align::Min))
-                .id_salt((node_index, "node")),
+                .id_salt((path.node, "node")),
         );
         let spacing = ui.spacing().item_spacing;
         ui.spacing_mut().item_spacing = Vec2::ZERO;
         ui.set_clip_rect(rect);
 
-        if self.dock_state[surface_index][node_index].tabs_count() == 0 {
+        if self.dock_state[path].tabs_count() == 0 {
             return;
         }
         let tabbar_rect = self.tab_bar(
             ui,
             state,
-            (surface_index, node_index),
+            path,
             tab_viewer,
             fade_style.map(|(style, _)| style),
             collapsed,
@@ -63,7 +64,7 @@ impl<Tab> DockArea<'_, Tab> {
         self.tab_body(
             ui,
             state,
-            (surface_index, node_index),
+            path,
             tab_viewer,
             spacing,
             tabbar_rect,
@@ -71,15 +72,13 @@ impl<Tab> DockArea<'_, Tab> {
             collapsed,
         );
 
-        let tabs = self.dock_state[surface_index][node_index]
+        let tabs = self.dock_state[path]
             .tabs_mut()
             .expect("This node must be a leaf here");
         for (tab_index, tab) in tabs.iter_mut().enumerate() {
             if tab_viewer.force_close(tab) {
                 self.to_remove.push(TabRemoval::Tab(
-                    surface_index,
-                    node_index,
-                    TabIndex(tab_index),
+                    (path, TabIndex(tab_index)).into(),
                     ForcedRemoval(true),
                 ));
             }
@@ -90,12 +89,12 @@ impl<Tab> DockArea<'_, Tab> {
         &mut self,
         ui: &mut Ui,
         state: &mut State,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
+        path: NodePath,
         tab_viewer: &mut impl TabViewer<Tab = Tab>,
         fade_style: Option<&Style>,
         collapsed: bool,
     ) -> Rect {
-        assert!(self.dock_state[surface_index][node_index].is_leaf());
+        assert!(self.dock_state[path].is_leaf());
 
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let (tabbar_outer_rect, tabbar_response) = ui.allocate_exact_size(
@@ -131,8 +130,9 @@ impl<Tab> DockArea<'_, Tab> {
         }
 
         let (actual_width, tab_hovered) = {
-            let leaf = self.dock_state[surface_index][node_index]
-                .get_leaf_mut()
+            let leaf = self
+                .dock_state
+                .leaf_mut(path)
                 .expect("This node must be a leaf");
 
             let tabbar_inner_rect = Rect::from_min_size(
@@ -172,7 +172,7 @@ impl<Tab> DockArea<'_, Tab> {
             let tab_hovered = self.tabs(
                 tabs_ui,
                 state,
-                (surface_index, node_index),
+                path,
                 tab_viewer,
                 tabbar_outer_rect,
                 prefered_width,
@@ -201,27 +201,20 @@ impl<Tab> DockArea<'_, Tab> {
                 } else {
                     0.0
                 };
-                self.tab_plus(
-                    ui,
-                    surface_index,
-                    node_index,
-                    tab_viewer,
-                    tabbar_outer_rect,
-                    offset,
-                    fade_style,
-                );
+                self.tab_plus(ui, path, tab_viewer, tabbar_outer_rect, offset, fade_style);
             }
 
             if self.show_leaf_close_all_buttons {
                 // Current leaf contains non-closable tabs.
-                let disabled = self.dock_state[surface_index][node_index]
-                    .get_leaf_mut()
+                let disabled = self
+                    .dock_state
+                    .leaf_mut(path)
                     .map(|leaf| !leaf.tabs.iter_mut().all(|tab| tab_viewer.is_closeable(tab)))
                     .expect("This node must be a leaf");
 
                 // Current window contains non-closable tabs.
                 let close_window_disabled = disabled
-                    || !self.dock_state[surface_index].iter_mut().all(|node| {
+                    || !self.dock_state[path.surface].iter_mut().all(|node| {
                         node.get_leaf_mut().is_none_or(|leaf| {
                             leaf.tabs.iter_mut().all(|tab| tab_viewer.is_closeable(tab))
                         })
@@ -229,8 +222,7 @@ impl<Tab> DockArea<'_, Tab> {
 
                 self.tab_close_all(
                     ui,
-                    surface_index,
-                    node_index,
+                    path,
                     tabbar_outer_rect,
                     fade_style,
                     disabled,
@@ -239,14 +231,7 @@ impl<Tab> DockArea<'_, Tab> {
             }
 
             if self.show_leaf_collapse_buttons {
-                self.tab_collapse(
-                    ui,
-                    surface_index,
-                    node_index,
-                    tabbar_outer_rect,
-                    fade_style,
-                    collapsed,
-                )
+                self.tab_collapse(ui, path, tabbar_outer_rect, fade_style, collapsed)
             }
 
             (tabs_ui.min_rect().width(), tab_hovered)
@@ -255,7 +240,7 @@ impl<Tab> DockArea<'_, Tab> {
         self.tab_bar_scroll(
             ui,
             state,
-            (surface_index, node_index),
+            path,
             actual_width,
             available_width,
             scroll_bar_width,
@@ -272,7 +257,7 @@ impl<Tab> DockArea<'_, Tab> {
         &mut self,
         tabs_ui: &mut Ui,
         state: &mut State,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
+        path: NodePath,
         tab_viewer: &mut impl TabViewer<Tab = Tab>,
         tabbar_outer_rect: Rect,
         preferred_width: Option<f32>,
@@ -280,11 +265,11 @@ impl<Tab> DockArea<'_, Tab> {
     ) -> bool {
         let mut tab_hovered = false;
 
-        assert!(self.dock_state[surface_index][node_index].is_leaf());
+        assert!(self.dock_state[path].is_leaf());
 
         let focused = self.dock_state.focused_leaf();
         let tabs_len = {
-            let tabs = self.dock_state[surface_index][node_index]
+            let tabs = self.dock_state[path]
                 .tabs()
                 .expect("This node must be a leaf here");
             tabs.len()
@@ -293,8 +278,8 @@ impl<Tab> DockArea<'_, Tab> {
         for tab_index in 0..tabs_len {
             let id = self
                 .id
-                .with((surface_index, "surface"))
-                .with((node_index, "node"))
+                .with((path.surface, "surface"))
+                .with((path.node, "node"))
                 .with((tab_index, "tab"));
             let tab_index = TabIndex(tab_index);
             let is_being_dragged = tabs_ui.ctx().is_being_dragged(id)
@@ -306,7 +291,7 @@ impl<Tab> DockArea<'_, Tab> {
             }
 
             let (is_active, label, tab_style, closeable) = {
-                let leaf = self.dock_state[surface_index][node_index]
+                let leaf = self.dock_state[path]
                     .get_leaf_mut()
                     .expect("This node must be a leaf");
                 let style = fade.unwrap_or_else(|| self.style.as_ref().unwrap());
@@ -330,7 +315,7 @@ impl<Tab> DockArea<'_, Tab> {
                             &tab_style,
                             id,
                             label,
-                            is_active && Some((surface_index, node_index)) == focused,
+                            is_active && Some(path) == focused,
                             is_active,
                             is_being_dragged,
                             preferred_width,
@@ -356,10 +341,8 @@ impl<Tab> DockArea<'_, Tab> {
                             mem.data.insert_temp(
                                 self.id.with("drag_data"),
                                 Some(DragData {
-                                    src: TreeComponent::Tab(surface_index, node_index, tab_index),
-                                    rect: self.dock_state[surface_index][node_index]
-                                        .rect()
-                                        .unwrap(),
+                                    src: TreeComponent::Tab((path, tab_index).into()),
+                                    rect: self.dock_state[path].rect().unwrap(),
                                 }),
                             );
                         });
@@ -376,7 +359,7 @@ impl<Tab> DockArea<'_, Tab> {
                     &tab_style,
                     id,
                     label,
-                    is_active && Some((surface_index, node_index)) == focused,
+                    is_active && Some(path) == focused,
                     is_active,
                     is_being_dragged,
                     preferred_width,
@@ -385,10 +368,10 @@ impl<Tab> DockArea<'_, Tab> {
                 );
                 let title_id = response.id;
                 let close_clicked = close_response.is_some_and(|res| res.clicked());
-                let is_lonely_tab = self.dock_state[surface_index].num_tabs() == 1;
+                let is_lonely_tab = self.dock_state[path.surface].num_tabs() == 1;
 
                 if self.show_tab_name_on_hover {
-                    let tabs = self.dock_state[surface_index][node_index]
+                    let tabs = self.dock_state[path]
                         .tabs_mut()
                         .expect("This node must be a leaf");
                     let tab = &mut tabs[tab_index.0];
@@ -404,30 +387,28 @@ impl<Tab> DockArea<'_, Tab> {
                         Button::new(&self.dock_state.translations.tab_context_menu.close_button);
 
                     response.context_menu(|ui| {
-                        let leaf = self.dock_state[surface_index][node_index]
+                        let leaf = self.dock_state[path]
                             .get_leaf_mut()
                             .expect("This node must be a leaf");
                         let tab = &mut leaf.tabs[tab_index.0];
 
-                        tab_viewer.context_menu(ui, tab, surface_index, node_index);
-                        if (surface_index.is_main() || !is_lonely_tab)
+                        tab_viewer.context_menu(ui, tab, path);
+                        if (path.surface.is_main() || !is_lonely_tab)
                             && tab_viewer.allowed_in_windows(tab)
                             && ui.add(eject_button).clicked()
                         {
-                            self.to_detach.push((surface_index, node_index, tab_index));
+                            self.to_detach.push((path, tab_index).into());
                             ui.close();
                         }
                         if show_close_button && ui.add(close_button).clicked() {
                             match tab_viewer.on_close(tab) {
                                 OnCloseResponse::Close => self.to_remove.push(TabRemoval::Tab(
-                                    surface_index,
-                                    node_index,
-                                    tab_index,
+                                    (path, tab_index).into(),
                                     ForcedRemoval(false),
                                 )),
                                 OnCloseResponse::Focus => {
                                     leaf.active = tab_index;
-                                    self.new_focused = Some((surface_index, node_index));
+                                    self.new_focused = Some(path);
                                 }
                                 OnCloseResponse::Ignore => (),
                             }
@@ -438,9 +419,7 @@ impl<Tab> DockArea<'_, Tab> {
 
                 if close_clicked {
                     self.to_remove.push(TabRemoval::Tab(
-                        surface_index,
-                        node_index,
-                        tab_index,
+                        (path, tab_index).into(),
                         ForcedRemoval(false),
                     ));
                 }
@@ -462,9 +441,7 @@ impl<Tab> DockArea<'_, Tab> {
             }
 
             // Paint hline below each tab unless its active (or option says otherwise).
-            let leaf = self.dock_state[surface_index][node_index]
-                .get_leaf_mut()
-                .unwrap();
+            let leaf = self.dock_state.leaf_mut(path).unwrap();
             let tab = &mut leaf.tabs[tab_index.0];
             let style = fade.unwrap_or_else(|| self.style.as_ref().unwrap());
             let tab_style = tab_viewer.tab_style_override(tab, &style.tab);
@@ -484,7 +461,7 @@ impl<Tab> DockArea<'_, Tab> {
                     && tabs_ui.input(|i| i.key_pressed(Key::Enter) || i.key_pressed(Key::Space)))
             {
                 leaf.active = tab_index;
-                self.new_focused = Some((surface_index, node_index));
+                self.new_focused = Some(path);
             }
 
             tab_viewer.on_tab_button(tab, &response);
@@ -492,9 +469,7 @@ impl<Tab> DockArea<'_, Tab> {
             if self.show_close_buttons && tab_viewer.is_closeable(tab) && response.middle_clicked()
             {
                 self.to_remove.push(TabRemoval::Tab(
-                    surface_index,
-                    node_index,
-                    tab_index,
+                    (path, tab_index).into(),
                     ForcedRemoval(false),
                 ));
             }
@@ -508,8 +483,7 @@ impl<Tab> DockArea<'_, Tab> {
     fn tab_plus(
         &mut self,
         ui: &mut Ui,
-        surface_index: SurfaceIndex,
-        node_index: NodeIndex,
+        path: NodePath,
         tab_viewer: &mut impl TabViewer<Tab = Tab>,
         tabbar_outer_rect: Rect,
         offset: f32,
@@ -524,7 +498,7 @@ impl<Tab> DockArea<'_, Tab> {
             UiBuilder::new()
                 .max_rect(rect)
                 .layout(Layout::left_to_right(Align::Center))
-                .id_salt((node_index, "tab_add")),
+                .id_salt((path.node, "tab_add")),
         );
 
         let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
@@ -569,12 +543,12 @@ impl<Tab> DockArea<'_, Tab> {
                 .id(popup_id)
                 .close_behavior(PopupCloseBehavior::CloseOnClickOutside)
                 .show(|ui| {
-                    tab_viewer.add_popup(ui, surface_index, node_index);
+                    tab_viewer.add_popup(ui, path);
                 });
         }
 
         if response.clicked() {
-            tab_viewer.on_add(surface_index, node_index);
+            tab_viewer.on_add(path);
         }
     }
 
@@ -584,8 +558,7 @@ impl<Tab> DockArea<'_, Tab> {
     fn tab_close_all(
         &mut self,
         ui: &mut Ui,
-        surface_index: SurfaceIndex,
-        node_index: NodeIndex,
+        path: NodePath,
         tabbar_outer_rect: Rect,
         fade_style: Option<&Style>,
         disabled: bool,
@@ -600,7 +573,7 @@ impl<Tab> DockArea<'_, Tab> {
             UiBuilder::new()
                 .max_rect(rect)
                 .layout(Layout::left_to_right(Align::Center))
-                .id_salt((node_index, "tab_close_all")),
+                .id_salt((path.node, "tab_close_all")),
         );
 
         let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
@@ -608,7 +581,7 @@ impl<Tab> DockArea<'_, Tab> {
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
 
         // Whether we're on "secondary button mode" due to modifier keys
-        let on_secondary_button = self.is_on_secondary_button(surface_index, ui, &response);
+        let on_secondary_button = self.is_on_secondary_button(path.surface, ui, &response);
 
         let mut stroke_color = if disabled {
             style.buttons.close_all_tabs_disabled_color
@@ -651,7 +624,7 @@ impl<Tab> DockArea<'_, Tab> {
         } else {
             // Close all tabs in this leaf
             if !disabled {
-                if !surface_index.is_main() && self.secondary_button_context_menu {
+                if !path.surface.is_main() && self.secondary_button_context_menu {
                     response.context_menu(|ui| {
                         ui.add_enabled_ui(!close_window_disabled, |ui| {
                             if ui
@@ -665,7 +638,7 @@ impl<Tab> DockArea<'_, Tab> {
                                 )
                                 .clicked()
                             {
-                                self.to_remove.push(TabRemoval::Window(surface_index));
+                                self.to_remove.push(TabRemoval::Window(path.surface));
                             }
                         });
                     });
@@ -685,11 +658,10 @@ impl<Tab> DockArea<'_, Tab> {
             if response.clicked() {
                 if on_secondary_button {
                     if !close_window_disabled {
-                        self.to_remove.push(TabRemoval::Window(surface_index));
+                        self.to_remove.push(TabRemoval::Window(path.surface));
                     }
                 } else if !disabled {
-                    self.to_remove
-                        .push(TabRemoval::Node(surface_index, node_index));
+                    self.to_remove.push(TabRemoval::Node(path));
                 }
             }
 
@@ -714,7 +686,7 @@ impl<Tab> DockArea<'_, Tab> {
         );
 
         if !disabled && !on_secondary_button {
-            response = self.show_tooltip_hints(surface_index, response);
+            response = self.show_tooltip_hints(path.surface, response);
         }
     }
 
@@ -722,8 +694,7 @@ impl<Tab> DockArea<'_, Tab> {
     fn tab_collapse(
         &mut self,
         ui: &mut Ui,
-        surface_index: SurfaceIndex,
-        node_index: NodeIndex,
+        path: NodePath,
         tabbar_outer_rect: Rect,
         fade_style: Option<&Style>,
         collapsed: bool,
@@ -737,7 +708,7 @@ impl<Tab> DockArea<'_, Tab> {
             UiBuilder::new()
                 .max_rect(rect)
                 .layout(Layout::left_to_right(Align::Center))
-                .id_salt((node_index, "tab_collapse")),
+                .id_salt((path.node, "tab_collapse")),
         );
 
         let (rect, mut response) = ui.allocate_exact_size(ui.available_size(), Sense::click());
@@ -747,7 +718,7 @@ impl<Tab> DockArea<'_, Tab> {
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
 
         // Whether we're on "secondary button mode" due to modifier keys
-        let on_secondary_button = self.is_on_secondary_button(surface_index, ui, &response);
+        let on_secondary_button = self.is_on_secondary_button(path.surface, ui, &response);
 
         let color = if response.hovered() || response.has_focus() {
             ui.painter().rect_filled(
@@ -783,28 +754,28 @@ impl<Tab> DockArea<'_, Tab> {
 
         if response.clicked() {
             if on_secondary_button {
-                self.window_toggle_minimized(surface_index);
+                self.window_toggle_minimized(path.surface);
             } else {
-                self.dock_state[surface_index][node_index].set_collapsed(!collapsed);
-                self.dock_state[surface_index].node_update_collapsed(node_index);
-                self.window_update_collapsed(surface_index, node_index);
+                self.dock_state[path].set_collapsed(!collapsed);
+                self.dock_state[path.surface].node_update_collapsed(path.node);
+                self.window_update_collapsed(path);
             }
         }
 
-        if !surface_index.is_main() && self.secondary_button_context_menu {
+        if !path.surface.is_main() && self.secondary_button_context_menu {
             response.context_menu(|ui| {
                 if ui
                     .button(&self.dock_state.translations.leaf.minimize_button)
                     .clicked()
                 {
                     ui.close();
-                    self.window_toggle_minimized(surface_index);
+                    self.window_toggle_minimized(path.surface);
                 }
             });
         }
 
         if !on_secondary_button {
-            self.show_tooltip_hints(surface_index, response);
+            self.show_tooltip_hints(path.surface, response);
         }
     }
 
@@ -934,11 +905,11 @@ impl<Tab> DockArea<'_, Tab> {
     }
 
     /// Updates the collapsed state of the node and its parents.
-    fn window_update_collapsed(&mut self, surface_index: SurfaceIndex, node_index: NodeIndex) {
-        let surface = &mut self.dock_state[surface_index];
-        let collapsed = surface[node_index].is_collapsed();
+    fn window_update_collapsed(&mut self, path: NodePath) {
+        let surface = &mut self.dock_state[path.surface];
+        let collapsed = surface[path.node].is_collapsed();
         if !collapsed {
-            if let Some(window_state) = self.dock_state.get_window_state_mut(surface_index) {
+            if let Some(window_state) = self.dock_state.get_window_state_mut(path.surface) {
                 window_state.set_new(true);
             }
         } else if surface.root_node().is_some_and(|root| root.is_collapsed()) {
@@ -948,7 +919,7 @@ impl<Tab> DockArea<'_, Tab> {
             } else {
                 0.0
             };
-            if let Some(window_state) = self.dock_state.get_window_state_mut(surface_index) {
+            if let Some(window_state) = self.dock_state.get_window_state_mut(path.surface) {
                 window_state.set_expanded_height(surface_height);
             }
         }
@@ -1098,7 +1069,7 @@ impl<Tab> DockArea<'_, Tab> {
         &mut self,
         ui: &mut Ui,
         state: &State,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
+        path: NodePath,
         actual_width: f32,
         available_width: f32,
         scroll_bar_width: f32,
@@ -1110,7 +1081,7 @@ impl<Tab> DockArea<'_, Tab> {
             return;
         }
 
-        let leaf = self.dock_state[surface_index][node_index]
+        let leaf = self.dock_state[path]
             .get_leaf_mut()
             .expect("This node must be a leaf");
         let overflow = (actual_width - available_width).at_least(0.0);
@@ -1143,7 +1114,7 @@ impl<Tab> DockArea<'_, Tab> {
 
                 let scroll_bar_handle_response = ui.interact(
                     scroll_bar_handle_rect,
-                    self.id.with((node_index, "node")),
+                    self.id.with((path.node, "node")),
                     Sense::drag(),
                 );
 
@@ -1190,7 +1161,7 @@ impl<Tab> DockArea<'_, Tab> {
         &mut self,
         ui: &mut Ui,
         state: &State,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
+        path: NodePath,
         tab_viewer: &mut impl TabViewer<Tab = Tab>,
         spacing: Vec2,
         tabbar_rect: Rect,
@@ -1200,8 +1171,9 @@ impl<Tab> DockArea<'_, Tab> {
         let (body_rect, _body_response) =
             ui.allocate_exact_size(ui.available_size_before_wrap(), Sense::hover());
 
-        let leaf = self.dock_state[surface_index][node_index]
-            .get_leaf_mut()
+        let leaf = self
+            .dock_state
+            .leaf_mut(path)
             .expect("This node must be a leaf");
         let LeafNode {
             rect,
@@ -1222,7 +1194,7 @@ impl<Tab> DockArea<'_, Tab> {
                         if body_rect.contains(pos)
                             && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
                         {
-                            self.new_focused = Some((surface_index, node_index));
+                            self.new_focused = Some(path);
                         }
                     }
                 }
@@ -1300,10 +1272,12 @@ impl<Tab> DockArea<'_, Tab> {
                     drag: DragData { src, .. },
                     ..
                 }) => match *src {
-                    TreeComponent::Tab(d_surf, d_node, d_tab) => {
-                        if let Node::Leaf(leaf) = &mut self.dock_state[d_surf][d_node] {
-                            tab_viewer.allowed_in_windows(&mut leaf.tabs[d_tab.0])
-                                || surface_index == SurfaceIndex::main()
+                    TreeComponent::Tab(src_path) => {
+                        if let Node::Leaf(leaf) =
+                            &mut self.dock_state[src_path.surface][src_path.node]
+                        {
+                            tab_viewer.allowed_in_windows(&mut leaf.tabs[src_path.tab.0])
+                                || path.surface == SurfaceIndex::main()
                         } else {
                             true
                         }
@@ -1319,12 +1293,11 @@ impl<Tab> DockArea<'_, Tab> {
                 let on_title_bar = tabbar_rect.contains(pointer);
                 let (dst, tab) = {
                     match self.tab_hover_rect {
-                        Some((rect, tab_index)) => (
-                            TreeComponent::Tab(surface_index, node_index, tab_index),
-                            Some(rect),
-                        ),
+                        Some((rect, tab_index)) => {
+                            (TreeComponent::Tab((path, tab_index).into()), Some(rect))
+                        }
                         None => (
-                            TreeComponent::Node(surface_index, node_index),
+                            TreeComponent::Node(path),
                             on_title_bar.then_some(tabbar_rect),
                         ),
                     }

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -448,7 +448,13 @@ impl<Tab> DockArea<'_, Tab> {
                 debug_assert!(!rect.any_nan() && rect.is_finite());
                 let rect = expand_to_pixel(rect, pixels_per_point);
 
-                let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
+                let dim_size = rect.dim_size();
+                let midpoint = if dim_size > 0.0 {
+                    rect.min.dim_point + dim_size * split.fraction
+                } else {
+                    rect.min.dim_point
+                };
+
                 let left_separator_border = map_to_pixel(
                     midpoint - style.separator.width * 0.5,
                     pixels_per_point,
@@ -566,11 +572,13 @@ impl<Tab> DockArea<'_, Tab> {
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
                 let range = rect.max.dim_point - rect.min.dim_point;
-                let min = (style.separator.extra / range).min(1.0);
-                let max = 1.0 - min;
-                let (min, max) = (min.min(max), max.max(min));
-                let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
-                split.fraction = (split.fraction + delta / range).clamp(min, max);
+                if range > 0.0 {
+                    let min = (style.separator.extra / range).min(1.0);
+                    let max = 1.0 - min;
+                    let (min, max) = (min.min(max), max.max(min));
+                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
+                    split.fraction = (split.fraction + delta / range).clamp(min, max);
+                }
 
                 if response.double_clicked() {
                     split.fraction = 0.5;

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -1,14 +1,14 @@
+use duplicate::duplicate;
 use egui::{
     CentralPanel, Color32, Context, CornerRadius, CursorIcon, EventFilter, Frame, Key, Pos2, Rect,
     Sense, StrokeKind, Ui, Vec2,
 };
-
-use duplicate::duplicate;
 use paste::paste;
 
 use super::{drag_and_drop::TreeComponent, state::State, tab_removal::TabRemoval};
 use crate::dock_area::tab_removal::ForcedRemoval;
 use crate::tab_viewer::OnCloseResponse;
+use crate::NodePath;
 use crate::{
     utils::{expand_to_pixel, fade_dock_style, map_to_pixel},
     AllowedSplits, DockArea, Node, NodeIndex, OverlayType, Style, SurfaceIndex, TabDestination,
@@ -90,9 +90,7 @@ impl<Tab> DockArea<'_, Tab> {
                 if let Some(destination) = tab_dst {
                     let source = {
                         match state.dnd.as_ref().unwrap().drag.src {
-                            TreeComponent::Tab(src_surf, src_node, src_tab) => {
-                                (src_surf, src_node, src_tab)
-                            }
+                            TreeComponent::Tab(src) => src,
                             _ => todo!(
                                 "collections of tabs, like nodes and surfaces can't be docked (yet)"
                             ),
@@ -132,18 +130,18 @@ impl<Tab> DockArea<'_, Tab> {
 
         for removal in self.to_remove.drain(..).rev() {
             match removal {
-                TabRemoval::Tab(surface, node, tab, ForcedRemoval(is_forced)) => {
+                TabRemoval::Tab(path, ForcedRemoval(is_forced)) => {
                     if is_forced {
-                        self.dock_state.remove_tab((surface, node, tab));
+                        self.dock_state.remove_tab(path);
                     } else {
-                        let leaf = &mut self.dock_state[surface][node].get_leaf_mut().unwrap();
-                        match tab_viewer.on_close(&mut leaf.tabs[tab.0]) {
+                        let leaf = &mut self.dock_state.leaf_mut(path.node_path()).unwrap();
+                        match tab_viewer.on_close(&mut leaf.tabs[path.tab.0]) {
                             OnCloseResponse::Close => {
-                                self.dock_state.remove_tab((surface, node, tab));
+                                self.dock_state.remove_tab(path);
                             }
                             OnCloseResponse::Focus => {
-                                leaf.active = tab;
-                                self.new_focused = Some((surface, node));
+                                leaf.active = path.tab;
+                                self.new_focused = Some(path.node_path());
                             }
                             OnCloseResponse::Ignore => {
                                 // no-op
@@ -151,9 +149,9 @@ impl<Tab> DockArea<'_, Tab> {
                         }
                     }
                 }
-                TabRemoval::Node(surface, node) => {
+                TabRemoval::Node(path) => {
                     let mut all_tabs_are_closable = true;
-                    for tab in self.dock_state[surface][node].iter_tabs_mut() {
+                    for tab in self.dock_state[path].iter_tabs_mut() {
                         if !(tab_viewer.is_closeable(tab)
                             && matches!(tab_viewer.on_close(tab), OnCloseResponse::Close))
                         {
@@ -161,7 +159,7 @@ impl<Tab> DockArea<'_, Tab> {
                         }
                     }
                     if all_tabs_are_closable {
-                        self.dock_state.remove_leaf((surface, node));
+                        self.dock_state.remove_leaf(path);
                     }
                 }
                 TabRemoval::Window(surface) => {
@@ -182,13 +180,13 @@ impl<Tab> DockArea<'_, Tab> {
             }
         }
 
-        for (surface_index, node_index, tab_index) in self.to_detach.drain(..).rev() {
+        for path in self.to_detach.drain(..).rev() {
             let mouse_pos = state.last_hover_pos;
             self.dock_state.detach_tab(
-                (surface_index, node_index, tab_index),
+                path,
                 Rect::from_min_size(
                     mouse_pos.unwrap_or(Pos2::ZERO),
-                    self.dock_state[surface_index][node_index]
+                    self.dock_state[path.node_path()]
                         .rect()
                         .map_or(Vec2::new(100., 150.), |rect| rect.size()),
                 ),
@@ -256,11 +254,11 @@ impl<Tab> DockArea<'_, Tab> {
         let allowed_splits = self.allowed_splits & restricted_splits;
 
         let allowed_in_window = match drag_state.drag.src {
-            TreeComponent::Tab(surface, node, tab) => {
-                let Node::Leaf(leaf) = &mut self.dock_state[surface][node] else {
+            TreeComponent::Tab(path) => {
+                let Node::Leaf(leaf) = &mut self.dock_state[path.node_path()] else {
                     unreachable!("tab drags can only come from leaf nodes")
                 };
-                tab_viewer.allowed_in_windows(&mut leaf.tabs[tab.0])
+                tab_viewer.allowed_in_windows(&mut leaf.tabs[path.tab.0])
             }
             _ => todo!("collections of tabs, like nodes or surfaces, can't be dragged! (yet)"),
         };
@@ -315,15 +313,23 @@ impl<Tab> DockArea<'_, Tab> {
         // First compute all rect sizes in the node graph.
         let max_rect = self.allocate_area_for_root_node(ui, surf_index);
         for node_index in self.dock_state[surf_index].breadth_first_index_iter() {
-            if self.dock_state[surf_index][node_index].is_parent() {
-                self.compute_rect_sizes(ui, (surf_index, node_index), max_rect);
+            let path = NodePath {
+                surface: surf_index,
+                node: node_index,
+            };
+            if self.dock_state[path].is_parent() {
+                self.compute_rect_sizes(ui, path, max_rect);
             }
         }
 
         // Then, draw the bodies of each leaves.
         for node_index in self.dock_state[surf_index].breadth_first_index_iter() {
-            if self.dock_state[surf_index][node_index].is_leaf() {
-                self.show_leaf(ui, state, (surf_index, node_index), tab_viewer, fade_style);
+            let path = NodePath {
+                surface: surf_index,
+                node: node_index,
+            };
+            if self.dock_state[path].is_leaf() {
+                self.show_leaf(ui, state, path, tab_viewer, fade_style);
             }
         }
 
@@ -331,8 +337,12 @@ impl<Tab> DockArea<'_, Tab> {
         // bodies (see `SeparatorStyle::extra_interact_width`).
         let fade_style = fade_style.map(|(style, _)| style);
         for node_index in self.dock_state[surf_index].breadth_first_index_iter() {
+            let path = NodePath {
+                surface: surf_index,
+                node: node_index,
+            };
             if self.dock_state[surf_index][node_index].is_parent() {
-                self.show_separator(ui, (surf_index, node_index), fade_style);
+                self.show_separator(ui, path, fade_style);
             }
         }
     }
@@ -364,26 +374,19 @@ impl<Tab> DockArea<'_, Tab> {
         rect
     }
 
-    fn compute_rect_sizes(
-        &mut self,
-        ui: &Ui,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
-        max_rect: Rect,
-    ) {
-        assert!(self.dock_state[surface_index][node_index].is_parent());
+    fn compute_rect_sizes(&mut self, ui: &Ui, path: NodePath, max_rect: Rect) {
+        assert!(self.dock_state[path].is_parent());
 
         let style = self.style.as_ref().unwrap();
         let pixels_per_point = ui.ctx().pixels_per_point();
 
-        let left_collapsed_count =
-            self.dock_state[surface_index][node_index.left()].collapsed_leaf_count();
-        let right_collapsed_count =
-            self.dock_state[surface_index][node_index.right()].collapsed_leaf_count();
-        let left_collapsed = self.dock_state[surface_index][node_index.left()].is_collapsed();
-        let right_collapsed = self.dock_state[surface_index][node_index.right()].is_collapsed();
+        let left_collapsed_count = self.dock_state[path.left_node()].collapsed_leaf_count();
+        let right_collapsed_count = self.dock_state[path.right_node()].collapsed_leaf_count();
+        let left_collapsed = self.dock_state[path.left_node()].is_collapsed();
+        let right_collapsed = self.dock_state[path.right_node()].is_collapsed();
 
         if left_collapsed || right_collapsed {
-            if let Node::Vertical(split) = &mut self.dock_state[surface_index][node_index] {
+            if let Node::Vertical(split) = &mut self.dock_state[path.surface][path.node] {
                 let rect = split.rect();
                 debug_assert!(!rect.any_nan() && rect.is_finite());
                 let rect = expand_to_pixel(rect, pixels_per_point);
@@ -408,8 +411,8 @@ impl<Tab> DockArea<'_, Tab> {
                     let right = rect
                         .intersect(Rect::everything_below(right_separator_border))
                         .intersect(max_rect);
-                    self.dock_state[surface_index][node_index.left()].set_rect(left);
-                    self.dock_state[surface_index][node_index.right()].set_rect(right);
+                    self.dock_state[path.left_node()].set_rect(left);
+                    self.dock_state[path.right_node()].set_rect(right);
                 } else {
                     // Only right collapsed
                     let border_y =
@@ -430,8 +433,8 @@ impl<Tab> DockArea<'_, Tab> {
                     let right = rect
                         .intersect(Rect::everything_below(right_separator_border))
                         .intersect(max_rect);
-                    self.dock_state[surface_index][node_index.left()].set_rect(left);
-                    self.dock_state[surface_index][node_index.right()].set_rect(right);
+                    self.dock_state[path.left_node()].set_rect(left);
+                    self.dock_state[path.right_node()].set_rect(right);
                 }
                 return;
             }
@@ -443,7 +446,7 @@ impl<Tab> DockArea<'_, Tab> {
                 [Horizontal]  [x]        [width]   [left_of]  [right_of];
                 [Vertical]    [y]        [height]  [above]    [below];
             ]
-            if let Node::orientation(split) = &mut self.dock_state[surface_index][node_index] {
+            if let Node::orientation(split) = &mut self.dock_state[path.surface][path.node] {
                 let rect = split.rect;
                 debug_assert!(!rect.any_nan() && rect.is_finite());
                 let rect = expand_to_pixel(rect, pixels_per_point);
@@ -471,24 +474,19 @@ impl<Tab> DockArea<'_, Tab> {
                     let right = rect.intersect(Rect::[<everything_ right_of>](right_separator_border)).intersect(max_rect);
                 }
 
-                self.dock_state[surface_index][node_index.left()].set_rect(left);
-                self.dock_state[surface_index][node_index.right()].set_rect(right);
+                self.dock_state[path.left_node()].set_rect(left);
+                self.dock_state[path.right_node()].set_rect(right);
             }
         }
     }
 
-    fn show_separator(
-        &mut self,
-        ui: &mut Ui,
-        (surface_index, node_index): (SurfaceIndex, NodeIndex),
-        fade_style: Option<&Style>,
-    ) {
-        assert!(self.dock_state[surface_index][node_index].is_parent());
+    fn show_separator(&mut self, ui: &mut Ui, path: NodePath, fade_style: Option<&Style>) {
+        assert!(self.dock_state[path.surface][path.node].is_parent());
 
         // If either of the children is collapsed, we don't want the user to interact with the separator
-        if (self.dock_state[surface_index][node_index.left()].is_collapsed()
-            || self.dock_state[surface_index][node_index.right()].is_collapsed())
-            && self.dock_state[surface_index][node_index].is_vertical()
+        if (self.dock_state[path.left_node()].is_collapsed()
+            || self.dock_state[path.right_node()].is_collapsed())
+            && self.dock_state[path.surface][path.node].is_vertical()
         {
             return;
         }
@@ -502,7 +500,7 @@ impl<Tab> DockArea<'_, Tab> {
                 [Horizontal]  [x]        [width];
                 [Vertical]    [y]        [height];
             ]
-            if let Node::orientation(split) = &mut self.dock_state[surface_index][node_index] {
+            if let Node::orientation(split) = &mut self.dock_state[path.surface][path.node] {
                 let rect = split.rect;
                 let mut separator = rect;
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -22,36 +22,23 @@ mod window_surface;
 impl<Tab> DockArea<'_, Tab> {
     /// Show the `DockArea` at the top level.
     ///
-    /// This is the same as doing:
+    /// Deprecated: use [`show_inside`](Self::show_inside) instead.
+    /// With eframe 0.34+, implement `App::ui` and call `show_inside` directly:
     ///
+    /// ```ignore
+    /// fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    ///     DockArea::new(&mut self.tree)
+    ///         .style(Style::from_egui(ui.style().as_ref()))
+    ///         .show_inside(ui, &mut tab_viewer);
+    /// }
     /// ```
-    /// # use egui_dock::{DockArea, DockState};
-    /// # use egui::{CentralPanel, Frame};
-    /// # struct TabViewer {}
-    /// # impl egui_dock::TabViewer for TabViewer {
-    /// #     type Tab = String;
-    /// #     fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText { (&*tab).into() }
-    /// #     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {}
-    /// # }
-    /// # let mut tree: DockState<String> = DockState::new(vec![]);
-    /// # let mut tab_viewer = TabViewer {};
-    /// # egui::__run_test_ctx(|ctx| {
-    /// CentralPanel::default()
-    ///     .frame(Frame::central_panel(&ctx.style()).inner_margin(0.))
-    ///     .show(ctx, |ui| {
-    ///         DockArea::new(&mut tree).show_inside(ui, &mut tab_viewer);
-    ///     });
-    /// # });
-    /// ```
-    ///
-    /// So you can't use the [`CentralPanel::show`] when using `DockArea`'s one.
-    ///
-    /// See also [`show_inside`](Self::show_inside).
     #[inline]
+    #[deprecated = "Use show_inside() instead — with eframe 0.34+, implement App::ui which gives &mut Ui directly"]
+    #[allow(deprecated)]
     pub fn show(self, ctx: &Context, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
         CentralPanel::default()
             .frame(
-                Frame::central_panel(&ctx.style())
+                Frame::central_panel(&ctx.global_style())
                     .inner_margin(0.)
                     .fill(Color32::TRANSPARENT),
             )

--- a/src/widgets/dock_area/state.rs
+++ b/src/widgets/dock_area/state.rs
@@ -1,8 +1,7 @@
 use egui::{Context, Id, Pos2};
 
-use crate::{Style, SurfaceIndex};
-
 use super::drag_and_drop::{DragData, DragDropState, HoverData};
+use crate::{Style, SurfaceIndex};
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct State {

--- a/src/widgets/dock_area/tab_removal.rs
+++ b/src/widgets/dock_area/tab_removal.rs
@@ -1,10 +1,10 @@
-use crate::{NodeIndex, SurfaceIndex, TabIndex};
+use crate::{NodePath, SurfaceIndex, TabPath};
 
 /// An enum expressing an entry in the `to_remove` field in [`DockArea`].
 #[derive(Debug, Clone, Copy)]
 pub(super) enum TabRemoval {
-    Tab(SurfaceIndex, NodeIndex, TabIndex, ForcedRemoval),
-    Node(SurfaceIndex, NodeIndex),
+    Tab(TabPath, ForcedRemoval),
+    Node(NodePath),
     Window(SurfaceIndex),
 }
 

--- a/src/widgets/tab_viewer.rs
+++ b/src/widgets/tab_viewer.rs
@@ -1,5 +1,6 @@
-use crate::{NodeIndex, SurfaceIndex, TabStyle};
 use egui::{Id, Ui, WidgetText};
+
+use crate::{NodePath, TabStyle};
 
 /// Defines how a tab should behave and be rendered inside a [`Tree`](crate::Tree).
 pub trait TabViewer {
@@ -14,16 +15,9 @@ pub trait TabViewer {
 
     /// Content inside the context menu shown when the tab is right-clicked.
     ///
-    /// `_surface` and `_node` specify which [`Surface`](crate::Surface) and [`Node`](crate::Node)
+    /// `_path` specifies which [`Surface`](crate::Surface) and [`Node`](crate::Node)
     /// that this particular context menu belongs to.
-    fn context_menu(
-        &mut self,
-        _ui: &mut Ui,
-        _tab: &mut Self::Tab,
-        _surface: SurfaceIndex,
-        _node: NodeIndex,
-    ) {
-    }
+    fn context_menu(&mut self, _ui: &mut Ui, _tab: &mut Self::Tab, _path: NodePath) {}
 
     /// Unique ID for this tab.
     ///
@@ -68,9 +62,9 @@ pub trait TabViewer {
 
     /// This is called when the add button is pressed.
     ///
-    /// `_surface` and `_node` specify which [`Surface`](crate::Surface) and on which
+    /// `_path` specifies which [`Surface`](crate::Surface) and on which
     /// [`Node`](crate::Node) this particular add button was pressed.
-    fn on_add(&mut self, _surface: SurfaceIndex, _node: NodeIndex) {}
+    fn on_add(&mut self, _path: NodePath) {}
 
     /// Called when the rectangle of the tab content changes.
     ///
@@ -86,7 +80,7 @@ pub trait TabViewer {
     ///
     /// This requires that [`DockArea::show_add_buttons`](crate::DockArea::show_add_buttons) and
     /// [`DockArea::show_add_popup`](crate::DockArea::show_add_popup) are set to `true`.
-    fn add_popup(&mut self, _ui: &mut Ui, _surface: SurfaceIndex, _node: NodeIndex) {}
+    fn add_popup(&mut self, _ui: &mut Ui, _path: NodePath) {}
 
     /// Sets custom style for given tab.
     fn tab_style_override(&self, _tab: &Self::Tab, _global_style: &TabStyle) -> Option<TabStyle> {


### PR DESCRIPTION
## egui_dock 0.19.0 - 2026/03/29

### Added

- `NodePath` and `TabPath` structs, useful for more consistent and terse indexing of nodes and
  tabs. ([#312](https://github.com/anhosh/egui_dock/pull/312))
- Indexing `LeafNode` with `TabIndex`. ([#311](https://github.com/anhosh/egui_dock/pull/311/))
- Indexing `DockState` using `NodePath`. ([#312](https://github.com/anhosh/egui_dock/pull/312))
- New methods ([#312](https://github.com/anhosh/egui_dock/pull/312)):
    - `DockState::node(_mut)`: returns a `Node` at a given `NodePath`,
    - `DockState::leaf(_mut)`: returns a `LeafNode` at a given `NodePath`,
    - `DockState::iter_surfaces(_mut)_indexed`: returns a `Surface` iterator paired with its `SurfaceIndex`,
    - `Surface::iter_nodes(_mut)_indexed`: returns a `Node<Tab>` iterator paired with its `NodeIndex`,
    - `Tree::leaf(_mut)`: returns a `Result<&LeafNode<Tab>>` at a given `NodeIndex`,
    - `Node::iter_tabs(_mut)_indexed`: returns a `Tab` iterator paried with its `TabIndex`.

### Fixed

- No more panics when a window is shrunk to zero available space. ([#309](https://github.com/anhosh/egui_dock/pull/309))
- No more panics while trying move a tab to the end of the list within the same leaf. ([#308](https://github.com/anhosh/egui_dock/pull/308))

### Breaking changes

- Upgraded to egui 0.34. ([#314](https://github.com/anhosh/egui_dock/pull/314))
- Replaced all `SurfaceIndex`, `NodeIndex`, and `TabIndex` groupings with `NodePath` and `TabPath` in the argument lists
  of the following functions ([#312](https://github.com/anhosh/egui_dock/pull/312)):
    - `DockState::set_active_tab`,
    - `DockState::set_focused_node_and_surface`,
    - `DockState::move_tab`,
    - `DockState::detach_tab`,
    - `DockState::remove_tab`,
    - `DockState::remove_leaf`,
    - `DockState::split`,
    - `DockState::focused_leaf`,
    - `TabViewer::context_menu`,
    - `TabViewer::on_add`,
    - `TabViewer::add_popup`.
- Changed the return type of some methods ([#312](https://github.com/anhosh/egui_dock/pull/312)):
    - `DockState::iter_all_nodes` now returns `impl Iterator<Item = (NodePath, &Node<Tab>)>`,
    - `DockState::iter_all_nodes_mut` now returns `impl Iterator<Item = (NodePath, &mut Node<Tab>)>`,
    - `DockState::iter_all_tabs` now returns `impl Iterator<Item = (TabPath, &Tab)>`,
    - `DockState::iter_all_tabs_mut` now returns `impl Iterator<Item = (TabPath, &mut Tab)>`,
    - `DockState::iter_leaves` now returns `impl Iterator<Item = (NodePath, &LeafNode<Tab>)>`,
    - `DockState::iter_leaves_mut` now returns `impl Iterator<Item = (NodePath, &mut LeafNode<Tab>)>`,
    - `DockState::find_tab_from` now returns `Option<TabPath>`,
    - `DockState::find_tab` now returns `Option<TabPath>`,
    - `Surface::iter_all_tabs` now returns `impl Iterator<Item = ((NodeIndex, TabIndex), &Tab)>`,
    - `Surface::iter_all_tabs_mut` now returns `impl Iterator<Item = ((NodeIndex, TabIndex), &mut Tab)>`,
    - `Tree::set_active_tab` now returns `Result<()>` (`Err` if any of the indices are invalid),
    - `LeafNode::::set_active_tab` now returns `Result<()>` (`Err` if the tab index is invalid).
- `impl From<(SurfaceIndex, NodeIndex, TabInsert)> for TabDestination` was replaced with
  `impl From<(NodePath, TabInsert)> for TabDestination`. ([#312](https://github.com/anhosh/egui_dock/pull/312))

### Deprecated

- `DockArea::show` - use `DockArea::show_inside` instead. ([#314](https://github.com/anhosh/egui_dock/pull/314))