### PR TITLE
Hiding tab bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 /.idea
 /.vscode
+*.code-workspace

--- a/examples/hidden_tabs.rs
+++ b/examples/hidden_tabs.rs
@@ -29,7 +29,9 @@ impl egui_dock::TabViewer for TabViewer {
         match tab.as_str() {
             "Visible" => {
                 ui.label("The tab bar is showing.");
-                ui.label("Right click a tab and press 'Hide Tab Bar' to collapse the tab bar region.");
+                ui.label(
+                    "Right click a tab and press 'Hide Tab Bar' to collapse the tab bar region.",
+                );
             }
             "Hidden" => {
                 ui.label("The tab bar is hidden.");
@@ -49,11 +51,9 @@ impl Default for MyApp {
     fn default() -> Self {
         let mut tree = DockState::new(vec!["Visible".to_owned()]);
 
-        let [_, b] = tree.main_surface_mut().split_right(
-            NodeIndex::root(),
-            0.5,
-            vec!["Hidden".to_owned()],
-        );
+        let [_, b] =
+            tree.main_surface_mut()
+                .split_right(NodeIndex::root(), 0.5, vec!["Hidden".to_owned()]);
 
         // Hide the tab bar on the right panel
         tree.main_surface_mut()[b].set_tab_bar_hidden(true);

--- a/examples/hidden_tabs.rs
+++ b/examples/hidden_tabs.rs
@@ -1,0 +1,83 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use eframe::{NativeOptions, egui};
+use egui_dock::{DockArea, DockState, NodeIndex, Style};
+
+fn main() -> eframe::Result<()> {
+    let options = NativeOptions::default();
+    eframe::run_native(
+        "Hidden Tabs",
+        options,
+        Box::new(|_cc| Ok(Box::<MyApp>::default())),
+    )
+}
+
+struct TabViewer {}
+
+impl egui_dock::TabViewer for TabViewer {
+    type Tab = String;
+
+    fn id(&mut self, tab: &mut Self::Tab) -> egui::Id {
+        egui::Id::new(tab)
+    }
+
+    fn title(&mut self, tab: &mut Self::Tab) -> egui::WidgetText {
+        (&*tab).into()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
+        match tab.as_str() {
+            "Visible" => {
+                ui.label("The tab bar is showing.");
+                ui.label("Right click a tab and press 'Hide Tab Bar' to collapse the tab bar region.");
+            }
+            "Hidden" => {
+                ui.label("The tab bar is hidden.");
+                ui.label("Try dragging by the top margin of the tab when the tab bar is hidden.");
+            }
+            _ => {}
+        }
+    }
+}
+
+struct MyApp {
+    tree: DockState<String>,
+    style: Option<Style>,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        let mut tree = DockState::new(vec!["Visible".to_owned()]);
+
+        let [_, b] = tree.main_surface_mut().split_right(
+            NodeIndex::root(),
+            0.5,
+            vec!["Hidden".to_owned()],
+        );
+
+        // Hide the tab bar on the right panel
+        tree.main_surface_mut()[b].set_tab_bar_hidden(true);
+
+        Self { tree, style: None }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let style = self
+            .style
+            .get_or_insert_with(|| {
+                let mut s = Style::from_egui(ui.style());
+                // Set a larger drag area for hidden tab bars
+                s.tab.tab_body.hidden_tab_bar_drag_height = Some(14.0);
+                s
+            })
+            .clone();
+
+        DockArea::new(&mut self.tree)
+            .style(style)
+            .hidable_tab_bars(true)
+            .draggable_tabs(true)
+            .show_inside(ui, &mut TabViewer {});
+    }
+}

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -16,6 +16,8 @@ pub struct TabContextMenuTranslations {
     pub close_button: String,
     /// Button that undocks the tab into a new window.
     pub eject_button: String,
+    /// Button that hides the tab bar.
+    pub hide_tab_bar_button: String,
 }
 
 /// Specifies text displayed in the primary buttons on a tab bar.
@@ -68,6 +70,7 @@ impl TabContextMenuTranslations {
         Self {
             close_button: String::from("Close"),
             eject_button: String::from("Eject"),
+            hide_tab_bar_button: String::from("Hide tab bar"),
         }
     }
 }

--- a/src/dock_state/translations.rs
+++ b/src/dock_state/translations.rs
@@ -18,6 +18,8 @@ pub struct TabContextMenuTranslations {
     pub eject_button: String,
     /// Button that hides the tab bar.
     pub hide_tab_bar_button: String,
+    /// Button that shows the tab bar.
+    pub show_tab_bar_button: String,
 }
 
 /// Specifies text displayed in the primary buttons on a tab bar.
@@ -71,6 +73,7 @@ impl TabContextMenuTranslations {
             close_button: String::from("Close"),
             eject_button: String::from("Eject"),
             hide_tab_bar_button: String::from("Hide tab bar"),
+            show_tab_bar_button: String::from("Show tab bar"),
         }
     }
 }

--- a/src/dock_state/tree/node/leaf.rs
+++ b/src/dock_state/tree/node/leaf.rs
@@ -26,7 +26,7 @@ pub struct LeafNode<Tab> {
     /// Whether the leaf is collapsed.
     pub collapsed: bool,
 
-    /// Whether the leaf tab bar is hidden
+    /// Whether the leaf tab bar is hidden.
     pub tab_bar_hidden: bool,
 }
 

--- a/src/dock_state/tree/node/leaf.rs
+++ b/src/dock_state/tree/node/leaf.rs
@@ -25,6 +25,9 @@ pub struct LeafNode<Tab> {
 
     /// Whether the leaf is collapsed.
     pub collapsed: bool,
+
+    /// Whether the leaf tab bar is hidden
+    pub tab_bar_hidden: bool,
 }
 
 impl<Tab> LeafNode<Tab> {
@@ -37,6 +40,7 @@ impl<Tab> LeafNode<Tab> {
             active: TabIndex(0),
             scroll: 0.0,
             collapsed: false,
+            tab_bar_hidden: false,
         }
     }
 

--- a/src/dock_state/tree/node/mod.rs
+++ b/src/dock_state/tree/node/mod.rs
@@ -351,6 +351,7 @@ impl<Tab> Node<Tab> {
                     active,
                     scroll,
                     collapsed,
+                    tab_bar_hidden,
                 } = leaf;
                 let tabs: Vec<_> = tabs.iter().filter_map(function).collect();
                 if tabs.is_empty() {
@@ -363,6 +364,7 @@ impl<Tab> Node<Tab> {
                         active: *active,
                         scroll: *scroll,
                         collapsed: *collapsed,
+                        tab_bar_hidden: *tab_bar_hidden,
                     })
                 }
             }

