### PR TITLE
Fix Widget changed layer_id panic when undocking tabs (debug builds)

### DIFF
--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -20,6 +20,10 @@ use crate::{
     DockArea, Node, NodeIndex, Style, SurfaceIndex, TabAddAlign, TabIndex, TabStyle, TabViewer,
 };
 
+fn tab_body_id(dock_area_id: Id, path: NodePath, tab_id: Id) -> Id {
+    dock_area_id.with((path.surface, "surface")).with(tab_id)
+}
+
 impl<Tab> DockArea<'_, Tab> {
     pub(super) fn show_leaf(
         &mut self,
@@ -1218,7 +1222,7 @@ impl<Tab> DockArea<'_, Tab> {
                 // We are forced to use `Ui::new` because other methods (eg: push_id) always mix
                 // the provided id with their own which would cause tabs to change id when moved
                 // from node to node.
-                let id = self.id.with(tab_viewer.id(tab));
+                let id = tab_body_id(self.id, path, tab_viewer.id(tab));
                 ui.ctx().check_for_id_clash(id, body_rect, "a tab with id");
                 let ui = &mut Ui::new(
                     ui.ctx().clone(),
@@ -1311,5 +1315,33 @@ impl<Tab> DockArea<'_, Tab> {
                 });
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tab_body_id;
+    use crate::{NodeIndex, NodePath, SurfaceIndex};
+    use egui::Id;
+
+    #[test]
+    fn tab_body_ids_differ_between_surfaces() {
+        let dock_area_id = Id::new("dock-area");
+        let tab_id = Id::new("same-tab");
+        let node = NodeIndex::root();
+
+        let main = NodePath {
+            surface: SurfaceIndex::main(),
+            node,
+        };
+        let detached = NodePath {
+            surface: SurfaceIndex(1),
+            node,
+        };
+
+        assert_ne!(
+            tab_body_id(dock_area_id, main, tab_id),
+            tab_body_id(dock_area_id, detached, tab_id)
+        );
     }
 }


### PR DESCRIPTION
## Problem

The tab body Ui was constructed with an ID that didn't include the surface:
```rust
let id = self.id.with(tab_viewer.id(tab));
```
When a tab is moved to a floating window surface, both the main dock (Background layer) and the window (Middle layer) can render a tab body with the same ID in the same frame. egui's debug assertion then fires because it sees the same widget ID appearing in two different layers.

## Fix

Scope the tab body ID by surface:
```rust
fn tab_body_id(dock_area_id: Id, path: NodePath, tab_id: Id) -> Id {
    dock_area_id.with((path.surface, "surface")).with(tab_id)
}
```

This preserves the original property that tab IDs remain stable when a tab is moved between nodes on the same surface, while ensuring tabs on different surfaces get distinct IDs.

<img width="3137" height="1445" alt="PixPin_2026-04-15_00-29-26" src="https://github.com/user-attachments/assets/d950d4fc-95fa-4c3d-9085-a7c83c3485ec" />


closes #317 