### PR TITLE
Update egui dependency to 0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # egui_dock changelog
 
+## egui_dock 0.19.1 - 2026/03/31
+
+- Corrected outdated documentation.
+
 ## egui_dock 0.19.0 - 2026/03/29
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## egui_dock 0.19.1 - 2026/03/31
 
-- Corrected outdated documentation.
+### Breaking changes
+
+- Upgraded to egui 0.35. ([#326](https://github.com/anhosh/egui_dock/pull/326))
+
+### Changed
+
+- Corrected outdated documentation. ([#326](https://github.com/anhosh/egui_dock/pull/326))
 
 ## egui_dock 0.19.0 - 2026/03/29
 
@@ -40,8 +46,8 @@
 
 ### Added
 
-- `NodePath` and `TabPath` structs, useful for more consistent and terse indexing of nodes and
-  tabs. ([#312](https://github.com/anhosh/egui_dock/pull/312))
+- `NodePath` and `TabPath` structs, useful for more consistent and terse indexing of nodes and tabs.
+  ([#312](https://github.com/anhosh/egui_dock/pull/312))
 - Indexing `LeafNode` with `TabIndex`. ([#311](https://github.com/anhosh/egui_dock/pull/311/))
 - Indexing `DockState` using `NodePath`. ([#312](https://github.com/anhosh/egui_dock/pull/312))
 - New methods ([#312](https://github.com/anhosh/egui_dock/pull/312)):
@@ -55,7 +61,8 @@
 ### Fixed
 
 - No more panics when a window is shrunk to zero available space. ([#309](https://github.com/anhosh/egui_dock/pull/309))
-- No more panics while trying move a tab to the end of the list within the same leaf. ([#308](https://github.com/anhosh/egui_dock/pull/308))
+- No more panics while trying move a tab to the end of the list within the same leaf.
+  ([#308](https://github.com/anhosh/egui_dock/pull/308))
 
 ### Deprecated
 
@@ -119,8 +126,8 @@
 
 ### Fixed
 
-- `DockState::retain_tabs` no longer deletes the main surface if it ends up
-  empty ([#277](https://github.com/Adanos020/egui_dock/pull/277)).
+- `DockState::retain_tabs` no longer deletes the main surface if it ends up empty
+  ([#277](https://github.com/Adanos020/egui_dock/pull/277)).
 - From [#275](https://github.com/Adanos020/egui_dock/pull/275):
     - `{DockState,Tree}::remove_leaf` now removes unused empty node`s at the back of the tree.
     - `{DockState,Tree}::retain_tabs` no longer deletes leaf nodes it shouldn't delete.
@@ -242,15 +249,15 @@
 
 ### Fixed
 
-- Tab body's background is now rounded with the value
-  of `TabBodyStyle::rounding`. ([#232](https://github.com/Adanos020/egui_dock/pull/232))
+- Tab body's background is now rounded with the value of `TabBodyStyle::rounding`.
+  ([#232](https://github.com/Adanos020/egui_dock/pull/232))
 
 ## 0.11.3 - 2024-03-07
 
 ### Fixed
 
-- `filter_map_tabs` sometimes deleting nodes when it
-  shouldn't. ([#230](https://github.com/Adanos020/egui_dock/pull/230))
+- `filter_map_tabs` sometimes deleting nodes when it shouldn't.
+  ([#230](https://github.com/Adanos020/egui_dock/pull/230))
 
 ## 0.11.2 - 2024-02-16
 
@@ -266,8 +273,8 @@ From [#225](https://github.com/Adanos020/egui_dock/pull/225):
 
 ### Fixed
 
-- Bug where tabs couldn't be re-docked onto the main surface if it's
-  empty. ([#222](https://github.com/Adanos020/egui_dock/pull/222))
+- Bug where tabs couldn't be re-docked onto the main surface if it's empty.
+  ([#222](https://github.com/Adanos020/egui_dock/pull/222))
 
 ## 0.11.0 - 2024-02-06
 
@@ -289,19 +296,19 @@ From [#225](https://github.com/Adanos020/egui_dock/pull/225):
     - Separators are now focusable with the keyboard and movable using the arrow keys while control or shift is held.
     - `TabStyle::active_with_kb_focus`, `TabStyle::inactive_with_kb_focus` and `TabStyle::focused_with_kb_focus` for
       style of tabs that are focused with the keyboard.
-- Missing translation for the tooltip showing when you hover on a grayed out window close
-  button. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
+- Missing translation for the tooltip showing when you hover on a grayed out window close button.
+  ([#216](https://github.com/Adanos020/egui_dock/pull/216))
 
 ### Fixed
 
-- Widgets inside tabs are now focusable with the tab key on the
-  keyboard. ([#211](https://github.com/Adanos020/egui_dock/pull/211))
+- Widgets inside tabs are now focusable with the tab key on the keyboard.
+  ([#211](https://github.com/Adanos020/egui_dock/pull/211))
 
 ### Breaking changes
 
 - Upgraded to egui 0.25
-- Replaced `Default` implementations for `{TabContextMenu,Window,}Translations` with associated functions
-  called `english`. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
+- Replaced `Default` implementations for `{TabContextMenu,Window,}Translations` with associated functions called
+  `english`. ([#216](https://github.com/Adanos020/egui_dock/pull/216))
 
 ## 0.9.1 - 2023-12-10
 
@@ -337,15 +344,15 @@ From [#225](https://github.com/Adanos020/egui_dock/pull/225):
 ### Fixed
 
 - Deserializing `WindowState` no longer crashes when `screen_rect` contains any `f32::INFINITY` values. Make sure to fix
-  your last serialized app state by
-  setting `screen_rect: null`. ([#198](https://github.com/Adanos020/egui_dock/pull/198))
+  your last serialized app state by setting `screen_rect: null`.
+  ([#198](https://github.com/Adanos020/egui_dock/pull/198))
 
 ## 0.8.1 - 2023-10-04
 
 ### Fixed
 
-- The tab bar no longer remains empty after it ends up having 0 width in any
-  way. ([#191](https://github.com/Adanos020/egui_dock/pull/191))
+- The tab bar no longer remains empty after it ends up having 0 width in any way.
+  ([#191](https://github.com/Adanos020/egui_dock/pull/191))
 
 ## 0.8.0 - 2023-09-28
 
@@ -362,8 +369,8 @@ From [#225](https://github.com/Adanos020/egui_dock/pull/225):
 
 ### Fixed
 
-- The "Eject" button is not available on tabs which are disallowed in
-  windows. ([#188](https://github.com/Adanos020/egui_dock/pull/188))
+- The "Eject" button is not available on tabs which are disallowed in windows.
+  ([#188](https://github.com/Adanos020/egui_dock/pull/188))
 
 ## 0.7.2 - 2023-09-20
 
@@ -379,27 +386,27 @@ From [#225](https://github.com/Adanos020/egui_dock/pull/225):
 
 ## 0.7.0 - 2023-09-18
 
-This is the biggest update so far, introducing the long awaited undocking feature: tabs can now be dragged out into
-new egui windows. Massive thanks to [Vickerinox](https://github.com/Vickerinox) for implementing it!
+This is the biggest update so far, introducing the long awaited undocking feature: tabs can now be dragged out into new
+egui windows. Massive thanks to [Vickerinox](https://github.com/Vickerinox) for implementing it!
 
 This update also includes an overhaul of the documentation, aiming to not only be more readable and correct, but also
 provide a guide of how to use the library.
 
 ### Changed
 
-- Adjusted the styling of tabs to closer follow the egui default
-  styling. ([#139](https://github.com/Adanos020/egui_dock/pull/139))
-- Double-clicking on a separator resets the size of both adjacent
-  nodes. ([#146](https://github.com/Adanos020/egui_dock/pull/146))
-- Tabs can now only be dragged with the primary pointer button (e.g. left mouse
-  button). ([#177](https://github.com/Adanos020/egui_dock/pull/177))
+- Adjusted the styling of tabs to closer follow the egui default styling.
+  ([#139](https://github.com/Adanos020/egui_dock/pull/139))
+- Double-clicking on a separator resets the size of both adjacent nodes.
+  ([#146](https://github.com/Adanos020/egui_dock/pull/146))
+- Tabs can now only be dragged with the primary pointer button (e.g. left mouse button).
+  ([#177](https://github.com/Adanos020/egui_dock/pull/177))
 
 ### Fixed
 
 - Correctly draw a border around a dock area using the `Style::border`
   property. ([#139](https://github.com/Adanos020/egui_dock/pull/139))
-- Non-closable tabs now cannot be closed by clicking with the middle mouse
-  button. ([9cdef8c](https://github.com/Adanos020/egui_dock/pull/149/commits/9cdef8cb77e73ef7a065d1313f7fb8feae0253b4))
+- Non-closable tabs now cannot be closed by clicking with the middle mouse button.
+  ([9cdef8c](https://github.com/Adanos020/egui_dock/pull/149/commits/9cdef8cb77e73ef7a065d1313f7fb8feae0253b4))
 - Dragging tabs around now works on touchscreens. ([#180](https://github.com/Adanos020/egui_dock/pull/180))
 
 ### Added
@@ -414,8 +421,8 @@ provide a guide of how to use the library.
       margin.
     - `TabStyle::minimum_width` to set the minimum width of the tab.
     - `TabInteractionStyle` to style the active/inactive/focused/hovered states of a tab.
-- `AllowedSplits` enum which lets you choose in which directions a `DockArea` can be
-  split. ([#145](https://github.com/Adanos020/egui_dock/pull/145))
+- `AllowedSplits` enum which lets you choose in which directions a `DockArea` can be split.
+  ([#145](https://github.com/Adanos020/egui_dock/pull/145))
 - From [#149](https://github.com/Adanos020/egui_dock/pull/149):
     - `DockState<Tab>` containing the entire state of the tab hierarchies stored in a collection of `Surfaces`.
     - `Surface<Tab>` enum which represents an area (e.g. a window) with its own `Tree<Tab>`.
@@ -437,13 +444,12 @@ provide a guide of how to use the library.
     - `DockArea::show_window_close_buttons` setting determining if windows should have a close button or not.
     - `DockArea::show_window_collapse_buttons` setting determining if windows should have a collapse button or not.
     - `TabViewer::allowed_in_windows` specifying if a given tab can be shown in a window.
-- `TabViewer::closable` lets individual tabs be closable or
-  not. ([#150](https://github.com/Adanos020/egui_dock/pull/150))
-- `TabViewer::scroll_bars` specifying if horizontal and vertical scrolling is enabled for given tab –
-  replaces `DockArea::scroll_area_in_tabs` (see breaking
-  changes). ([#160](https://github.com/Adanos020/egui_dock/pull/160))
-- `Translations` specifying what text will be displayed in some parts of the `DockingArea`, e.g. the tab context menus (
-  defined in `TabContextMenuTranslations`). ([#178](https://github.com/Adanos020/egui_dock/pull/178))
+- `TabViewer::closable` lets individual tabs be closable or not.
+  ([#150](https://github.com/Adanos020/egui_dock/pull/150))
+- `TabViewer::scroll_bars` specifying if horizontal and vertical scrolling is enabled for given tab – replaces
+  `DockArea::scroll_area_in_tabs` (see breaking changes). ([#160](https://github.com/Adanos020/egui_dock/pull/160))
+- `Translations` specifying what text will be displayed in some parts of the `DockingArea`, e.g. the tab context menus
+  (defined in `TabContextMenuTranslations`). ([#178](https://github.com/Adanos020/egui_dock/pull/178))
 
 ### Breaking changes
 
@@ -493,19 +499,19 @@ provide a guide of how to use the library.
 
 ### Added
 
-- `TabViewer::tab_style_override` that lets you define a custom `TabsStyle` for an individual
-  tab ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
-- `ButtonsStyle::add_tab_border_color` for the `+` button's left
-  border ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
-- `TabBarStyle::rounding` for rounding of the tab bar, independent from tab
-  rounding ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
-- Separate `from_egui` methods for `ButtonsStyle`, `SeparatorStyle`, `TabBarStyle`,
-  and `TabStyle` ([a660497](https://github.com/Adanos020/egui_dock/commit/a660497b21651dd9920665bf50d8fc9e75d0e1e0))
+- `TabViewer::tab_style_override` that lets you define a custom `TabsStyle` for an individual tab
+  ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
+- `ButtonsStyle::add_tab_border_color` for the `+` button's left border
+  ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
+- `TabBarStyle::rounding` for rounding of the tab bar, independent from tab rounding
+  ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
+- Separate `from_egui` methods for `ButtonsStyle`, `SeparatorStyle`, `TabBarStyle`, and `TabStyle`
+  ([a660497](https://github.com/Adanos020/egui_dock/commit/a660497b21651dd9920665bf50d8fc9e75d0e1e0))
 
 ### Breaking changes
 
-- Upgraded `egui` to version
-  0.22 ([c2e8fee](https://github.com/Adanos020/egui_dock/commit/c2e8feeb7713e2b2d2f0fa1b13a46732f9c6df62))
+- Upgraded `egui` to version 0.22
+  ([c2e8fee](https://github.com/Adanos020/egui_dock/commit/c2e8feeb7713e2b2d2f0fa1b13a46732f9c6df62))
 - Renamed `TabsStyle`
   to `TabStyle` ([89f3248](https://github.com/Adanos020/egui_dock/commit/89f32487a9e1fe8dee92f1fbdc296a2d460c0909))
 -
@@ -513,15 +519,17 @@ provide a guide of how to use the library.
 Removed
 `StyleBuilder` ([9a9b275](https://github.com/Adanos020/egui_dock/commit/9a9b2750cd290bebcc4088761249e02102cb0ce7))
 
-- Removed `TabViewer::inner_margin_override` – no deprecation as it's in direct conflict
-  with
-  `TabViewer::tab_style_override` ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
+- Removed `TabViewer::inner_margin_override` – no deprecation as it's in direct conflict with
+  `TabViewer::tab_style_override`
+  ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
 - Moved `Style::default_inner_margin`
   to
-  `TabsStyle::inner_margin` ([78ecf3a](https://github.com/Adanos020/egui_dock/commit/78ecf3a175ffb960724f328274682dfded800e0f))
+  `TabsStyle::inner_margin`
+  ([78ecf3a](https://github.com/Adanos020/egui_dock/commit/78ecf3a175ffb960724f328274682dfded800e0f))
 - Moved `TabStyle::hline_color`
   to
-  `TabBarStyle::hline_color` ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
+  `TabBarStyle::hline_color`
+  ([99333b0](https://github.com/Adanos020/egui_dock/commit/99333b093d307181c288b3e134379cfe47647a7c))
 
 ## 0.5.2 - 2023-06-04
 
@@ -537,21 +545,21 @@ Removed
 
 ### Added
 
-- `SeparatorStyle::extra_interact_width` option that adds "logical" width to separators so that they are easier to
-  grab ([#128](https://github.com/Adanos020/egui_dock/pull/128))
+- `SeparatorStyle::extra_interact_width` option that adds "logical" width to separators so that they are easier to grab
+  ([#128](https://github.com/Adanos020/egui_dock/pull/128))
 
 ## 0.5.0 - 2023-04-22
 
 ### Fixed
 
 - Ensure `Tab` have a stable `egui::Id` when moved ([#121](https://github.com/Adanos020/egui_dock/pull/121))
-- Don't display the "grab" cursor icon on tabs when hovered and the `draggable_tabs` flag is
-  unset ([#123](https://github.com/Adanos020/egui_dock/pull/123))
+- Don't display the "grab" cursor icon on tabs when hovered and the `draggable_tabs` flag is unset
+  ([#123](https://github.com/Adanos020/egui_dock/pull/123))
 
 ### Added
 
-- `Tree::move_tab` method that allows moving a tab from one node to the
-  other ([#115](https://github.com/Adanos020/egui_dock/pull/107))
+- `Tree::move_tab` method that allows moving a tab from one node to the other
+  ([#115](https://github.com/Adanos020/egui_dock/pull/107))
 - `Tree::remove_leaf` method that deletes a selected leaf node ([#115](https://github.com/Adanos020/egui_dock/pull/107))
 - New methods in `DockArea` ([#115](https://github.com/Adanos020/egui_dock/pull/115))
     - `show_add_popup`
@@ -562,13 +570,13 @@ Removed
     - `scroll_area_in_tabs`
     - `show_tab_name_on_hover`
 - Make tabs scrollable when they overflow ([#116](https://github.com/Adanos020/egui_dock/pull/116))
-- `TabViewer::id` method that allows specifying a custom id for each
-  tab ([#121](https://github.com/Adanos020/egui_dock/pull/121))
+- `TabViewer::id` method that allows specifying a custom id for each tab
+  ([#121](https://github.com/Adanos020/egui_dock/pull/121))
 
 ### Breaking changes
 
-- Removed `remove_empty_leaf` which was used for internal usage and should not be needed by
-  users ([#115](https://github.com/Adanos020/egui_dock/pull/107))
+- Removed `remove_empty_leaf` which was used for internal usage and should not be needed by users
+  ([#115](https://github.com/Adanos020/egui_dock/pull/107))
 - Removed `show_close_buttons` from `StyleBuilder` ([#115](https://github.com/Adanos020/egui_dock/pull/115))
 - Moved the following fields from `Style` to `DockArea` ([#115](https://github.com/Adanos020/egui_dock/pull/115))
     - `show_add_popup`
@@ -578,8 +586,8 @@ Removed
     - `show_context_menu` (renamed to `tab_context_menus`)
     - `tab_include_scrollarea` (renamed to `scroll_area_in_tabs`)
     - `tab_hover_name` (renamed to `show_tab_name_on_hover`)
-- `Style` is now split up into smaller structs for maintainability and consistence
-  with `egui::Style` ([#115](https://github.com/Adanos020/egui_dock/pull/115))
+- `Style` is now split up into smaller structs for maintainability and consistence with `egui::Style`
+  ([#115](https://github.com/Adanos020/egui_dock/pull/115))
 
 | Old names and locations                         | New names and locations                          |
 |-------------------------------------------------|--------------------------------------------------|
@@ -623,10 +631,10 @@ Removed
 
 ### Fixed
 
-- Light mode now works in
-  tabs ([528b892](https://github.com/Adanos020/egui_dock/commit/528b89245928d055dabb00cd9001c22d275f789b))
-- `DockArea::show_inside` no longer obscures previously added
-  elements ([#102](https://github.com/Adanos020/egui_dock/pull/102))
+- Light mode now works in tabs
+  ([528b892](https://github.com/Adanos020/egui_dock/commit/528b89245928d055dabb00cd9001c22d275f789b))
+- `DockArea::show_inside` no longer obscures previously added elements
+  ([#102](https://github.com/Adanos020/egui_dock/pull/102))
 - Splitter drag now behaves like egui `DragValue` ([#103](https://github.com/Adanos020/egui_dock/pull/103))
 
 ## 0.4.0 - 2023-02-09
@@ -648,8 +656,8 @@ Removed
 
 ### Added
 
-- `Style` now includes an option to change the tab's
-  height - `tab_bar_height`. ([#62](https://github.com/Adanos020/egui_dock/pull/62))
+- `Style` now includes an option to change the tab's height - `tab_bar_height`.
+  ([#62](https://github.com/Adanos020/egui_dock/pull/62))
 - Implemented the `std::fmt::Debug` trait on all exported types. ([#84](https://github.com/Adanos020/egui_dock/pull/84))
 
 ### Fixed
@@ -660,10 +668,10 @@ Removed
 
 ### Added
 
-- `TabViewer::clear_background` method that returns if current tab's background should be
-  cleared. ([#35](https://github.com/Adanos020/egui_dock/pull/35))
-- You can now close tabs with middle mouse button if `Style::show_close_buttons` is
-  true. ([#34](https://github.com/Adanos020/egui_dock/pull/34))
+- `TabViewer::clear_background` method that returns if current tab's background should be cleared.
+  ([#35](https://github.com/Adanos020/egui_dock/pull/35))
+- You can now close tabs with middle mouse button if `Style::show_close_buttons` is true.
+  ([#34](https://github.com/Adanos020/egui_dock/pull/34))
 - Option to disable dragging tabs.
 - New option `expand_tabs` in `Style` and `StyleBuiler` causes tab titles to expand to match the width of their tab
   bars.
@@ -681,8 +689,7 @@ Removed
 
 - Renamed `TabViewer::inner_margin`
   to `TabViewer::inner_margin_override`. ([#67](https://github.com/Adanos020/egui_dock/pull/67))
-- `Style::with_separator_color` has been split
-  into `separator_color_idle`, `separator_color_hovered`,
+- `Style::with_separator_color` has been split into `separator_color_idle`, `separator_color_hovered`,
   `separator_color_dragged` ([#68](https://github.com/Adanos020/egui_dock/pull/68))
 - Updated `egui` to 0.20.0 [#77](https://github.com/Adanos020/egui_dock/pull/77)
 
@@ -719,8 +726,8 @@ Removed
 - The dock will keep track of the currently focused leaf.
 - Using `Tree::push_to_focused_leaf` will push the given tab to the currently active leaf.
 - `StyleBuilder` for the `Style`.
-- New fields in `Style:` `separator_color`, `border_color`, and `border_width` (last two for the cases when
-  used `Margin`).
+- New fields in `Style:` `separator_color`, `border_color`, and `border_width` (last two for the cases when used
+  `Margin`).
 - `TabBuilder` for the `BuiltTab`.
 - Support for all implementations of `Into<WidgetText>` in tab titles.
 - Style editor in the `hello` example.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
-egui = { version = "0.34", default-features = false }
+egui = { version = "0.35", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 duplicate = "2.0"
@@ -27,7 +27,7 @@ paste = "1.0"
 thiserror = "2.0.18"
 
 [dev-dependencies]
-eframe = { version = "0.34", default-features = false, features = [
+eframe = { version = "0.35", default-features = false, features = [
     "default",
     "default_fonts",
     "glow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 rust-version = "1.92"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "egui_dock"
 description = "Docking system for egui - an immediate-mode GUI library for Rust"
 authors = ["lain-dono", "Adam Gąsior (Adanos020)"]
-version = "0.19.1"
-edition = "2021"
+version = "0.20.0"
+edition = "2024"
 rust-version = "1.92"
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Before contributing, please read [the contribution guide](CONTRIBUTING.md).
 This library is a collaborative project developed with direct involvement of its users.
 
 Please feel free to open new issues and pull requests, and participate in discussions!
-A lot of our discussions take place on [`egui`'s official Discord server](https://discord.gg/JFcEma9bJq),
-in the `#egui_dock` channel.
+A lot of our discussions take place on [`egui`'s official Discord server](https://discord.gg/JFcEma9bJq), in the
+`#egui_dock` channel.
 
 ## Features
 
@@ -32,18 +32,18 @@ Add `egui` and `egui_dock` to your project's dependencies.
 
 ```toml
 [dependencies]
-egui = "0.34"
-egui_dock = "0.19"
+egui = "0.35"
+egui_dock = "0.20"
 ```
 
-Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start).
-Once that's done, you can start using `egui_dock` – more details on that can be found in the
+Then proceed by setting up `egui`, following its [quick start guide](https://github.com/emilk/egui#quick-start). Once
+that's done, you can start using `egui_dock` – more details on that can be found in the
 [documentation](https://docs.rs/egui_dock/latest/egui_dock/).
 
 ## Examples
 
-The Git repository of this crate contains some example applications demonstrating how to achieve certain effects.
-You can find all of them in the [`examples`](examples) folder.
+The Git repository of this crate contains some example applications demonstrating how to achieve certain effects. You
+can find all of them in the [`examples`](examples) folder.
 
 You can run them with Cargo from the crate's root directory, for example: `cargo run --example hello`.
 
@@ -58,8 +58,7 @@ You can run them with Cargo from the crate's root directory, for example: `cargo
 It's a library aiming to achieve similar goals in addition to being more flexible and customizable.
 
 One feature it supports that `egui_dock` does not at the moment is the ability to divide nodes into more than two
-children,
-enabling horizontal, vertical, and grid layouts.
+children, enabling horizontal, vertical, and grid layouts.
 
 > [!NOTE]
 > `egui_tiles` is much earlier in development than `egui_dock` and doesn't yet support a lot of features.

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -4,12 +4,13 @@ use std::collections::HashSet;
 
 use eframe::NativeOptions;
 use egui::{
-    color_picker::{color_edit_button_srgba, Alpha},
-    vec2, ComboBox, CornerRadius, Panel, Slider, Ui, ViewportBuilder, WidgetText,
+    ComboBox, CornerRadius, Panel, Slider, Ui, ViewportBuilder, WidgetText,
+    color_picker::{Alpha, color_edit_button_srgba},
+    vec2,
 };
 use egui_dock::{
-    tab_viewer::OnCloseResponse, AllowedSplits, DockArea, DockState, NodeIndex, NodePath,
-    OverlayType, Style, SurfaceIndex, TabInteractionStyle, TabViewer,
+    AllowedSplits, DockArea, DockState, NodeIndex, NodePath, OverlayType, Style, SurfaceIndex,
+    TabInteractionStyle, TabViewer, tab_viewer::OnCloseResponse,
 };
 
 /// Adds a widget with a label next to it, can be given an extra parameter in order to show a hover text
@@ -49,7 +50,9 @@ macro_rules! unit_slider {
 }
 
 fn main() -> eframe::Result<()> {
-    std::env::set_var("RUST_BACKTRACE", "1");
+    unsafe {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
     let options = NativeOptions {
         viewport: ViewportBuilder::default().with_inner_size(vec2(1024.0, 1024.0)),
         ..Default::default()
@@ -571,7 +574,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        Panel::top("egui_dock::MenuBar").show_inside(ui, |ui| {
+        Panel::top("egui_dock::MenuBar").show(ui, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("View", |ui| {
                     // allow certain tabs to be toggled

--- a/examples/reject_windows.rs
+++ b/examples/reject_windows.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, NativeOptions};
+use eframe::{NativeOptions, egui};
 use egui_dock::{DockArea, DockState, NodeIndex, Style};
 
 fn main() -> eframe::Result<()> {

--- a/examples/save_load_dock_state.rs
+++ b/examples/save_load_dock_state.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 
-use eframe::{egui, NativeOptions};
+use eframe::{NativeOptions, egui};
 use egui_dock::{DockArea, DockState, NodeIndex, Style};
 
 const DOCK_STATE_FILE: &str = "target/dock_state.json";

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, NativeOptions};
+use eframe::{NativeOptions, egui};
 use egui_dock::tab_viewer::OnCloseResponse;
 use egui_dock::{DockArea, DockState, NodeIndex, Style};
 

--- a/examples/tab_add.rs
+++ b/examples/tab_add.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, NativeOptions};
+use eframe::{NativeOptions, egui};
 use egui_dock::{DockArea, DockState, NodeIndex, NodePath, Style};
 
 fn main() -> eframe::Result<()> {

--- a/examples/tab_add_popup.rs
+++ b/examples/tab_add_popup.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use eframe::{egui, NativeOptions};
+use eframe::{NativeOptions, egui};
 use egui::{Color32, RichText};
 use egui_dock::{DockArea, DockState, NodeIndex, NodePath, Style, SurfaceIndex};
 

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -65,7 +65,7 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::Panel::left("documents").show_inside(ui, |ui| {
+        egui::Panel::left("documents").show(ui, |ui| {
             for title in self.buffers.buffers.keys() {
                 let tab_location = self.tree.find_tab(title);
                 let is_open = tab_location.is_some();

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use eframe::{egui, NativeOptions};
+use eframe::{NativeOptions, egui};
 use egui_dock::{DockArea, DockState, Style, TabViewer};
 
 /// We identify tabs by the title of the file we are editing.

--- a/src/dock_state/mod.rs
+++ b/src/dock_state/mod.rs
@@ -219,7 +219,7 @@ impl<Tab> DockState<Tab> {
         })
     }
 
-    /// Sets which is the active tab within a specific node on a given surface.
+    /// Sets which is the active tab at a specific `path`.
     ///
     /// # Errors
     ///
@@ -233,9 +233,9 @@ impl<Tab> DockState<Tab> {
         Ok(())
     }
 
-    /// Immutably borrows a node at the given path.
+    /// Immutably borrows a node at the given `path`.
     ///
-    /// This is the same as `&self[path]` but never panics.
+    /// This is the same as `&self[path]` but returns an error instead of panicking.
     pub fn node(&self, path: NodePath) -> Result<&Node<Tab>> {
         self.surfaces
             .get(path.surface.0)
@@ -247,9 +247,9 @@ impl<Tab> DockState<Tab> {
             .ok_or(Error::InvalidNode)
     }
 
-    /// Mutably borrows a node at the given path.
+    /// Mutably borrows a node at the given `path`.
     ///
-    /// This is the same as `&mut self[path]` but never panics.
+    /// This is the same as `&mut self[path]` but returns an error instead of panicking.
     pub fn node_mut(&mut self, path: NodePath) -> Result<&mut Node<Tab>> {
         self.surfaces
             .get_mut(path.surface.0)
@@ -261,23 +261,23 @@ impl<Tab> DockState<Tab> {
             .ok_or(Error::InvalidNode)
     }
 
-    /// Immutably borrows a leaf node at the given path.
+    /// Immutably borrows a leaf node at the given `path`.
     ///
-    /// Returns `Err` if the path is invalid or the node at the path is not a leaf.
+    /// Returns `Err` if the `path` is invalid or the node at the path is not a leaf.
     pub fn leaf(&self, path: NodePath) -> Result<&LeafNode<Tab>> {
         self.node(path)?.get_leaf().ok_or(Error::NonLeafNode)
     }
 
-    /// Mutably borrows a leaf node at the given path.
+    /// Mutably borrows a leaf node at the given `path`.
     ///
-    /// Returns `Err` if the path is invalid or the node at the path is not a leaf.
+    /// Returns `Err` if the `path` is invalid or the node at the `path` is not a leaf.
     pub fn leaf_mut(&mut self, path: NodePath) -> Result<&mut LeafNode<Tab>> {
         self.node_mut(path)?
             .get_leaf_mut()
             .ok_or(Error::NonLeafNode)
     }
 
-    /// Sets the currently focused leaf to `node_index` if the node at `node_index` is a leaf.
+    /// Sets the currently focused leaf to `path` if the node at `path` is a leaf.
     #[inline]
     pub fn set_focused_node_and_surface(&mut self, path: NodePath) {
         if self.leaf(path).is_ok() {
@@ -358,7 +358,7 @@ impl<Tab> DockState<Tab> {
         surface_index
     }
 
-    /// Currently focused leaf.
+    /// Returns the currently focused leaf if there is one.
     #[inline]
     pub fn focused_leaf(&self) -> Option<NodePath> {
         let surface = self.focused_surface?;
@@ -368,7 +368,7 @@ impl<Tab> DockState<Tab> {
         })
     }
 
-    /// Remove a tab at the specified surface, node, and tab index.
+    /// Removes a tab at the specified `path`.
     /// This method will yield the removed tab, or `None` if it doesn't exist.
     pub fn remove_tab(&mut self, path: TabPath) -> Option<Tab> {
         let removed_tab = self[path.surface].remove_tab((path.node, path.tab));
@@ -378,7 +378,7 @@ impl<Tab> DockState<Tab> {
         removed_tab
     }
 
-    /// Remove a leaf at the specified surface, and node index.
+    /// Removes a leaf at the specified `path`.
     pub fn remove_leaf(&mut self, path: NodePath) {
         self[path.surface].remove_leaf(path.node);
         if !path.surface.is_main() && self[path.surface].is_empty() {
@@ -547,14 +547,7 @@ impl<Tab> DockState<Tab> {
                 surface
                     .iter_all_tabs()
                     .map(move |((node_index, tab_index), tab)| {
-                        (
-                            TabPath {
-                                surface: surface_index,
-                                node: node_index,
-                                tab: tab_index,
-                            },
-                            tab,
-                        )
+                        (TabPath::new(surface_index, node_index, tab_index), tab)
                     })
             })
     }
@@ -567,14 +560,7 @@ impl<Tab> DockState<Tab> {
                 surface
                     .iter_all_tabs_mut()
                     .map(move |((node_index, tab_index), tab)| {
-                        (
-                            TabPath {
-                                surface: surface_index,
-                                node: node_index,
-                                tab: tab_index,
-                            },
-                            tab,
-                        )
+                        (TabPath::new(surface_index, node_index, tab_index), tab)
                     })
             })
     }
@@ -606,7 +592,7 @@ impl<Tab> DockState<Tab> {
             .filter_map(|(index, node)| node.get_leaf().map(|leaf| (index, leaf)))
     }
 
-    /// Returns a mutable [`Iterator`] of all [``LeafNode``]s in the dock state.
+    /// Returns a mutable [`Iterator`] of all [`LeafNode`]s in the dock state.
     pub fn iter_leaves_mut(&mut self) -> impl Iterator<Item = (NodePath, &mut LeafNode<Tab>)> {
         self.iter_all_nodes_mut()
             .filter_map(|(index, node)| node.get_leaf_mut().map(|leaf| (index, leaf)))
@@ -704,9 +690,9 @@ impl<Tab> DockState<Tab> {
         });
     }
 
-    /// Find a tab based on the conditions of a functino.
+    /// Find a tab based on the conditions of a function.
     ///
-    /// Returns in which node and where in that node the tab is.
+    /// Returns the full path to that tab if it was found.
     ///
     /// The returned [`NodeIndex`] will always point to a [`Node::Leaf`].
     ///

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -22,12 +22,12 @@ pub mod node_index;
 
 use std::{
     cmp::max,
+    collections::HashSet,
     fmt,
     ops::{Index, IndexMut},
     slice::{Iter, IterMut},
 };
 
-use egui::ahash::HashSet;
 use egui::Rect;
 pub use node::LeafNode;
 pub use node::Node;

--- a/src/dock_state/tree/mod.rs
+++ b/src/dock_state/tree/mod.rs
@@ -224,7 +224,7 @@ impl<Tab> Tree<Tab> {
 
     /// Returns an [`Iterator`] of [`NodeIndex`] ordered in a breadth first manner.
     #[inline(always)]
-    pub(crate) fn breadth_first_index_iter(&self) -> impl Iterator<Item = NodeIndex> {
+    pub(crate) fn breadth_first_index_iter(&self) -> impl Iterator<Item = NodeIndex> + use<Tab> {
         (0..self.nodes.len()).map(NodeIndex)
     }
 

--- a/src/dock_state/window_state.rs
+++ b/src/dock_state/window_state.rs
@@ -128,10 +128,8 @@ impl WindowState {
             window_constructor = window_constructor.fixed_size(size);
         }
         // Reset the height of the window if it is now expanded
-        if new {
-            if let Some(height) = self.expanded_height() {
-                window_constructor = window_constructor.max_height(height).min_height(height);
-            }
+        if new && let Some(height) = self.expanded_height() {
+            window_constructor = window_constructor.max_height(height).min_height(height);
         }
         self.new = false;
         window_constructor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,7 @@
 //! non-empty surfaces: `Main` and `Window`.
 //!
 //! There can only be one `Main` surface. It's the one surface that is rendered inside the
-//! [`Ui`](egui::Ui) you've passed to [`DockArea::show_inside`], or inside the
-//! [`egui::CentralPanel`] created by [`DockArea::show`].
+//! [`Ui`](egui::Ui) you've passed to [`DockArea::show_inside`].
 //!
 //! On the other hand, there can be multiple `Window` surfaces. Those represent surfaces that were
 //! created by undocking tabs from the `Main` surface, and each of them is rendered inside

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,9 @@
 //! }
 //!
 //! # let mut my_tabs = MyTabs::new();
-//! # egui::__run_test_ctx(|ctx| {
+//! # egui::__run_test_ui(|ui| {
 //! #     #[allow(deprecated)]
-//! #     egui::CentralPanel::default().show(ctx, |ui| my_tabs.ui(ui));
+//! #     egui::CentralPanel::default().show(ui, |ui| my_tabs.ui(ui));
 //! # });
 //! ```
 //!
@@ -93,9 +93,9 @@
 //! #     fn title(&mut self, tab: &mut Self::Tab) -> WidgetText { WidgetText::default() }
 //! #     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {}
 //! # }
-//! # egui::__run_test_ctx(|ctx| {
+//! # egui::__run_test_ui(|ui| {
 //! # #[allow(deprecated)]
-//! # egui::CentralPanel::default().show(ctx, |ui| {
+//! # egui::CentralPanel::default().show(ui, |ui| {
 //! # let mut dock_state = DockState::new(vec![]);
 //! // Inherit the look and feel from egui.
 //! let mut style = Style::from_egui(ui.style());

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,4 +1,4 @@
-use egui::{ecolor::*, CornerRadius, Margin, Stroke};
+use egui::{CornerRadius, Margin, Stroke, ecolor::*};
 
 /// Left or right alignment for tab add button.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/src/style.rs
+++ b/src/style.rs
@@ -27,9 +27,9 @@ pub enum TabAddAlign {
 /// #     fn title(&mut self, tab: &mut Self::Tab) -> WidgetText { WidgetText::default() }
 /// #     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {}
 /// # }
-/// # egui::__run_test_ctx(|ctx| {
+/// # egui::__run_test_ui(|ui| {
 /// # #[allow(deprecated)]
-/// # egui::CentralPanel::default().show(ctx, |ui| {
+/// # egui::CentralPanel::default().show(ui, |ui| {
 /// # let mut dock_state = DockState::new(vec![]);
 /// // Inherit the look and feel from egui.
 /// let mut style = Style::from_egui(ui.style());

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -229,11 +229,10 @@ impl DragDropState {
                         pointer,
                         style,
                         Some(split),
-                    ) {
-                        if let TreeComponent::Node(path) = self.hover.dst {
+                    )
+                        && let TreeComponent::Node(path) = self.hover.dst {
                             destination = Some(TabDestination::Node(path, TabInsert::Split(split)))
                         }
-                    }
                 }
             }
         }

--- a/src/widgets/dock_area/drag_and_drop.rs
+++ b/src/widgets/dock_area/drag_and_drop.rs
@@ -1,8 +1,9 @@
 use std::ops::BitOrAssign;
 
 use egui::{
-    emath::{inverse_lerp, GuiRounding},
-    vec2, Context, Id, LayerId, NumExt, Order, Painter, Pos2, Rect, Stroke, StrokeKind, Ui, Vec2,
+    Context, Id, LayerId, NumExt, Order, Painter, Pos2, Rect, Stroke, StrokeKind, Ui, Vec2,
+    emath::{GuiRounding, inverse_lerp},
+    vec2,
 };
 
 use crate::{
@@ -229,10 +230,10 @@ impl DragDropState {
                         pointer,
                         style,
                         Some(split),
-                    )
-                        && let TreeComponent::Node(path) = self.hover.dst {
-                            destination = Some(TabDestination::Node(path, TabInsert::Split(split)))
-                        }
+                    ) && let TreeComponent::Node(path) = self.hover.dst
+                    {
+                        destination = Some(TabDestination::Node(path, TabInsert::Split(split)))
+                    }
                 }
             }
         }

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -167,7 +167,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     }
 
     /// The bounds for any windows inside the [`DockArea`]. Defaults to the screen rect.
-    /// By default it's set to [`egui::Context::screen_rect`].
+    /// By default it's set to [`egui::Context::content_rect`].
     #[inline(always)]
     pub fn window_bounds(mut self, bounds: Rect) -> Self {
         self.window_bounds = Some(bounds);

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -10,10 +10,10 @@ mod state;
 mod tab_removal;
 
 pub use allowed_splits::AllowedSplits;
-use egui::{emath::*, Id, Modifiers};
+use egui::{Id, Modifiers, emath::*};
 use tab_removal::TabRemoval;
 
-use crate::{dock_state::DockState, NodePath, Style, TabIndex, TabPath};
+use crate::{NodePath, Style, TabIndex, TabPath, dock_state::DockState};
 
 /// Displays a [`DockState`] in `egui`.
 pub struct DockArea<'tree, Tab> {

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1125,12 +1125,10 @@ impl<Tab> DockArea<'_, Tab> {
                 leaf.scroll -=
                     scroll_bar_handle_response.drag_delta().x * points_to_scroll_coefficient;
 
-                if let Some(pos) = state.last_hover_pos {
-                    if scroll_bar_rect.contains(pos) {
-                        leaf.scroll += ui
-                            .input(|i| i.smooth_scroll_delta.y + i.smooth_scroll_delta.x)
-                            * points_to_scroll_coefficient;
-                    }
+                if let Some(pos) = state.last_hover_pos && scroll_bar_rect.contains(pos) {
+                    leaf.scroll += ui
+                        .input(|i| i.smooth_scroll_delta.y + i.smooth_scroll_delta.x)
+                        * points_to_scroll_coefficient;
                 }
 
                 // Draw the bar.
@@ -1182,82 +1180,78 @@ impl<Tab> DockArea<'_, Tab> {
             active,
             ..
         } = leaf;
-        if !collapsed {
-            if let Some(tab) = tabs.get_mut(active.0) {
-                if *viewport != body_rect {
-                    *viewport = body_rect;
-                    tab_viewer.on_rect_changed(tab);
-                }
-
-                if ui.input(|i| i.pointer.any_click()) {
-                    if let Some(pos) = state.last_hover_pos {
-                        if body_rect.contains(pos)
-                            && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
-                        {
-                            self.new_focused = Some(path);
-                        }
-                    }
-                }
-
-                let (style, fade_factor) =
-                    fade.unwrap_or_else(|| (self.style.as_ref().unwrap(), 1.0));
-                let tabs_styles = tab_viewer.tab_style_override(tab, &style.tab);
-
-                let tabs_style = tabs_styles.as_ref().unwrap_or(&style.tab);
-
-                if tab_viewer.clear_background(tab) {
-                    ui.painter().rect_filled(
-                        body_rect,
-                        tabs_style.tab_body.corner_radius,
-                        tabs_style.tab_body.bg_fill,
-                    );
-                }
-
-                // Construct a new ui with the correct tab id.
-                //
-                // We are forced to use `Ui::new` because other methods (eg: push_id) always mix
-                // the provided id with their own which would cause tabs to change id when moved
-                // from node to node.
-                let id = self.id.with(tab_viewer.id(tab));
-                ui.ctx().check_for_id_clash(id, body_rect, "a tab with id");
-                let ui = &mut Ui::new(
-                    ui.ctx().clone(),
-                    id,
-                    UiBuilder::new().max_rect(body_rect).layer_id(ui.layer_id()),
-                );
-                ui.set_clip_rect(Rect::from_min_max(ui.cursor().min, ui.clip_rect().max));
-
-                // Use initial spacing for ui.
-                ui.spacing_mut().item_spacing = spacing;
-
-                // Offset the background rectangle up to hide the top border behind the clip rect.
-                // To avoid anti-aliasing lines when the stroke width is not divisible by two, we
-                // need to calculate the effective anti-aliased stroke width.
-                let effective_stroke_width = (tabs_style.tab_body.stroke.width / 2.0).ceil() * 2.0;
-                let tab_body_rect = Rect::from_min_max(
-                    ui.clip_rect().min - vec2(0.0, effective_stroke_width),
-                    ui.clip_rect().max,
-                );
-                ui.painter().rect_stroke(
-                    rect_stroke_box(tab_body_rect, tabs_style.tab_body.stroke.width),
-                    tabs_style.tab_body.corner_radius,
-                    tabs_style.tab_body.stroke,
-                    StrokeKind::Inside,
-                );
-
-                ScrollArea::new(tab_viewer.scroll_bars(tab)).show(ui, |ui| {
-                    Frame::new()
-                        .inner_margin(tabs_style.tab_body.inner_margin)
-                        .show(ui, |ui| {
-                            if fade_factor != 1.0 {
-                                fade_visuals(ui.visuals_mut(), fade_factor);
-                            }
-                            let available_rect = ui.available_rect_before_wrap();
-                            ui.expand_to_include_rect(available_rect);
-                            tab_viewer.ui(ui, tab);
-                        });
-                });
+        if !collapsed && let Some(tab) = tabs.get_mut(active.0) {
+            if *viewport != body_rect {
+                *viewport = body_rect;
+                tab_viewer.on_rect_changed(tab);
             }
+
+            if ui.input(|i| i.pointer.any_click())
+                && let Some(pos) = state.last_hover_pos
+                    && body_rect.contains(pos)
+                        && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
+                    {
+                        self.new_focused = Some(path);
+                    }
+
+            let (style, fade_factor) =
+                fade.unwrap_or_else(|| (self.style.as_ref().unwrap(), 1.0));
+            let tabs_styles = tab_viewer.tab_style_override(tab, &style.tab);
+
+            let tabs_style = tabs_styles.as_ref().unwrap_or(&style.tab);
+
+            if tab_viewer.clear_background(tab) {
+                ui.painter().rect_filled(
+                    body_rect,
+                    tabs_style.tab_body.corner_radius,
+                    tabs_style.tab_body.bg_fill,
+                );
+            }
+
+            // Construct a new ui with the correct tab id.
+            //
+            // We are forced to use `Ui::new` because other methods (eg: push_id) always mix
+            // the provided id with their own which would cause tabs to change id when moved
+            // from node to node.
+            let id = self.id.with(tab_viewer.id(tab));
+            ui.ctx().check_for_id_clash(id, body_rect, "a tab with id");
+            let ui = &mut Ui::new(
+                ui.ctx().clone(),
+                id,
+                UiBuilder::new().max_rect(body_rect).layer_id(ui.layer_id()),
+            );
+            ui.set_clip_rect(Rect::from_min_max(ui.cursor().min, ui.clip_rect().max));
+
+            // Use initial spacing for ui.
+            ui.spacing_mut().item_spacing = spacing;
+
+            // Offset the background rectangle up to hide the top border behind the clip rect.
+            // To avoid anti-aliasing lines when the stroke width is not divisible by two, we
+            // need to calculate the effective anti-aliased stroke width.
+            let effective_stroke_width = (tabs_style.tab_body.stroke.width / 2.0).ceil() * 2.0;
+            let tab_body_rect = Rect::from_min_max(
+                ui.clip_rect().min - vec2(0.0, effective_stroke_width),
+                ui.clip_rect().max,
+            );
+            ui.painter().rect_stroke(
+                rect_stroke_box(tab_body_rect, tabs_style.tab_body.stroke.width),
+                tabs_style.tab_body.corner_radius,
+                tabs_style.tab_body.stroke,
+                StrokeKind::Inside,
+            );
+
+            ScrollArea::new(tab_viewer.scroll_bars(tab)).show(ui, |ui| {
+                Frame::new()
+                    .inner_margin(tabs_style.tab_body.inner_margin)
+                    .show(ui, |ui| {
+                        if fade_factor != 1.0 {
+                            fade_visuals(ui.visuals_mut(), fade_factor);
+                        }
+                        let available_rect = ui.available_rect_before_wrap();
+                        ui.expand_to_include_rect(available_rect);
+                        tab_viewer.ui(ui, tab);
+                    });
+            });
         }
 
         // change hover destination

--- a/src/widgets/dock_area/show/leaf.rs
+++ b/src/widgets/dock_area/show/leaf.rs
@@ -1,23 +1,23 @@
 use std::ops::RangeInclusive;
 
 use egui::{
-    emath::TSTransform, epaint::TextShape, lerp, pos2, vec2, Align, Align2, Button, Color32,
-    CornerRadius, CursorIcon, Frame, Id, Key, LayerId, Layout, NumExt, Order, Popup,
-    PopupCloseBehavior, Rect, Response, ScrollArea, Sense, Shape, Stroke, StrokeKind, TextStyle,
-    Ui, UiBuilder, Vec2, WidgetText,
+    Align, Align2, Button, Color32, CornerRadius, CursorIcon, Frame, Id, Key, LayerId, Layout,
+    NumExt, Order, Popup, PopupCloseBehavior, Rect, Response, ScrollArea, Sense, Shape, Stroke,
+    StrokeKind, TextStyle, Ui, UiBuilder, Vec2, WidgetText, emath::TSTransform, epaint::TextShape,
+    lerp, pos2, vec2,
 };
 
+use crate::NodePath;
 use crate::dock_area::tab_removal::{ForcedRemoval, TabRemoval};
 use crate::node::LeafNode;
 use crate::tab_viewer::OnCloseResponse;
-use crate::NodePath;
 use crate::{
+    DockArea, Node, NodeIndex, Style, SurfaceIndex, TabAddAlign, TabIndex, TabStyle, TabViewer,
     dock_area::{
         drag_and_drop::{DragData, DragDropState, HoverData, TreeComponent},
         state::State,
     },
     utils::{fade_visuals, rect_set_size_centered, rect_stroke_box},
-    DockArea, Node, NodeIndex, Style, SurfaceIndex, TabAddAlign, TabIndex, TabStyle, TabViewer,
 };
 
 impl<Tab> DockArea<'_, Tab> {
@@ -1125,9 +1125,10 @@ impl<Tab> DockArea<'_, Tab> {
                 leaf.scroll -=
                     scroll_bar_handle_response.drag_delta().x * points_to_scroll_coefficient;
 
-                if let Some(pos) = state.last_hover_pos && scroll_bar_rect.contains(pos) {
-                    leaf.scroll += ui
-                        .input(|i| i.smooth_scroll_delta.y + i.smooth_scroll_delta.x)
+                if let Some(pos) = state.last_hover_pos
+                    && scroll_bar_rect.contains(pos)
+                {
+                    leaf.scroll += ui.input(|i| i.smooth_scroll_delta.y + i.smooth_scroll_delta.x)
                         * points_to_scroll_coefficient;
                 }
 
@@ -1188,14 +1189,13 @@ impl<Tab> DockArea<'_, Tab> {
 
             if ui.input(|i| i.pointer.any_click())
                 && let Some(pos) = state.last_hover_pos
-                    && body_rect.contains(pos)
-                        && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
-                    {
-                        self.new_focused = Some(path);
-                    }
+                && body_rect.contains(pos)
+                && Some(ui.layer_id()) == ui.ctx().layer_id_at(pos)
+            {
+                self.new_focused = Some(path);
+            }
 
-            let (style, fade_factor) =
-                fade.unwrap_or_else(|| (self.style.as_ref().unwrap(), 1.0));
+            let (style, fade_factor) = fade.unwrap_or_else(|| (self.style.as_ref().unwrap(), 1.0));
             let tabs_styles = tab_viewer.tab_style_override(tab, &style.tab);
 
             let tabs_style = tabs_styles.as_ref().unwrap_or(&style.tab);

--- a/src/widgets/dock_area/show/main_surface.rs
+++ b/src/widgets/dock_area/show/main_surface.rs
@@ -1,11 +1,11 @@
 use egui::{Sense, Ui};
 
 use crate::{
+    DockArea, SurfaceIndex, TabViewer,
     dock_area::{
         drag_and_drop::{HoverData, TreeComponent},
         state::State,
     },
-    DockArea, SurfaceIndex, TabViewer,
 };
 
 impl<Tab> DockArea<'_, Tab> {

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -20,8 +20,6 @@ mod window_surface;
 
 impl<Tab> DockArea<'_, Tab> {
     /// Shows the docking hierarchy inside a [`Ui`].
-    ///
-    /// See also [`show`](Self::show).
     pub fn show_inside(mut self, ui: &mut Ui, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
         self.style
             .get_or_insert(Style::from_egui(ui.style().as_ref()));

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -45,8 +45,8 @@ impl<Tab> DockArea<'_, Tab> {
             let style = self.style.as_ref().unwrap();
             state.set_drag_and_drop(source, hover, ui.ctx(), style);
             let tab_dst = self.show_drag_drop_overlay(ui, &mut state, tab_viewer);
-            if ui.input(|i| i.pointer.primary_released()) {
-                if let Some(destination) = tab_dst {
+            if ui.input(|i| i.pointer.primary_released())
+                && let Some(destination) = tab_dst {
                     let source = {
                         match state.dnd.as_ref().unwrap().drag.src {
                             TreeComponent::Tab(src) => src,
@@ -57,7 +57,6 @@ impl<Tab> DockArea<'_, Tab> {
                     };
                     self.dock_state.move_tab(source, destination);
                 }
-            }
         }
 
         if ui.input(|i| i.pointer.primary_released()) {
@@ -167,12 +166,11 @@ impl<Tab> DockArea<'_, Tab> {
         hold_time: f32,
         ctx: &Context,
     ) -> Option<SurfaceIndex> {
-        if let Some(dnd_state) = &state.dnd {
-            if dnd_state.is_locked(self.style.as_ref().unwrap(), ctx) {
+        if let Some(dnd_state) = &state.dnd
+            && dnd_state.is_locked(self.style.as_ref().unwrap(), ctx) {
                 state.window_fade =
                     Some((ctx.input(|i| i.time), dnd_state.hover.dst.surface_address()));
             }
-        }
 
         state.window_fade.and_then(|(time, surface)| {
             ctx.request_repaint();
@@ -344,8 +342,8 @@ impl<Tab> DockArea<'_, Tab> {
         let left_collapsed = self.dock_state[path.left_node()].is_collapsed();
         let right_collapsed = self.dock_state[path.right_node()].is_collapsed();
 
-        if left_collapsed || right_collapsed {
-            if let Node::Vertical(split) = &mut self.dock_state[path.surface][path.node] {
+        if (left_collapsed || right_collapsed)
+            && let Node::Vertical(split) = &mut self.dock_state[path.surface][path.node] {
                 let rect = split.rect();
                 debug_assert!(!rect.any_nan() && rect.is_finite());
                 let rect = expand_to_pixel(rect, pixels_per_point);
@@ -397,7 +395,6 @@ impl<Tab> DockArea<'_, Tab> {
                 }
                 return;
             }
-        }
 
         duplicate! {
             [

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -5,13 +5,13 @@ use egui::{
 use paste::paste;
 
 use super::{drag_and_drop::TreeComponent, state::State, tab_removal::TabRemoval};
+use crate::NodePath;
 use crate::dock_area::tab_removal::ForcedRemoval;
 use crate::tab_viewer::OnCloseResponse;
-use crate::NodePath;
 use crate::{
-    utils::{expand_to_pixel, fade_dock_style, map_to_pixel},
     AllowedSplits, DockArea, Node, NodeIndex, OverlayType, Style, SurfaceIndex, TabDestination,
     TabViewer,
+    utils::{expand_to_pixel, fade_dock_style, map_to_pixel},
 };
 
 mod leaf;
@@ -46,17 +46,18 @@ impl<Tab> DockArea<'_, Tab> {
             state.set_drag_and_drop(source, hover, ui.ctx(), style);
             let tab_dst = self.show_drag_drop_overlay(ui, &mut state, tab_viewer);
             if ui.input(|i| i.pointer.primary_released())
-                && let Some(destination) = tab_dst {
-                    let source = {
-                        match state.dnd.as_ref().unwrap().drag.src {
-                            TreeComponent::Tab(src) => src,
-                            _ => todo!(
-                                "collections of tabs, like nodes and surfaces can't be docked (yet)"
-                            ),
-                        }
-                    };
-                    self.dock_state.move_tab(source, destination);
-                }
+                && let Some(destination) = tab_dst
+            {
+                let source = {
+                    match state.dnd.as_ref().unwrap().drag.src {
+                        TreeComponent::Tab(src) => src,
+                        _ => todo!(
+                            "collections of tabs, like nodes and surfaces can't be docked (yet)"
+                        ),
+                    }
+                };
+                self.dock_state.move_tab(source, destination);
+            }
         }
 
         if ui.input(|i| i.pointer.primary_released()) {
@@ -167,10 +168,11 @@ impl<Tab> DockArea<'_, Tab> {
         ctx: &Context,
     ) -> Option<SurfaceIndex> {
         if let Some(dnd_state) = &state.dnd
-            && dnd_state.is_locked(self.style.as_ref().unwrap(), ctx) {
-                state.window_fade =
-                    Some((ctx.input(|i| i.time), dnd_state.hover.dst.surface_address()));
-            }
+            && dnd_state.is_locked(self.style.as_ref().unwrap(), ctx)
+        {
+            state.window_fade =
+                Some((ctx.input(|i| i.time), dnd_state.hover.dst.surface_address()));
+        }
 
         state.window_fade.and_then(|(time, surface)| {
             ctx.request_repaint();
@@ -343,58 +345,57 @@ impl<Tab> DockArea<'_, Tab> {
         let right_collapsed = self.dock_state[path.right_node()].is_collapsed();
 
         if (left_collapsed || right_collapsed)
-            && let Node::Vertical(split) = &mut self.dock_state[path.surface][path.node] {
-                let rect = split.rect();
-                debug_assert!(!rect.any_nan() && rect.is_finite());
-                let rect = expand_to_pixel(rect, pixels_per_point);
+            && let Node::Vertical(split) = &mut self.dock_state[path.surface][path.node]
+        {
+            let rect = split.rect();
+            debug_assert!(!rect.any_nan() && rect.is_finite());
+            let rect = expand_to_pixel(rect, pixels_per_point);
 
-                if left_collapsed {
-                    // EITHER only left collapsed OR left and right both collapsed
-                    let border_y =
-                        rect.min.y + (left_collapsed_count as f32) * style.tab_bar.height;
-                    let left_separator_border = map_to_pixel(
-                        border_y - style.separator.width * 0.5,
-                        pixels_per_point,
-                        f32::round,
-                    );
-                    let right_separator_border = map_to_pixel(
-                        border_y + style.separator.width * 0.5,
-                        pixels_per_point,
-                        f32::round,
-                    );
-                    let left = rect
-                        .intersect(Rect::everything_above(left_separator_border))
-                        .intersect(max_rect);
-                    let right = rect
-                        .intersect(Rect::everything_below(right_separator_border))
-                        .intersect(max_rect);
-                    self.dock_state[path.left_node()].set_rect(left);
-                    self.dock_state[path.right_node()].set_rect(right);
-                } else {
-                    // Only right collapsed
-                    let border_y =
-                        rect.max.y - (right_collapsed_count as f32) * style.tab_bar.height;
-                    let left_separator_border = map_to_pixel(
-                        border_y - style.separator.width * 0.5,
-                        pixels_per_point,
-                        f32::round,
-                    );
-                    let right_separator_border = map_to_pixel(
-                        border_y + style.separator.width * 0.5,
-                        pixels_per_point,
-                        f32::round,
-                    );
-                    let left = rect
-                        .intersect(Rect::everything_above(left_separator_border))
-                        .intersect(max_rect);
-                    let right = rect
-                        .intersect(Rect::everything_below(right_separator_border))
-                        .intersect(max_rect);
-                    self.dock_state[path.left_node()].set_rect(left);
-                    self.dock_state[path.right_node()].set_rect(right);
-                }
-                return;
+            if left_collapsed {
+                // EITHER only left collapsed OR left and right both collapsed
+                let border_y = rect.min.y + (left_collapsed_count as f32) * style.tab_bar.height;
+                let left_separator_border = map_to_pixel(
+                    border_y - style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round,
+                );
+                let right_separator_border = map_to_pixel(
+                    border_y + style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round,
+                );
+                let left = rect
+                    .intersect(Rect::everything_above(left_separator_border))
+                    .intersect(max_rect);
+                let right = rect
+                    .intersect(Rect::everything_below(right_separator_border))
+                    .intersect(max_rect);
+                self.dock_state[path.left_node()].set_rect(left);
+                self.dock_state[path.right_node()].set_rect(right);
+            } else {
+                // Only right collapsed
+                let border_y = rect.max.y - (right_collapsed_count as f32) * style.tab_bar.height;
+                let left_separator_border = map_to_pixel(
+                    border_y - style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round,
+                );
+                let right_separator_border = map_to_pixel(
+                    border_y + style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round,
+                );
+                let left = rect
+                    .intersect(Rect::everything_above(left_separator_border))
+                    .intersect(max_rect);
+                let right = rect
+                    .intersect(Rect::everything_below(right_separator_border))
+                    .intersect(max_rect);
+                self.dock_state[path.left_node()].set_rect(left);
+                self.dock_state[path.right_node()].set_rect(right);
             }
+            return;
+        }
 
         duplicate! {
             [

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -1,7 +1,6 @@
 use duplicate::duplicate;
 use egui::{
-    CentralPanel, Color32, Context, CornerRadius, CursorIcon, EventFilter, Frame, Key, Pos2, Rect,
-    Sense, StrokeKind, Ui, Vec2,
+    Context, CornerRadius, CursorIcon, EventFilter, Key, Pos2, Rect, Sense, StrokeKind, Ui, Vec2,
 };
 use paste::paste;
 
@@ -20,33 +19,6 @@ mod main_surface;
 mod window_surface;
 
 impl<Tab> DockArea<'_, Tab> {
-    /// Show the `DockArea` at the top level.
-    ///
-    /// Deprecated: use [`show_inside`](Self::show_inside) instead.
-    /// With eframe 0.34+, implement `App::ui` and call `show_inside` directly:
-    ///
-    /// ```ignore
-    /// fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-    ///     DockArea::new(&mut self.tree)
-    ///         .style(Style::from_egui(ui.style().as_ref()))
-    ///         .show_inside(ui, &mut tab_viewer);
-    /// }
-    /// ```
-    #[inline]
-    #[deprecated = "Use show_inside() instead — with eframe 0.34+, implement App::ui which gives &mut Ui directly"]
-    #[allow(deprecated)]
-    pub fn show(self, ctx: &Context, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
-        CentralPanel::default()
-            .frame(
-                Frame::central_panel(&ctx.global_style())
-                    .inner_margin(0.)
-                    .fill(Color32::TRANSPARENT),
-            )
-            .show(ctx, |ui| {
-                self.show_inside(ui, tab_viewer);
-            });
-    }
-
     /// Shows the docking hierarchy inside a [`Ui`].
     ///
     /// See also [`show`](Self::show).

--- a/src/widgets/dock_area/show/window_surface.rs
+++ b/src/widgets/dock_area/show/window_surface.rs
@@ -1,12 +1,12 @@
 use egui::{
-    vec2, Align, Color32, CornerRadius, CursorIcon, Frame, Layout, Rect, Response, RichText, Sense,
-    Shape, Stroke, Ui, UiBuilder, Vec2, WidgetText,
+    Align, Color32, CornerRadius, CursorIcon, Frame, Layout, Rect, Response, RichText, Sense,
+    Shape, Stroke, Ui, UiBuilder, Vec2, WidgetText, vec2,
 };
 
 use crate::{
+    DockArea, NodeIndex, Style, SurfaceIndex, TabViewer,
     dock_area::{state::State, tab_removal::TabRemoval},
     utils::{fade_visuals, rect_set_size_centered},
-    DockArea, NodeIndex, Style, SurfaceIndex, TabViewer,
 };
 
 impl<Tab> DockArea<'_, Tab> {


### PR DESCRIPTION
We remove the deprecated `DockArea::show`, because it uses an egui API that has been removed in 0.35.