--- a/src/dock_state/tree/node/mod.rs
+++ b/src/dock_state/tree/node/mod.rs
@@ -286,6 +286,15 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Returns `true` if the node is a leaf with a hidden tab bar, otherwise `false`.
+    #[inline(always)]
+    pub fn is_tab_bar_hidden(&self) -> bool {
+        match self {
+            Node::Leaf(leaf) => leaf.tab_bar_hidden,
+            _ => false,
+        }
+    }
+
     /// Sets the tab bar hidden state of the node.
     ///
     /// # Panics

--- a/src/dock_state/tree/node/mod.rs
+++ b/src/dock_state/tree/node/mod.rs
@@ -286,6 +286,19 @@ impl<Tab> Node<Tab> {
         }
     }
 
+    /// Sets the tab bar hidden state of the node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is not a [`Leaf`](Node::Leaf) node.
+    #[inline]
+    pub fn set_tab_bar_hidden(&mut self, tab_bar_hidden: bool) {
+        match self {
+            Node::Leaf(leaf) => leaf.tab_bar_hidden = tab_bar_hidden,
+            _ => panic!("node was not a leaf"),
+        }
+    }
+
     /// Sets the number of layers of collapsed leaf subnodes.
     ///
     /// # Panics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,8 @@
 //!     tab_context_menu: TabContextMenuTranslations {
 //!         close_button: "Zamknij zakładkę".to_string(),
 //!         eject_button: "Przenieś zakładkę do nowego okna".to_string(),
+//!         hide_tab_bar_button: "Schowaj pasek zakładek".to_string(),
+//!         show_tab_bar_button: "Pokaż pasek zakładek".to_string(),
 //!     },
 //!     leaf: LeafTranslations {
 //!         close_button_disabled_tooltip: "Ten węzeł zawiera niezamykalne zakładki.".to_string(),
@@ -225,6 +227,8 @@
 //! let mut dock_state = DockState::<Tab>::new(vec![]);
 //! dock_state.translations.tab_context_menu.close_button = "タブを閉じる".to_string();
 //! dock_state.translations.tab_context_menu.eject_button = "タブを新しいウィンドウへ移動".to_string();
+//! dock_state.translations.tab_context_menu.hide_tab_bar_button = "タブバーを非表示".to_string();
+//! dock_state.translations.tab_context_menu.show_tab_bar_button = "タブバーを表示".to_string();
 //! dock_state.translations.leaf.close_button_disabled_tooltip = "このノードは閉じられないタブがある".to_string();
 //! dock_state.translations.leaf.close_all_button = "ウィンドウを閉じる".to_string();
 //! dock_state.translations.leaf.close_all_button_menu_hint = "右クリックでこのウィンドウを閉じる".to_string();

--- a/src/style.rs
+++ b/src/style.rs
@@ -492,7 +492,7 @@ impl Default for OverlayStyle {
 
             hovered_leaf_highlight: Default::default(),
             button_color: Color32::from_gray(140),
-            button_border_stroke: Stroke::new(1.0, Color32::from_gray(60)),
+            button_border_stroke: Stroke::new(1.0_f32, Color32::from_gray(60)),
             overlay_type: OverlayType::Widgets,
             feel: Default::default(),
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -272,6 +272,14 @@ pub struct TabBodyStyle {
 
     /// Colour of the tab's background. By `Default` it's [`Color32::WHITE`].
     pub bg_fill: Color32,
+
+    /// Optional height override for the draggable area when the tab bar is hidden.
+    ///
+    /// When `None` (default), the drag area height equals [`TabBodyStyle::inner_margin`]`.top`.
+    /// When `Some(height)`, the drag area uses this height instead, overlapping the tab body
+    /// content without shifting it down.
+    /// Setting this to `Some(0.0)` disables dragging from the hidden tab bar entirely.
+    pub hidden_tab_bar_drag_height: Option<f32>,
 }
 
 /// Specifies the look and feel of the tab drop overlay.
@@ -494,6 +502,7 @@ impl Default for TabBodyStyle {
             stroke: Stroke::default(),
             corner_radius: CornerRadius::default(),
             bg_fill: Color32::WHITE,
+            hidden_tab_bar_drag_height: None,
         }
     }
 }
@@ -803,6 +812,7 @@ impl TabBodyStyle {
             stroke: style.visuals.widgets.noninteractive.bg_stroke,
             corner_radius: style.visuals.widgets.active.corner_radius,
             bg_fill: style.visuals.window_fill(),
+            hidden_tab_bar_drag_height: None,
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -129,6 +129,18 @@ pub struct ButtonsStyle {
 
     /// Color of the minimize window button's left border.
     pub minimize_window_border_color: Color32,
+
+    /// Color of the show tab bar triangle button.
+    pub show_tab_bar_color: Color32,
+
+    /// Color of the show tab bar triangle button when hovered.
+    pub show_tab_bar_active_color: Color32,
+
+    /// Size of the show tab bar triangle button.
+    pub show_tab_bar_size: f32,
+
+    /// How much the show tab bar button grows when hovered.
+    pub show_tab_bar_hover_expand: f32,
 }
 
 /// Specifies the look and feel of node separators.
@@ -394,6 +406,11 @@ impl Default for ButtonsStyle {
             minimize_window_active_color: Color32::WHITE,
             minimize_window_bg_fill: Color32::GRAY,
             minimize_window_border_color: Color32::BLACK,
+
+            show_tab_bar_color: Color32::GRAY,
+            show_tab_bar_active_color: Color32::WHITE,
+            show_tab_bar_size: 10.0,
+            show_tab_bar_hover_expand: 1.0,
         }
     }
 }
