### PR TITLE
fix: unbreak CI clippy on examples/hello.rs

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -143,7 +143,7 @@ impl MyContext {
         if ui.button("Click each year").clicked() {
             self.age += 1;
         }
-        ui.label(format!("Hello '{}', age {}", &self.title, &self.age));
+        ui.label(format!("Hello '{}', age {}", self.title, self.age));
     }
 
     fn style_editor(&mut self, ui: &mut Ui) {


### PR DESCRIPTION
CI on `main` is currently red on recent stable: the `Clippy all-features` step fails with

```
error: redundant reference in `format!` argument
   --> examples/hello.rs:146:48
```

`clippy::useless_borrows_in_formatting` fires twice on that line. Because the clippy step runs before the test step, this makes *every* PR red and the test results never show up. Removing the two redundant `&` makes `cargo clippy --all-targets --all-features -- -D warnings` pass on `main` again; nothing else is touched.

Disclosure: this one-line change was produced with Claude Code (Anthropic). I drive the agent and review outcomes at the behaviour level rather than line-by-line; for this patch the verification is simply that clippy and the example both build clean.
