### PR TITLE
fix!: skip translations when de/serializing DockState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # egui_dock changelog
 
+## egui_dock 0.20.1 - Unreleased
+
+### Fixed
+
+- "Widget changed layer_id" panic when undocking tabs. ([318](https://github.com/anhosh/egui_dock/pull/318))
+- Translations are no longer serialised. ([319](https://github.com/anhosh/egui_dock/pull/319))
 
 ## egui_dock 0.20.0 - 2026/06/27
 

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -34,6 +34,12 @@ use crate::{
 /// Indexing it with a [`SurfaceIndex`] will yield a [`Tree`] which then contains nodes and tabs.
 ///
 /// [`DockState`] is generic, so you can use any type of data to represent a tab.
+///
+/// # Serialization
+///
+/// `DockState` may be serialized to record the placement of all surfaces.
+///
+/// This does not include serialization of translations.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DockState<Tab> {
@@ -41,6 +47,7 @@ pub struct DockState<Tab> {
     focused_surface: Option<SurfaceIndex>, // Part of the tree which is in focus.
 
     /// Contains translations of text shown in [`DockArea`](crate::DockArea).
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub translations: Translations,
 }
 

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -62,6 +62,12 @@ impl Translations {
     }
 }
 
+impl Default for Translations {
+    fn default() -> Self {
+        Self::english()
+    }
+}
+
 impl TabContextMenuTranslations {
     /// Default English translations.
     pub fn english() -> Self {


### PR DESCRIPTION
There is no reason to serialize dock state and translations together, since the latter is often configured separately.