@@ -598,6 +615,8 @@ impl ButtonsStyle {
             minimize_window_color: style.visuals.text_color(),
             minimize_window_active_color: style.visuals.strong_text_color(),
             minimize_window_border_color: style.visuals.widgets.noninteractive.bg_fill,
+            show_tab_bar_color: style.visuals.text_color(),
+            show_tab_bar_active_color: style.visuals.strong_text_color(),
             ..ButtonsStyle::default()
         }
     }

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -95,7 +95,7 @@ fn button_ui(
     split: Option<Split>,
 ) -> bool {
     let visuals = &style.overlay;
-    let button_stroke = Stroke::new(1.0, visuals.button_color);
+    let button_stroke = Stroke::new(1.0_f32, visuals.button_color);
     let painter = make_overlay_painter(ui);
     painter.rect_stroke(rect, 0.0, visuals.button_border_stroke, StrokeKind::Inside);
     let rect = rect.shrink(rect.width() * 0.1);

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -25,6 +25,7 @@ pub struct DockArea<'tree, Tab> {
     show_close_buttons: bool,
     tab_context_menus: bool,
     draggable_tabs: bool,
+    hidable_tab_bars: bool,
     show_tab_name_on_hover: bool,
     show_window_close_buttons: bool,
     show_window_collapse_buttons: bool,
@@ -57,6 +58,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             show_close_buttons: true,
             tab_context_menus: true,
             draggable_tabs: true,
+            hidable_tab_bars: false,
             show_tab_name_on_hover: false,
             allowed_splits: AllowedSplits::default(),
             to_remove: Vec::new(),
@@ -121,6 +123,13 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     /// By default it's `true`.
     pub fn draggable_tabs(mut self, draggable_tabs: bool) -> Self {
         self.draggable_tabs = draggable_tabs;
+        self
+    }
+
+    /// Whether tab bars can be hidden with the context menu.
+    /// By default it's `false`.
+    pub fn hidable_tab_bars(mut self, hidable_tab_bars: bool) -> Self {
+        self.hidable_tab_bars = hidable_tab_bars;
         self
     }
 

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -520,11 +520,11 @@ impl<Tab> DockArea<'_, Tab> {
 
         ui.painter().line_segment(
             [plus_rect.center_top(), plus_rect.center_bottom()],
-            Stroke::new(1.0, color),
+            Stroke::new(1.0_f32, color),
         );
         ui.painter().line_segment(
             [plus_rect.right_center(), plus_rect.left_center()],
-            Stroke::new(1.0, color),
+            Stroke::new(1.0_f32, color),
         );
 
         // Draw button left border.
@@ -667,11 +667,11 @@ impl<Tab> DockArea<'_, Tab> {
 
             ui.painter().line_segment(
                 [close_all_rect.left_top(), close_all_rect.right_bottom()],
-                Stroke::new(1.0, stroke_color),
+                Stroke::new(1.0_f32, stroke_color),
             );
             ui.painter().line_segment(
                 [close_all_rect.right_top(), close_all_rect.left_bottom()],
-                Stroke::new(1.0, stroke_color),
+                Stroke::new(1.0_f32, stroke_color),
             );
         }
 
@@ -832,15 +832,15 @@ impl<Tab> DockArea<'_, Tab> {
                     .center_top()
                     .lerp(close_all_rect.left_top(), 0.5),
             ],
-            Stroke::new(1.0, stroke_color),
+            Stroke::new(1.0_f32, stroke_color),
         ));
         ui.painter().line_segment(
             [close_all_rect.center_top(), close_all_rect.right_center()],
-            Stroke::new(1.0, stroke_color),
+            Stroke::new(1.0_f32, stroke_color),
         );
         ui.painter().line_segment(
             [close_all_rect.center(), close_all_rect.right_top()],
-            Stroke::new(1.0, stroke_color),
+            Stroke::new(1.0_f32, stroke_color),
         );
     }
 
@@ -994,7 +994,7 @@ impl<Tab> DockArea<'_, Tab> {
         ui.painter().rect_stroke(
             stroke_rect,
             tab_style.corner_radius,
-            Stroke::new(1.0, tab_style.outline_color),
+            Stroke::new(1.0_f32, tab_style.outline_color),
             StrokeKind::Inside,
         );
         if !is_being_dragged {
@@ -1005,7 +1005,7 @@ impl<Tab> DockArea<'_, Tab> {
                     stroke_rect.max.x - f32::max(tab_style.corner_radius.se.into(), 1.5),
                 ),
                 stroke_rect.bottom(),
-                Stroke::new(2.0, tab_style.bg_fill),
+                Stroke::new(2.0_f32, tab_style.bg_fill),
             );
         }
 
@@ -1051,11 +1051,11 @@ impl<Tab> DockArea<'_, Tab> {
             rect_set_size_centered(&mut x_rect, Vec2::splat(Style::TAB_CLOSE_X_SIZE));
             ui.painter().line_segment(
                 [x_rect.left_top(), x_rect.right_bottom()],
-                Stroke::new(1.0, color),
+                Stroke::new(1.0_f32, color),
             );
             ui.painter().line_segment(
                 [x_rect.right_top(), x_rect.left_bottom()],
-                Stroke::new(1.0, color),
+                Stroke::new(1.0_f32, color),
             );
 
             close_response

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -88,6 +88,39 @@ impl<Tab> DockArea<'_, Tab> {
             collapsed,
         );
 
