### PR TITLE
fix: restore previously-active tab when active tab is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # egui_dock changelog
 
+## Unreleased
+
+### Fixed
+
+- Removing the active tab of a leaf (closing it, or moving/detaching it out via
+  a split) now restores the tab that was active *before* it, instead of always
+  falling back to the left neighbour. This fixes the surprising jump when you
+  append a tab to a leaf (which auto-focuses it) and then move it elsewhere: the
+  leaf used to show the appended tab's neighbour rather than the tab you were
+  actually looking at. Tracked via a new `LeafNode::prev_active` field
+  (`#[serde(default)]`, so existing serialized layouts load unchanged).
+
 ## egui_dock 0.20.1 - 2026/06/28
 
 ### Fixed

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -692,8 +692,10 @@ impl<Tab> Tree<Tab> {
         for (index, node) in &mut self.nodes.iter_mut().enumerate() {
             match node {
                 Node::Leaf(leaf) => {
-                    leaf.active = TabIndex(leaf.tabs.len());
-                    leaf.tabs.push(tab);
+                    // Go through `append_tab` rather than inlining the push:
+                    // it is the one place that keeps `prev_active` in sync with
+                    // the auto-focus this method performs.
+                    leaf.append_tab(tab);
                     self.focused_node = Some(NodeIndex(index));
                     return;
                 }

--- a/src/dock_state/tree/node/leaf.rs
+++ b/src/dock_state/tree/node/leaf.rs
@@ -20,6 +20,33 @@ pub struct LeafNode<Tab> {
     /// The opened tab.
     pub active: TabIndex,
 
+    /// The tab that was active immediately *before* [`active`](Self::active),
+    /// or `None` if there is no such history (fresh leaf, or the previous
+    /// active tab has since been removed).
+    ///
+    /// # Why this exists
+    ///
+    /// `active` is a *positional* index, not a tab identity. When the active
+    /// tab is removed (closed / moved out via a split / detached) we must pick
+    /// a new active tab. The naive choice — the left neighbour (`active - 1`) —
+    /// is surprising: open a non-last tab, append a new one (which auto-focuses),
+    /// then move that new tab elsewhere, and the leaf jumps to the neighbour
+    /// instead of returning to the tab you were actually looking at.
+    /// `prev_active` records "where we came from" so removal of the active tab
+    /// falls back to it instead.
+    ///
+    /// # Invariant (upheld by every method on this type)
+    ///
+    /// * Either `None`, or `Some(i)` with `i < tabs.len()` and `i != active`.
+    /// * Updated **only** through the methods below — never assign `active`
+    ///   directly from outside. UI activation paths must go through
+    ///   [`set_active_tab`](Self::set_active_tab) or
+    ///   [`activate_tab_remembering`](Self::activate_tab_remembering) so this
+    ///   field stays in sync. One place per mutation touches it — that is what
+    ///   keeps this addition easy to maintain.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub prev_active: Option<TabIndex>,
+
     /// Scroll amount of the tab bar.
     pub scroll: f32,
 
@@ -35,6 +62,7 @@ impl<Tab> LeafNode<Tab> {
             viewport: Rect::NOTHING,
             tabs,
             active: TabIndex(0),
+            prev_active: None,
             scroll: 0.0,
             collapsed: false,
         }
@@ -47,10 +75,26 @@ impl<Tab> LeafNode<Tab> {
     pub fn set_active_tab(&mut self, active_tab: impl Into<TabIndex>) -> Result {
         let index = active_tab.into();
         if index.0 < self.len() {
-            self.active = index;
+            self.activate_tab_remembering(index);
             Ok(())
         } else {
             Err(Error::InvalidTab)
+        }
+    }
+
+    /// Make `index` the active tab, recording the previously-active tab in
+    /// [`prev_active`](Self::prev_active) so a later removal of `index` can fall
+    /// back to it. A no-op (and history-preserving) if `index` is already active.
+    ///
+    /// `index` is assumed to be in bounds — this is the single chokepoint every
+    /// "switch to this tab" path (including the UI tab-bar click handlers) must
+    /// funnel through, so the [`prev_active`](Self::prev_active) invariant cannot
+    /// drift out of sync.
+    #[inline]
+    pub fn activate_tab_remembering(&mut self, index: TabIndex) {
+        if index != self.active {
+            self.prev_active = Some(self.active);
+            self.active = index;
         }
     }
 
@@ -93,6 +137,10 @@ impl<Tab> LeafNode<Tab> {
     #[track_caller]
     #[inline]
     pub fn append_tab(&mut self, tab: Tab) {
+        // Appending happens at the end, so existing indices (including the old
+        // active) keep their positions — record the old active verbatim as the
+        // tab to return to if this freshly-focused tab is later removed.
+        self.prev_active = (!self.tabs.is_empty()).then_some(self.active);
         self.active = TabIndex(self.tabs.len());
         self.tabs.push(tab);
     }
@@ -108,6 +156,12 @@ impl<Tab> LeafNode<Tab> {
     #[inline]
     pub fn insert_tab(&mut self, tab_index: impl Into<TabIndex>, tab: Tab) {
         let tab_index = tab_index.into();
+        // Capture the old active before the insertion shifts indices: any tab
+        // at or after the insertion point moves one slot to the right.
+        self.prev_active = (!self.tabs.is_empty()).then(|| {
+            let old = self.active.0;
+            TabIndex(if old >= tab_index.0 { old + 1 } else { old })
+        });
         self.tabs.insert(tab_index.0, tab);
         self.active = tab_index;
     }
@@ -122,8 +176,39 @@ impl<Tab> LeafNode<Tab> {
     #[inline]
     pub fn remove_tab(&mut self, tab_index: impl Into<TabIndex>) -> Option<Tab> {
         let index = tab_index.into();
-        if index <= self.active {
-            self.active.0 = self.active.0.saturating_sub(1);
+        if index == self.active {
+            // Removing the active tab: fall back to the previously-active tab
+            // if we still have a valid record of it (the common case behind the
+            // "split moved the wrong tab into focus" bug). Otherwise keep the
+            // old left-neighbour behaviour.
+            match self.prev_active {
+                // `prev != index` always holds by the invariant, but guard anyway.
+                Some(prev) if prev != index => {
+                    // `prev` survives the removal; shift it left if it sat to the
+                    // right of the tab being removed.
+                    self.active = if prev.0 > index.0 {
+                        TabIndex(prev.0 - 1)
+                    } else {
+                        prev
+                    };
+                }
+                _ => self.active.0 = self.active.0.saturating_sub(1),
+            }
+            // The history slot is consumed: the tab we came from is now active,
+            // so there is no longer a meaningful "before that" to keep.
+            self.prev_active = None;
+        } else {
+            // Removing some other tab: keep `active` pointing at the same tab,
+            // shifting its index if the removal was to its left.
+            if index.0 < self.active.0 {
+                self.active.0 -= 1;
+            }
+            // Keep `prev_active` pointing at the same tab as well.
+            self.prev_active = match self.prev_active {
+                Some(prev) if prev == index => None, // the remembered tab is gone
+                Some(prev) if index.0 < prev.0 => Some(TabIndex(prev.0 - 1)),
+                other => other,
+            };
         }
         Some(self.tabs.remove(index.0))
     }
@@ -134,6 +219,9 @@ impl<Tab> LeafNode<Tab> {
         F: FnMut(&mut Tab) -> bool,
     {
         self.tabs.retain_mut(predicate);
+        // A bulk retain can drop arbitrary tabs, so the recorded "previous
+        // active" index can no longer be trusted — drop it.
+        self.prev_active = None;
     }
 
     /// Return the area and tab which is currently representing this [`LeafNode`]
@@ -158,5 +246,156 @@ impl<Tab> ops::Index<TabIndex> for LeafNode<Tab> {
 impl<Tab> ops::IndexMut<TabIndex> for LeafNode<Tab> {
     fn index_mut(&mut self, index: TabIndex) -> &mut Tab {
         &mut self.tabs[index.0]
+    }
+}
+
+#[cfg(test)]
+mod prev_active_tests {
+    use super::LeafNode;
+    use crate::{TabIndex, Tree};
+
+    /// Build a leaf with the given tabs and active index set *via the public
+    /// path* (`set_active_tab`) so `prev_active` is initialised the same way the
+    /// real UI would set it.
+    fn leaf_active(tabs: &[char], active: usize) -> LeafNode<char> {
+        let mut leaf = LeafNode::new(tabs.to_vec());
+        leaf.set_active_tab(TabIndex(active)).unwrap();
+        leaf
+    }
+
+    /// The exact reported bug: open a non-last tab, append a new tab (which
+    /// auto-focuses), then remove that appended tab (as a split/move does).
+    /// The leaf must return to the tab that was active *before* the append,
+    /// not the appended tab's left neighbour.
+    #[test]
+    fn append_then_remove_active_returns_to_prior_tab() {
+        // tabs [A,B,C,D], active = C (index 2)
+        let mut leaf = leaf_active(&['A', 'B', 'C', 'D'], 2);
+        assert_eq!(leaf.prev_active, Some(TabIndex(0))); // set_active recorded default-0
+
+        // append E -> auto-focus, prev becomes C(2)
+        leaf.append_tab('E');
+        assert_eq!(leaf.active, TabIndex(4));
+        assert_eq!(leaf.prev_active, Some(TabIndex(2)));
+
+        // move E out == remove the active tab
+        let removed = leaf.remove_tab(TabIndex(4));
+        assert_eq!(removed, Some('E'));
+        assert_eq!(leaf.tabs, vec!['A', 'B', 'C', 'D']);
+        // BEFORE the fix this was D (index 3); now it is C (index 2).
+        assert_eq!(leaf.active, TabIndex(2));
+        assert_eq!(leaf.prev_active, None, "history slot consumed on fallback");
+    }
+
+    #[test]
+    fn append_on_fresh_leaf_has_no_history() {
+        let mut leaf = LeafNode::new(Vec::<char>::new());
+        leaf.append_tab('A');
+        assert_eq!(leaf.active, TabIndex(0));
+        assert_eq!(leaf.prev_active, None);
+    }
+
+    #[test]
+    fn remove_active_without_history_uses_left_neighbour() {
+        // No set_active call -> prev_active is None.
+        let mut leaf = LeafNode::new(vec!['A', 'B', 'C']);
+        leaf.set_active_tab(TabIndex(2)).unwrap(); // prev = 0
+        // First removal of active consumes the history...
+        leaf.remove_tab(TabIndex(2)); // active -> prev (0)
+        assert_eq!(leaf.active, TabIndex(0));
+        assert_eq!(leaf.prev_active, None);
+        // ...so a second removal of the active tab has no history and falls
+        // back to the classic left-neighbour rule (saturating at 0).
+        leaf.remove_tab(TabIndex(0));
+        assert_eq!(leaf.tabs, vec!['B']);
+        assert_eq!(leaf.active, TabIndex(0));
+    }
+
+    #[test]
+    fn insert_tab_shifts_recorded_prev_active() {
+        // tabs [A,B,C], active C(2), prev recorded as default 0.
+        let mut leaf = leaf_active(&['A', 'B', 'C'], 2);
+        // Insert X at front and focus it: everything shifts right by one.
+        leaf.insert_tab(TabIndex(0), 'X');
+        assert_eq!(leaf.tabs, vec!['X', 'A', 'B', 'C']);
+        assert_eq!(leaf.active, TabIndex(0));
+        assert_eq!(leaf.prev_active, Some(TabIndex(3))); // old C, shifted 2 -> 3
+
+        // Remove the focused X -> fall back to the shifted prior tab C.
+        leaf.remove_tab(TabIndex(0));
+        assert_eq!(leaf.tabs, vec!['A', 'B', 'C']);
+        assert_eq!(leaf.active, TabIndex(2)); // C again
+    }
+
+    #[test]
+    fn removing_remembered_tab_clears_history() {
+        // active C(2), prev = A(0).
+        let mut leaf = leaf_active(&['A', 'B', 'C', 'D'], 2);
+        assert_eq!(leaf.prev_active, Some(TabIndex(0)));
+        // Remove A (the remembered tab, not the active one).
+        leaf.remove_tab(TabIndex(0));
+        assert_eq!(leaf.tabs, vec!['B', 'C', 'D']);
+        assert_eq!(leaf.active, TabIndex(1)); // C shifted left
+        assert_eq!(leaf.prev_active, None, "remembered tab gone");
+    }
+
+    #[test]
+    fn removing_tab_right_of_active_leaves_indices_untouched() {
+        // active B(1), prev = A(0).
+        let mut leaf = leaf_active(&['A', 'B', 'C', 'D'], 1);
+        leaf.remove_tab(TabIndex(3)); // remove D, to the right of both
+        assert_eq!(leaf.tabs, vec!['A', 'B', 'C']);
+        assert_eq!(leaf.active, TabIndex(1));
+        assert_eq!(leaf.prev_active, Some(TabIndex(0)));
+    }
+
+    #[test]
+    fn prev_active_tracks_only_one_level() {
+        let mut leaf = LeafNode::new(vec!['A', 'B', 'C']);
+        leaf.set_active_tab(TabIndex(1)).unwrap(); // active B, prev A(0)
+        assert_eq!(leaf.prev_active, Some(TabIndex(0)));
+        leaf.set_active_tab(TabIndex(2)).unwrap(); // active C, prev B(1)
+        assert_eq!(leaf.prev_active, Some(TabIndex(1)));
+        // Removing active C returns to B, not A.
+        leaf.remove_tab(TabIndex(2));
+        assert_eq!(leaf.active, TabIndex(1));
+    }
+
+    #[test]
+    fn reactivating_same_tab_is_a_noop_for_history() {
+        let mut leaf = leaf_active(&['A', 'B', 'C'], 2); // prev = 0
+        leaf.set_active_tab(TabIndex(2)).unwrap(); // same active -> no change
+        assert_eq!(leaf.prev_active, Some(TabIndex(0)));
+    }
+
+    #[test]
+    fn retain_drops_history() {
+        let mut leaf = leaf_active(&['A', 'B', 'C'], 2); // prev = 0
+        leaf.retain_tabs(|t| *t != 'B');
+        assert_eq!(leaf.prev_active, None);
+    }
+
+    /// `Tree::push_to_first_leaf` auto-focuses the pushed tab, so it is an
+    /// active-changing site and must funnel through `append_tab` like every
+    /// other one — otherwise the bug above survives on that path.
+    #[test]
+    fn push_to_first_leaf_records_history() {
+        let mut tree = Tree::new(vec!['A', 'B', 'C']);
+        let root = crate::NodeIndex::root();
+        tree[root]
+            .get_leaf_mut()
+            .unwrap()
+            .set_active_tab(TabIndex(1))
+            .unwrap();
+
+        tree.push_to_first_leaf('D');
+
+        let leaf = tree[root].get_leaf_mut().unwrap();
+        assert_eq!(leaf.active, TabIndex(3), "the pushed tab is focused");
+        assert_eq!(leaf.prev_active, Some(TabIndex(1)));
+
+        // Moving the pushed tab out returns to B, not to its left neighbour C.
+        leaf.remove_tab(TabIndex(3));
+        assert_eq!(leaf.active, TabIndex(1));
     }
 }

--- a/src/dock_state/tree/node/mod.rs
+++ b/src/dock_state/tree/node/mod.rs
@@ -349,6 +349,10 @@ impl<Tab> Node<Tab> {
                     viewport,
                     tabs,
                     active,
+                    // Filtering can drop arbitrary tabs, invalidating the
+                    // recorded "previous active" index, so we deliberately reset
+                    // it rather than try to remap it through the filter.
+                    prev_active: _,
                     scroll,
                     collapsed,
                 } = leaf;
@@ -361,6 +365,7 @@ impl<Tab> Node<Tab> {
                         viewport: *viewport,
                         tabs,
                         active: *active,
+                        prev_active: None,
                         scroll: *scroll,
                         collapsed: *collapsed,
                     })

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -411,7 +411,7 @@ impl<Tab> DockArea<'_, Tab> {
                                     ForcedRemoval(false),
                                 )),
                                 OnCloseResponse::Focus => {
-                                    leaf.active = tab_index;
+                                    leaf.activate_tab_remembering(tab_index);
                                     self.new_focused = Some(path);
                                 }
                                 OnCloseResponse::Ignore => (),
@@ -444,6 +444,12 @@ impl<Tab> DockArea<'_, Tab> {
                 tab_hovered = true;
             }
 
+            // Deferred tab activation: the `tab` borrow below holds `leaf`
+            // mutably until `on_tab_button`, so we cannot call the
+            // whole-`self`-borrowing `activate_tab_remembering` inside the click
+            // handler. Record the intent and apply it once that borrow ends.
+            let mut activate_to: Option<TabIndex> = None;
+
             // Paint hline below each tab unless its active (or option says otherwise).
             let leaf = self.dock_state.leaf_mut(path).unwrap();
             let tab = &mut leaf.tabs[tab_index.0];
@@ -464,7 +470,11 @@ impl<Tab> DockArea<'_, Tab> {
                 || (tabs_ui.memory(|m| m.has_focus(title_id))
                     && tabs_ui.input(|i| i.key_pressed(Key::Enter) || i.key_pressed(Key::Space)))
             {
-                leaf.active = tab_index;
+                // Reading `leaf.active` is a disjoint-field borrow (fine while
+                // `tab` borrows `leaf.tabs`); the actual mutation is deferred.
+                if leaf.active != tab_index {
+                    activate_to = Some(tab_index);
+                }
                 self.new_focused = Some(path);
             }
 
@@ -476,6 +486,16 @@ impl<Tab> DockArea<'_, Tab> {
                     (path, tab_index).into(),
                     ForcedRemoval(false),
                 ));
+            }
+
+            // `tab` is no longer borrowed past this point — safe to take a fresh
+            // `&mut leaf` and funnel through the single activation chokepoint so
+            // `prev_active` is recorded.
+            if let Some(index) = activate_to {
+                self.dock_state
+                    .leaf_mut(path)
+                    .unwrap()
+                    .activate_tab_remembering(index);
             }
         }
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -97,7 +97,7 @@ impl<Tab> DockArea<'_, Tab> {
                                 self.dock_state.remove_tab(path);
                             }
                             OnCloseResponse::Focus => {
-                                leaf.active = path.tab;
+                                leaf.activate_tab_remembering(path.tab);
                                 self.new_focused = Some(path.node_path());
                             }
                             OnCloseResponse::Ignore => {


### PR DESCRIPTION
## Problem

A `LeafNode`'s `active` tab is a **positional** index. When the active tab is removed — closed, or moved/detached out via a split — the leaf falls back to the left neighbour (`active - 1`).

That is surprising right after appending a tab. `append_tab` auto-focuses the new tab, so the sequence "open a non-last tab → append a new tab → move that new tab elsewhere" leaves the leaf showing the appended tab's **neighbour** instead of the tab the user was actually looking at before the append.

## Fix

Track the previously-active tab in a new `LeafNode::prev_active: Option<TabIndex>`:

- Updated at every active-changing site through a single chokepoint, `activate_tab_remembering`, so it cannot drift out of sync. `set_active_tab` and the UI tab-activation paths (`show/leaf.rs`, `show/mod.rs`) funnel through it.
- `append_tab` / `insert_tab` record the prior active (shifted for the insertion), and the index is kept in lockstep across insert/remove.
- `remove_tab` falls back to `prev_active` when the **active** tab is removed (and clears it once consumed); otherwise it keeps the classic left-neighbour behaviour.
- Bulk operations that can drop arbitrary tabs (`retain_tabs`, `filter_map_tabs`) reset `prev_active` rather than try to remap it.
- `Tree::push_to_first_leaf` inlined its own append (assigning `active` directly). That is an active-changing site too, so it would have left `prev_active` stale on exactly the append-then-move path this PR is about; it now calls `LeafNode::append_tab` like every other append site.

The field is `#[serde(default)]`, so existing serialized layouts deserialize unchanged. No public signatures change.

## Tests

Adds 10 unit tests in `leaf.rs` covering the reported scenario and the index-shift edges (insert/remove on either side of active, history cleared when the remembered tab is removed, one-level history, no-op re-activation, retain drop, and the `push_to_first_leaf` path). Full suite green: 15 unit + 20 doctests, `cargo fmt --check` clean, and clippy clean for the touched code.

## Rebase

Rebased onto current `main` (`8cc2208`). The earlier red CI on this branch was not caused by the patch — it was the `f32: From<f64>` fallback error, fixed upstream in `6c5a5b8`, which this rebase picks up. The only conflict was in `CHANGELOG.md`.

Note: `cargo clippy --all-targets -- -D warnings` currently also fails on `examples/hello.rs:146` (`useless_borrows_in_formatting`) on a recent stable toolchain. That is pre-existing on `main` and untouched here, so I left it alone — happy to fix it in a separate PR if you want.

## Disclosure

This work was produced with Claude Code (Anthropic). I drive the agent and review outcomes at the behaviour level — I run the patched build in a real application — but I do not line-by-line review the generated diffs. If that does not meet the project's AI policy, treat this as an issue report rather than a contribution: the problem described above is a real bug with reproduction steps, and you are free to reimplement the fix however you see fit.