+        // handle dragging by the top margin when the tab bar is hidden
+        if tab_bar_hidden && self.draggable_tabs {
+            let id = self.id
+                .with((path.surface, "surface"))
+                .with((path.node, "node"))
+                .with("hidden_tab_bar_drag");
+            ui.interact(tabbar_rect, id, Sense::click_and_drag());
+            let is_being_dragged = ui.ctx().is_being_dragged(id)
+                && ui.input(|i| i.pointer.is_decidedly_dragging());
+            if is_being_dragged {
+                ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
+                if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+                    let start = *state.drag_start.get_or_insert(pointer_pos);
+                    let delta = pointer_pos - start;
+                    if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
+                        let active = self.dock_state[path]
+                            .get_leaf()
+                            .expect("This node must be a leaf")
+                            .active;
+                        ui.memory_mut(|mem| {
+                            mem.data.insert_temp(
+                                self.id.with("drag_data"),
+                                Some(DragData {
+                                    src: TreeComponent::Tab((path, active).into()),
+                                    rect: self.dock_state[path].rect().unwrap(),
+                                }),
+                            );
+                        });
+                    }
+                }
+            }
+        }
+
         let tabs = self.dock_state[path]
             .tabs_mut()
             .expect("This node must be a leaf here");

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -53,14 +53,30 @@ impl<Tab> DockArea<'_, Tab> {
         if self.dock_state[path].tabs_count() == 0 {
             return;
         }
-        let tabbar_rect = self.tab_bar(
-            ui,
-            state,
-            path,
-            tab_viewer,
-            fade_style.map(|(style, _)| style),
-            collapsed,
-        );
+        
+        let leaf = self.dock_state.leaf(path).expect("This node must be a leaf");
+        let tab_bar_hidden = self.hidable_tab_bars && leaf.tab_bar_hidden;
+        let style = fade_style.map(|(style, _)| style);
+
+        let tabbar_rect = if !tab_bar_hidden {
+            self.tab_bar(
+                ui,
+                state,
+                path,
+                tab_viewer,
+                style,
+                collapsed,
+            )
+        } else {
+            // allow leaf to be dragged by the top inner margin of the tab when the tab bar is hidden
+            let style = style
+                .unwrap_or_else(|| self.style.as_ref().unwrap());
+            let drag_size = vec2(
+                ui.available_width(),
+                style.tab.tab_body.inner_margin.top as f32
+            );
+            Rect::from_min_size(ui.cursor().min, drag_size)
+        };
         self.tab_body(
             ui,
             state,
@@ -385,6 +401,8 @@ impl<Tab> DockArea<'_, Tab> {
                         Button::new(&self.dock_state.translations.tab_context_menu.eject_button);
                     let close_button =
                         Button::new(&self.dock_state.translations.tab_context_menu.close_button);
+                    let hide_tab_bar_button =
+                        Button::new(&self.dock_state.translations.tab_context_menu.hide_tab_bar_button);
 
                     response.context_menu(|ui| {
                         let leaf = self.dock_state[path]
@@ -413,6 +431,9 @@ impl<Tab> DockArea<'_, Tab> {
                                 OnCloseResponse::Ignore => (),
                             }
                             ui.close();
+                        }
+                        if self.hidable_tab_bars && ui.add(hide_tab_bar_button).clicked() {
+                            leaf.tab_bar_hidden = true;
                         }
                     });
                 }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -94,7 +94,10 @@ impl<Tab> DockArea<'_, Tab> {
                 .with((path.surface, "surface"))
                 .with((path.node, "node"))
                 .with("hidden_tab_bar_drag");
-            ui.interact(tabbar_rect, id, Sense::click_and_drag());
+            let response = ui.interact(tabbar_rect, id, Sense::click_and_drag());
+            if response.hovered() {
+                ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
+            }
             let is_being_dragged = ui.ctx().is_being_dragged(id)
                 && ui.input(|i| i.pointer.is_decidedly_dragging());
             if is_being_dragged {

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -68,7 +68,7 @@ impl<Tab> DockArea<'_, Tab> {
                 collapsed,
             )
         } else {
-            // allow leaf to be dragged by the top inner margin of the tab when the tab bar is hidden
+            // use the top margin of the tab body as a tab bar
             let style = style
                 .unwrap_or_else(|| self.style.as_ref().unwrap());
             let drag_size = vec2(
@@ -88,37 +88,58 @@ impl<Tab> DockArea<'_, Tab> {
             collapsed,
         );
 
-        // handle dragging by the top margin when the tab bar is hidden
-        if tab_bar_hidden && self.draggable_tabs {
+        // handle interaction with the top margin when the tab bar is hidden
+        if tab_bar_hidden {
             let id = self.id
                 .with((path.surface, "surface"))
                 .with((path.node, "node"))
                 .with("hidden_tab_bar_drag");
             let response = ui.interact(tabbar_rect, id, Sense::click_and_drag());
-            if response.hovered() {
-                ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
-            }
-            let is_being_dragged = ui.ctx().is_being_dragged(id)
-                && ui.input(|i| i.pointer.is_decidedly_dragging());
-            if is_being_dragged {
-                ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
-                if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
-                    let start = *state.drag_start.get_or_insert(pointer_pos);
-                    let delta = pointer_pos - start;
-                    if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
-                        let active = self.dock_state[path]
-                            .get_leaf()
+
+            // right-click context menu for the tab bar
+            if self.tab_context_menus {
+                let show_button = Button::new(
+                    &self.dock_state.translations.tab_context_menu.show_tab_bar_button,
+                );
+                response.context_menu(|ui| {
+                    // shows the hidden tab bar when pressed
+                    if ui.add(show_button).clicked() {
+                        self.dock_state[path]
+                            .get_leaf_mut()
                             .expect("This node must be a leaf")
-                            .active;
-                        ui.memory_mut(|mem| {
-                            mem.data.insert_temp(
-                                self.id.with("drag_data"),
-                                Some(DragData {
-                                    src: TreeComponent::Tab((path, active).into()),
-                                    rect: self.dock_state[path].rect().unwrap(),
-                                }),
-                            );
-                        });
+                            .tab_bar_hidden = false;
+                        ui.close();
+                    }
+                });
+            }
+
+            // allow tab to be draggable via the top margin of the tab body
+            if self.draggable_tabs {
+                if response.hovered() {
+                    ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
+                }
+                let is_being_dragged = ui.ctx().is_being_dragged(id)
+                    && ui.input(|i| i.pointer.is_decidedly_dragging());
+                if is_being_dragged {
+                    ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
+                    if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+                        let start = *state.drag_start.get_or_insert(pointer_pos);
+                        let delta = pointer_pos - start;
+                        if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
+                            let active = self.dock_state[path]
+                                .get_leaf()
+                                .expect("This node must be a leaf")
+                                .active;
+                            ui.memory_mut(|mem| {
+                                mem.data.insert_temp(
+                                    self.id.with("drag_data"),
+                                    Some(DragData {
+                                        src: TreeComponent::Tab((path, active).into()),
+                                        rect: self.dock_state[path].rect().unwrap(),
+                                    }),
+                                );
+                            });
+                        }
                     }
                 }
             }

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1270,6 +1270,7 @@ impl<Tab> DockArea<'_, Tab> {
                 if ui.input(|i| i.pointer.any_click()) {
                     if let Some(pos) = state.last_hover_pos {
                         if body_rect.contains(pos)
+                            && !tabbar_rect.contains(pos)
                             && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
                         {
                             self.new_focused = Some(path);

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -88,98 +88,14 @@ impl<Tab> DockArea<'_, Tab> {
             collapsed,
         );
 
-        // handle interaction with the top margin when the tab bar is hidden
         if tab_bar_hidden {
-            let style = style.unwrap_or_else(|| self.style.as_ref().unwrap());
-            let btn_size = style.buttons.show_tab_bar_size;
-            let btn_expand = style.buttons.show_tab_bar_hover_expand;
-            let btn_color = style.buttons.show_tab_bar_color;
-            let btn_active_color = style.buttons.show_tab_bar_active_color;
-
-            // register the drag area first so the button takes priority over it
-            let drag_id = self.id
-                .with((path.surface, "surface"))
-                .with((path.node, "node"))
-                .with("hidden_tab_bar_drag");
-            let drag_response = ui.interact(tabbar_rect, drag_id, Sense::click_and_drag());
-
-            // triangle button in the top-left corner to show the tab bar
-            let btn_rect = Rect::from_min_size(tabbar_rect.left_top(), Vec2::splat(btn_size));
-            let btn_id = self.id
-                .with((path.surface, "surface"))
-                .with((path.node, "node"))
-                .with("show_tab_bar_btn");
-            let btn_response = ui.interact(btn_rect, btn_id, Sense::click());
-            let (draw_rect, color) = if btn_response.hovered() {
-                let expanded_size = Vec2::splat(btn_size + btn_expand);
-                (Rect::from_min_size(btn_rect.left_top(), expanded_size), btn_active_color)
-            } else {
-                (btn_rect, btn_color)
-            };
-            ui.painter().add(Shape::convex_polygon(
-                vec![
-                    draw_rect.left_top(),
-                    draw_rect.right_top(),
-                    draw_rect.left_bottom(),
-                ],
-                color,
-                Stroke::NONE,
-            ));
-            if btn_response.clicked() {
-                self.dock_state[path]
-                    .get_leaf_mut()
-                    .expect("This node must be a leaf")
-                    .tab_bar_hidden = false;
-            }
-
-            let on_button = btn_response.hovered() || btn_response.clicked();
-
-            // right-click context menu to show the tab bar
-            if self.tab_context_menus && !on_button {
-                let show_button = Button::new(
-                    &self.dock_state.translations.tab_context_menu.show_tab_bar_button,
-                );
-                drag_response.context_menu(|ui| {
-                    if ui.add(show_button).clicked() {
-                        self.dock_state[path]
-                            .get_leaf_mut()
-                            .expect("This node must be a leaf")
-                            .tab_bar_hidden = false;
-                        ui.close();
-                    }
-                });
-            }
-
-            // allow tab to be draggable via the top margin of the tab body
-            if self.draggable_tabs && !on_button {
-                if drag_response.hovered() {
-                    ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
-                }
-                let is_being_dragged = ui.ctx().is_being_dragged(drag_id)
-                    && ui.input(|i| i.pointer.is_decidedly_dragging());
-                if is_being_dragged {
-                    ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
-                    if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
-                        let start = *state.drag_start.get_or_insert(pointer_pos);
-                        let delta = pointer_pos - start;
-                        if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
-                            let active = self.dock_state[path]
-                                .get_leaf()
-                                .expect("This node must be a leaf")
-                                .active;
-                            ui.memory_mut(|mem| {
-                                mem.data.insert_temp(
-                                    self.id.with("drag_data"),
-                                    Some(DragData {
-                                        src: TreeComponent::Tab((path, active).into()),
-                                        rect: self.dock_state[path].rect().unwrap(),
-                                    }),
-                                );
-                            });
-                        }
-                    }
-                }
-            }
+            self.hidden_tab_bar_controls(
+                ui,
+                state,
+                path,
+                tabbar_rect,
+                style,
+            );
         }
 
         let tabs = self.dock_state[path]
@@ -191,6 +107,94 @@ impl<Tab> DockArea<'_, Tab> {
                     (path, TabIndex(tab_index)).into(),
                     ForcedRemoval(true),
                 ));
+            }
+        }
+    }
+
+    /// Draws controls for the hidden tab bar: a triangle button to show it,
+    /// a right-click context menu, and drag handling on the top margin.
+    fn hidden_tab_bar_controls(
+        &mut self,
+        ui: &mut Ui,
+        state: &mut State,
+        path: NodePath,
+        tabbar_rect: Rect,
+        fade_style: Option<&Style>,
+    ) {
+        let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
+        let btn_size = style.buttons.show_tab_bar_size;
+        let btn_expand = style.buttons.show_tab_bar_hover_expand;
+        let btn_color = style.buttons.show_tab_bar_color;
+        let btn_active_color = style.buttons.show_tab_bar_active_color;
+
+        // register the drag area first so the button takes priority over it
+        let drag_id = self.id
+            .with((path.surface, "surface"))
+            .with((path.node, "node"))
+            .with("hidden_tab_bar_drag");
+        let drag_response = ui.interact(tabbar_rect, drag_id, Sense::click_and_drag());
+
+        // triangle button in the top-left corner to show the tab bar
+        let btn_rect = Rect::from_min_size(tabbar_rect.left_top(), Vec2::splat(btn_size));
+        let btn_id = self.id
+            .with((path.surface, "surface"))
+            .with((path.node, "node"))
+            .with("show_tab_bar_btn");
+        let btn_response = ui.interact(btn_rect, btn_id, Sense::click());
+        let (draw_rect, color) = if btn_response.hovered() {
+            let expanded_size = Vec2::splat(btn_size + btn_expand);
+            (Rect::from_min_size(btn_rect.left_top(), expanded_size), btn_active_color)
+        } else {
+            (btn_rect, btn_color)
+        };
+        ui.painter().add(Shape::convex_polygon(
+            vec![
+                draw_rect.left_top(),
+                draw_rect.right_top(),
+                draw_rect.left_bottom(),
+            ],
+            color,
+            Stroke::NONE,
+        ));
+        if btn_response.clicked() {
+            self.dock_state[path]
+                .get_leaf_mut()
+                .expect("This node must be a leaf")
+                .tab_bar_hidden = false;
+        }
+
+        let on_button = btn_response.hovered() || btn_response.clicked();
+
+        // right-click context menu to show the tab bar
+        if self.tab_context_menus && !on_button {
+            let show_button = Button::new(
+                &self.dock_state.translations.tab_context_menu.show_tab_bar_button,
+            );
+            drag_response.context_menu(|ui| {
+                if ui.add(show_button).clicked() {
+                    self.dock_state[path]
+                        .get_leaf_mut()
+                        .expect("This node must be a leaf")
+                        .tab_bar_hidden = false;
+                    ui.close();
+                }
+            });
+        }
+
+        // allow tab to be draggable via the top margin of the tab body
+        if self.draggable_tabs && !on_button {
+            if drag_response.hovered() {
+                ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
+            }
+            let is_being_dragged = ui.ctx().is_being_dragged(drag_id)
+                && ui.input(|i| i.pointer.is_decidedly_dragging());
+            if is_being_dragged {
+                ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);
+                let active = self.dock_state[path]
+                    .get_leaf()
+                    .expect("This node must be a leaf")
+                    .active;
+                self.try_initiate_tab_drag(ui, state, path, active);
             }
         }
     }
@@ -439,24 +443,12 @@ impl<Tab> DockArea<'_, Tab> {
                 let response =
                     tabs_ui.interact(response.rect, id.with("dragged"), Sense::click_and_drag());
 
-                if let Some(pointer_pos) = tabs_ui.ctx().pointer_interact_pos() {
-                    let start = *state.drag_start.get_or_insert(pointer_pos);
-                    let delta = pointer_pos - start;
-                    if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
-                        tabs_ui
-                            .ctx()
-                            .transform_layer_shapes(layer_id, TSTransform::new(delta, 1.0));
-
-                        tabs_ui.memory_mut(|mem| {
-                            mem.data.insert_temp(
-                                self.id.with("drag_data"),
-                                Some(DragData {
-                                    src: TreeComponent::Tab((path, tab_index).into()),
-                                    rect: self.dock_state[path].rect().unwrap(),
-                                }),
-                            );
-                        });
-                    }
+                if let Some(delta) = self.try_initiate_tab_drag(
+                    tabs_ui, state, path, tab_index,
+                ) {
+                    tabs_ui
+                        .ctx()
+                        .transform_layer_shapes(layer_id, TSTransform::new(delta, 1.0));
                 }
 
                 (response, title_id)
@@ -957,6 +949,34 @@ impl<Tab> DockArea<'_, Tab> {
             [close_all_rect.center(), close_all_rect.right_top()],
             Stroke::new(1.0_f32, stroke_color),
         );
+    }
+
+    /// Checks if a drag has exceeded the movement threshold, and if so,
+    /// stores DragData for the given tab. Returns the drag delta if stored.
+    fn try_initiate_tab_drag(
+        &self,
+        ui: &Ui,
+        state: &mut State,
+        path: NodePath,
+        tab_index: TabIndex,
+    ) -> Option<Vec2> {
+        let pointer_pos = ui.ctx().pointer_interact_pos()?;
+        let start = *state.drag_start.get_or_insert(pointer_pos);
+        let delta = pointer_pos - start;
+        if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
+            ui.memory_mut(|mem| {
+                mem.data.insert_temp(
+                    self.id.with("drag_data"),
+                    Some(DragData {
+                        src: TreeComponent::Tab((path, tab_index).into()),
+                        rect: self.dock_state[path].rect().unwrap(),
+                    }),
+                );
+            });
+            Some(delta)
+        } else {
+            None
+        }
     }
 
     fn draw_arrow(collapsed: bool, ui: &mut Ui, color: Color32, arrow_rect: Rect) {

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -57,27 +57,22 @@ impl<Tab> DockArea<'_, Tab> {
         if self.dock_state[path].tabs_count() == 0 {
             return;
         }
-        
-        let leaf = self.dock_state.leaf(path).expect("This node must be a leaf");
+
+        let leaf = self
+            .dock_state
+            .leaf(path)
+            .expect("This node must be a leaf");
         let tab_bar_hidden = self.hidable_tab_bars && leaf.tab_bar_hidden;
         let style = fade_style.map(|(style, _)| style);
 
         let tabbar_rect = if !tab_bar_hidden {
-            self.tab_bar(
-                ui,
-                state,
-                path,
-                tab_viewer,
-                style,
-                collapsed,
-            )
+            self.tab_bar(ui, state, path, tab_viewer, style, collapsed)
         } else {
             // use the top margin of the tab body as a tab bar
-            let style = style
-                .unwrap_or_else(|| self.style.as_ref().unwrap());
+            let style = style.unwrap_or_else(|| self.style.as_ref().unwrap());
             let drag_size = vec2(
                 ui.available_width(),
-                style.tab.tab_body.inner_margin.top as f32
+                style.tab.tab_body.inner_margin.top as f32,
             );
             Rect::from_min_size(ui.cursor().min, drag_size)
         };
@@ -93,13 +88,7 @@ impl<Tab> DockArea<'_, Tab> {
         );
 
         if tab_bar_hidden {
-            self.hidden_tab_bar_controls(
-                ui,
-                state,
-                path,
-                tabbar_rect,
-                style,
-            );
+            self.hidden_tab_bar_controls(ui, state, path, tabbar_rect, style);
         }
 
         let tabs = self.dock_state[path]
@@ -132,7 +121,8 @@ impl<Tab> DockArea<'_, Tab> {
         let btn_active_color = style.buttons.show_tab_bar_active_color;
 
         // register the drag area first so the button takes priority over it
-        let drag_id = self.id
+        let drag_id = self
+            .id
             .with((path.surface, "surface"))
             .with((path.node, "node"))
             .with("hidden_tab_bar_drag");
@@ -140,14 +130,18 @@ impl<Tab> DockArea<'_, Tab> {
 
         // triangle button in the top-left corner to show the tab bar
         let btn_rect = Rect::from_min_size(tabbar_rect.left_top(), Vec2::splat(btn_size));
-        let btn_id = self.id
+        let btn_id = self
+            .id
             .with((path.surface, "surface"))
             .with((path.node, "node"))
             .with("show_tab_bar_btn");
         let btn_response = ui.interact(btn_rect, btn_id, Sense::click());
         let (draw_rect, color) = if btn_response.hovered() {
             let expanded_size = Vec2::splat(btn_size + btn_expand);
-            (Rect::from_min_size(btn_rect.left_top(), expanded_size), btn_active_color)
+            (
+                Rect::from_min_size(btn_rect.left_top(), expanded_size),
+                btn_active_color,
+            )
         } else {
             (btn_rect, btn_color)
         };
@@ -172,7 +166,11 @@ impl<Tab> DockArea<'_, Tab> {
         // right-click context menu to show the tab bar
         if self.tab_context_menus && !on_button {
             let show_button = Button::new(
-                &self.dock_state.translations.tab_context_menu.show_tab_bar_button,
+                &self
+                    .dock_state
+                    .translations
+                    .tab_context_menu
+                    .show_tab_bar_button,
             );
             drag_response.context_menu(|ui| {
                 if ui.add(show_button).clicked() {
@@ -447,9 +445,7 @@ impl<Tab> DockArea<'_, Tab> {
                 let response =
                     tabs_ui.interact(response.rect, id.with("dragged"), Sense::click_and_drag());
 
-                if let Some(delta) = self.try_initiate_tab_drag(
-                    tabs_ui, state, path, tab_index,
-                ) {
+                if let Some(delta) = self.try_initiate_tab_drag(tabs_ui, state, path, tab_index) {
                     tabs_ui
                         .ctx()
                         .transform_layer_shapes(layer_id, TSTransform::new(delta, 1.0));
@@ -491,8 +487,13 @@ impl<Tab> DockArea<'_, Tab> {
                         Button::new(&self.dock_state.translations.tab_context_menu.eject_button);
                     let close_button =
                         Button::new(&self.dock_state.translations.tab_context_menu.close_button);
-                    let hide_tab_bar_button =
-                        Button::new(&self.dock_state.translations.tab_context_menu.hide_tab_bar_button);
+                    let hide_tab_bar_button = Button::new(
+                        &self
+                            .dock_state
+                            .translations
+                            .tab_context_menu
+                            .hide_tab_bar_button,
+                    );
 
                     response.context_menu(|ui| {
                         let leaf = self.dock_state[path]

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -90,19 +90,56 @@ impl<Tab> DockArea<'_, Tab> {
 
         // handle interaction with the top margin when the tab bar is hidden
         if tab_bar_hidden {
-            let id = self.id
+            let style = style.unwrap_or_else(|| self.style.as_ref().unwrap());
+            let btn_size = style.buttons.show_tab_bar_size;
+            let btn_expand = style.buttons.show_tab_bar_hover_expand;
+            let btn_color = style.buttons.show_tab_bar_color;
+            let btn_active_color = style.buttons.show_tab_bar_active_color;
+
+            // register the drag area first so the button takes priority over it
+            let drag_id = self.id
                 .with((path.surface, "surface"))
                 .with((path.node, "node"))
                 .with("hidden_tab_bar_drag");
-            let response = ui.interact(tabbar_rect, id, Sense::click_and_drag());
+            let drag_response = ui.interact(tabbar_rect, drag_id, Sense::click_and_drag());
 
-            // right-click context menu for the tab bar
-            if self.tab_context_menus {
+            // triangle button in the top-left corner to show the tab bar
+            let btn_rect = Rect::from_min_size(tabbar_rect.left_top(), Vec2::splat(btn_size));
+            let btn_id = self.id
+                .with((path.surface, "surface"))
+                .with((path.node, "node"))
+                .with("show_tab_bar_btn");
+            let btn_response = ui.interact(btn_rect, btn_id, Sense::click());
+            let (draw_rect, color) = if btn_response.hovered() {
+                let expanded_size = Vec2::splat(btn_size + btn_expand);
+                (Rect::from_min_size(btn_rect.left_top(), expanded_size), btn_active_color)
+            } else {
+                (btn_rect, btn_color)
+            };
+            ui.painter().add(Shape::convex_polygon(
+                vec![
+                    draw_rect.left_top(),
+                    draw_rect.right_top(),
+                    draw_rect.left_bottom(),
+                ],
+                color,
+                Stroke::NONE,
+            ));
+            if btn_response.clicked() {
+                self.dock_state[path]
+                    .get_leaf_mut()
+                    .expect("This node must be a leaf")
+                    .tab_bar_hidden = false;
+            }
+
+            let on_button = btn_response.hovered() || btn_response.clicked();
+
+            // right-click context menu to show the tab bar
+            if self.tab_context_menus && !on_button {
                 let show_button = Button::new(
                     &self.dock_state.translations.tab_context_menu.show_tab_bar_button,
                 );
-                response.context_menu(|ui| {
-                    // shows the hidden tab bar when pressed
+                drag_response.context_menu(|ui| {
                     if ui.add(show_button).clicked() {
                         self.dock_state[path]
                             .get_leaf_mut()
@@ -114,11 +151,11 @@ impl<Tab> DockArea<'_, Tab> {
             }
 
             // allow tab to be draggable via the top margin of the tab body
-            if self.draggable_tabs {
-                if response.hovered() {
+            if self.draggable_tabs && !on_button {
+                if drag_response.hovered() {
                     ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
                 }
-                let is_being_dragged = ui.ctx().is_being_dragged(id)
+                let is_being_dragged = ui.ctx().is_being_dragged(drag_id)
                     && ui.input(|i| i.pointer.is_decidedly_dragging());
                 if is_being_dragged {
                     ui.output_mut(|o| o.cursor_icon = CursorIcon::Grabbing);

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -70,10 +70,12 @@ impl<Tab> DockArea<'_, Tab> {
         } else {
             // use the top margin of the tab body as a tab bar
             let style = style.unwrap_or_else(|| self.style.as_ref().unwrap());
-            let drag_size = vec2(
-                ui.available_width(),
-                style.tab.tab_body.inner_margin.top as f32,
-            );
+            let drag_height = style
+                .tab
+                .tab_body
+                .hidden_tab_bar_drag_height
+                .unwrap_or(style.tab.tab_body.inner_margin.top as f32);
+            let drag_size = vec2(ui.available_width(), drag_height);
             Rect::from_min_size(ui.cursor().min, drag_size)
         };
         self.tab_body(
@@ -184,7 +186,13 @@ impl<Tab> DockArea<'_, Tab> {
         }
 
         // allow tab to be draggable via the top margin of the tab body
-        if self.draggable_tabs && !on_button {
+
+        let drag_enabled = style
+            .tab
+            .tab_body
+            .hidden_tab_bar_drag_height
+            .is_none_or(|h| h > 0.0);
+        if self.draggable_tabs && drag_enabled && !on_button {
             if drag_response.hovered() {
                 ui.output_mut(|o| o.cursor_icon = CursorIcon::Grab);
             }
@@ -968,7 +976,7 @@ impl<Tab> DockArea<'_, Tab> {
         let pointer_pos = ui.ctx().pointer_interact_pos()?;
         let start = *state.drag_start.get_or_insert(pointer_pos);
         let delta = pointer_pos - start;
-        if delta.x.abs() > 30.0 || delta.y.abs() > 6.0 {
+        (delta.x.abs() > 30.0 || delta.y.abs() > 6.0).then(|| {
             ui.memory_mut(|mem| {
                 mem.data.insert_temp(
                     self.id.with("drag_data"),
@@ -978,10 +986,8 @@ impl<Tab> DockArea<'_, Tab> {
                     }),
                 );
             });
-            Some(delta)
-        } else {
-            None
-        }
+            delta
+        })
     }
 
     fn draw_arrow(collapsed: bool, ui: &mut Ui, color: Color32, arrow_rect: Rect) {

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -57,12 +57,12 @@ impl<Tab> DockArea<'_, Tab> {
                 let src_tab_count = self.dock_state[source.node_path()].tabs_count();
                 self.dock_state.move_tab(source, destination);
                 // unhide tab bar on the source leaf when a tab is dragged out
-                if self.hidable_tab_bars {
-                    if let Ok(leaf) = self.dock_state.leaf_mut(source.node_path()) {
-                        if leaf.tabs.len() < src_tab_count && leaf.tab_bar_hidden {
-                            leaf.tab_bar_hidden = false;
-                        }
-                    }
+                if self.hidable_tab_bars
+                    && let Ok(leaf) = self.dock_state.leaf_mut(source.node_path())
+                    && leaf.tabs.len() < src_tab_count
+                    && leaf.tab_bar_hidden
+                {
+                    leaf.tab_bar_hidden = false;
                 }
             }
         }

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -83,7 +83,16 @@ impl<Tab> DockArea<'_, Tab> {
                             ),
                         }
                     };
+                    let src_tab_count = self.dock_state[source.node_path()].tabs_count();
                     self.dock_state.move_tab(source, destination);
+                    // unhide tab bar on the source leaf when a tab is dragged out
+                    if self.hidable_tab_bars {
+                        if let Ok(leaf) = self.dock_state.leaf_mut(source.node_path()) {
+                            if leaf.tabs.len() < src_tab_count && leaf.tab_bar_hidden {
+                                leaf.tab_bar_hidden = false;
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This adds the option to hide/show tab bars for a given leaf, see https://github.com/anhosh/egui_dock/issues/321.

- Adds hidable_tab_bars option to DockArea that enables tab bars to be hidden per-leaf.
- When hidden, the tab body's top inner margin acts as a drag handle for the active tab, with the same grab/grabbing cursor behavior as regular tabs.
- A configurable triangle button in the top-left corner allows showing the tab bar again.
- Right-clicking the top margin also provides a "Show tab bar" context menu.
- When a tab is dragged out of a leaf with a hidden tab bar, the tab bar automatically unhides so remaining tabs stay accessible.

`TODO`
- [x] Consider adding an example to demo the new feature.
- [x] Consider whether a setting to disable dragging via the top margin would be needed.

Note:
I think there should be an interface to display a custom button in place of the triangle, but that would better to include in a PR later on that adds custom button UI for _all_ the buttons.