### PR TITLE
Dragging two perpendicular splitters at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `DockArea::draggable_separator_junctions`: sets whether separator junctions can be dragged.
 - `SeparatorStyle::junction_merge_distance`: maximum distance between two perpendicular separators
   that could be dragged as one junction.
+- `SeparatorStyle::arrow_key_step_distance`: how far a focused separator moves per arrow key press.
 
 ## egui_dock 0.21.1 - 2026/08/06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # egui_dock changelog
 
+## Unreleased
+
+### Added
+
+- Dragging the junction where two perpendicular separators meet now drags all of them at once.
+  ([#200](https://github.com/anhosh/egui_dock/issues/200))
+- `DockArea::draggable_separator_junctions`: sets whether separator junctions can be dragged.
+- `SeparatorStyle::junction_merge_distance`: maximum distance between two perpendicular separators
+  that could be dragged as one junction.
+
 ## egui_dock 0.21.1 - 2026/08/06
 
 ### Fixed

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -73,6 +73,7 @@ struct MyContext {
     show_close_buttons: bool,
     show_add_buttons: bool,
     draggable_tabs: bool,
+    draggable_separator_junctions: bool,
     show_tab_name_on_hover: bool,
     allowed_splits: AllowedSplits,
     show_leaf_close_all: bool,
@@ -157,6 +158,10 @@ impl MyContext {
             ui.checkbox(&mut self.show_close_buttons, "Show close buttons");
             ui.checkbox(&mut self.show_add_buttons, "Show add buttons");
             ui.checkbox(&mut self.draggable_tabs, "Draggable tabs");
+            ui.checkbox(
+                &mut self.draggable_separator_junctions,
+                "Draggable separator junctions",
+            );
             ui.checkbox(&mut self.show_tab_name_on_hover, "Show tab name on hover");
             ui.checkbox(
                 &mut self.show_leaf_close_all,
@@ -236,6 +241,13 @@ impl MyContext {
 
                 ui.label("Offset limit:");
                 ui.add(Slider::new(&mut style.separator.extra, 1.0..=300.0));
+                ui.end_row();
+
+                ui.label("Junction merge distance:");
+                ui.add(Slider::new(
+                    &mut style.separator.junction_merge_distance,
+                    0.0..=30.0,
+                ));
                 ui.end_row();
 
                 ui.label("Idle color:");
@@ -565,6 +577,7 @@ impl Default for MyApp {
             show_close_buttons: true,
             show_add_buttons: false,
             draggable_tabs: true,
+            draggable_separator_junctions: true,
             show_tab_name_on_hover: false,
             allowed_splits: AllowedSplits::default(),
         };
@@ -613,6 +626,7 @@ impl eframe::App for MyApp {
             .show_close_buttons(self.context.show_close_buttons)
             .show_add_buttons(self.context.show_add_buttons)
             .draggable_tabs(self.context.draggable_tabs)
+            .draggable_separator_junctions(self.context.draggable_separator_junctions)
             .show_tab_name_on_hover(self.context.show_tab_name_on_hover)
             .allowed_splits(self.context.allowed_splits)
             .show_leaf_close_all_buttons(self.context.show_leaf_close_all)

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -250,6 +250,13 @@ impl MyContext {
                 ));
                 ui.end_row();
 
+                ui.label("Arrow key step distance:");
+                ui.add(Slider::new(
+                    &mut style.separator.arrow_key_step_distance,
+                    1.0..=64.0,
+                ));
+                ui.end_row();
+
                 ui.label("Idle color:");
                 color_edit_button_srgba(ui, &mut style.separator.color_idle, Alpha::OnlyBlend);
                 ui.end_row();

--- a/src/style.rs
+++ b/src/style.rs
@@ -175,6 +175,9 @@ pub struct SeparatorStyle {
     /// one junction. By `Default` it's `8.0`.
     pub junction_merge_distance: f32,
 
+    /// How far a focused separator moves per arrow key press. By `Default` it's `16.0`.
+    pub arrow_key_step_distance: f32,
+
     /// Idle color of the rectangle separator. By `Default` it's [`Color32::BLACK`].
     pub color_idle: Color32,
 
@@ -475,6 +478,7 @@ impl Default for SeparatorStyle {
             extra_interact_width: 2.0,
             extra: 175.0,
             junction_merge_distance: 8.0,
+            arrow_key_step_distance: 16.0,
             color_idle: Color32::BLACK,
             color_hovered: Color32::GRAY,
             color_dragged: Color32::WHITE,

--- a/src/style.rs
+++ b/src/style.rs
@@ -171,6 +171,10 @@ pub struct SeparatorStyle {
     /// `bigger value > less allowed offset` for the current window size.
     pub extra: f32,
 
+    /// Maximum distance between two perpendicular separators that could be dragged as
+    /// one junction. By `Default` it's `8.0`.
+    pub junction_merge_distance: f32,
+
     /// Idle color of the rectangle separator. By `Default` it's [`Color32::BLACK`].
     pub color_idle: Color32,
 
@@ -470,6 +474,7 @@ impl Default for SeparatorStyle {
             width: 1.0,
             extra_interact_width: 2.0,
             extra: 175.0,
+            junction_merge_distance: 8.0,
             color_idle: Color32::BLACK,
             color_hovered: Color32::GRAY,
             color_dragged: Color32::WHITE,

--- a/src/widgets/dock_area/mod.rs
+++ b/src/widgets/dock_area/mod.rs
@@ -25,6 +25,7 @@ pub struct DockArea<'tree, Tab> {
     show_close_buttons: bool,
     tab_context_menus: bool,
     draggable_tabs: bool,
+    draggable_separator_junctions: bool,
     hidable_tab_bars: bool,
     show_tab_name_on_hover: bool,
     show_window_close_buttons: bool,
@@ -58,6 +59,7 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
             show_close_buttons: true,
             tab_context_menus: true,
             draggable_tabs: true,
+            draggable_separator_junctions: true,
             hidable_tab_bars: false,
             show_tab_name_on_hover: false,
             allowed_splits: AllowedSplits::default(),
@@ -123,6 +125,13 @@ impl<'tree, Tab> DockArea<'tree, Tab> {
     /// By default it's `true`.
     pub fn draggable_tabs(mut self, draggable_tabs: bool) -> Self {
         self.draggable_tabs = draggable_tabs;
+        self
+    }
+
+    /// Whether the junction of two perpendicular separators can be dragged as one point.
+    /// By default it's `true`.
+    pub fn draggable_separator_junctions(mut self, draggable_separator_junctions: bool) -> Self {
+        self.draggable_separator_junctions = draggable_separator_junctions;
         self
     }
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -17,7 +17,7 @@ mod main_surface;
 mod separator;
 mod window_surface;
 
-pub(super) use separator::Axis;
+pub(super) use separator::SeparatorAxis;
 
 impl<Tab> DockArea<'_, Tab> {
     /// Shows the docking hierarchy inside a [`Ui`].

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -17,6 +17,8 @@ mod main_surface;
 mod separator;
 mod window_surface;
 
+pub(super) use separator::Axis;
+
 impl<Tab> DockArea<'_, Tab> {
     /// Shows the docking hierarchy inside a [`Ui`].
     pub fn show_inside(mut self, ui: &mut Ui, tab_viewer: &mut impl TabViewer<Tab = Tab>) {
@@ -313,7 +315,7 @@ impl<Tab> DockArea<'_, Tab> {
         }
 
         if self.draggable_separator_junctions {
-            self.show_separator_junctions(ui, &separators, fade_style);
+            self.show_separator_junctions(ui, state, surf_index, &separators, fade_style);
         }
     }
 

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -1,7 +1,5 @@
 use duplicate::duplicate;
-use egui::{
-    Context, CornerRadius, CursorIcon, EventFilter, Key, Pos2, Rect, Sense, StrokeKind, Ui, Vec2,
-};
+use egui::{Context, Pos2, Rect, Sense, StrokeKind, Ui, Vec2};
 use paste::paste;
 
 use super::{drag_and_drop::TreeComponent, state::State, tab_removal::TabRemoval};
@@ -16,6 +14,7 @@ use crate::{
 
 mod leaf;
 mod main_surface;
+mod separator;
 mod window_surface;
 
 impl<Tab> DockArea<'_, Tab> {
@@ -444,108 +443,4 @@ impl<Tab> DockArea<'_, Tab> {
         }
     }
 
-    fn show_separator(&mut self, ui: &mut Ui, path: NodePath, fade_style: Option<&Style>) {
-        assert!(self.dock_state[path.surface][path.node].is_parent());
-
-        // If either of the children is collapsed, we don't want the user to interact with the separator
-        if (self.dock_state[path.left_node()].is_collapsed()
-            || self.dock_state[path.right_node()].is_collapsed())
-            && self.dock_state[path.surface][path.node].is_vertical()
-        {
-            return;
-        }
-
-        let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
-        let pixels_per_point = ui.ctx().pixels_per_point();
-
-        duplicate! {
-            [
-                orientation   dim_point  dim_size;
-                [Horizontal]  [x]        [width];
-                [Vertical]    [y]        [height];
-            ]
-            if let Node::orientation(split) = &mut self.dock_state[path.surface][path.node] {
-                let rect = split.rect;
-                let mut separator = rect;
-
-                let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
-                separator.min.dim_point = midpoint - style.separator.width * 0.5;
-                separator.max.dim_point = midpoint + style.separator.width * 0.5;
-
-                let mut expand = Vec2::ZERO;
-                expand.dim_point += style.separator.extra_interact_width / 2.0;
-                let interact_rect = separator.expand2(expand);
-
-                let response = ui.allocate_rect(interact_rect, Sense::click_and_drag())
-                    .on_hover_and_drag_cursor(paste!{ CursorIcon::[<Resize orientation>]});
-
-                let should_respond_to_arrow_keys = ui.input(|i| i.modifiers.command || i.modifiers.shift);
-
-                if response.has_focus() {
-                    // Prevent the default behaviour of removing focus from the separators when the
-                    // arrow keys are pressed
-                    ui.memory_mut(|m| m.set_focus_lock_filter(response.id, EventFilter {
-                        horizontal_arrows: should_respond_to_arrow_keys,
-                        vertical_arrows: should_respond_to_arrow_keys,
-                        tab: false,
-                        escape: false
-                    }));
-                }
-
-                let arrow_key_offset = if response.has_focus() && should_respond_to_arrow_keys {
-                    if ui.input(|i| i.key_pressed(Key::ArrowUp)) {
-                        Some(egui::vec2(0., -16.))
-                    } else if ui.input(|i| i.key_pressed(Key::ArrowDown)) {
-                        Some(egui::vec2(0., 16.))
-                    } else if ui.input(|i| i.key_pressed(Key::ArrowLeft)) {
-                        Some(egui::vec2(-16., 0.))
-                    } else if ui.input(|i| i.key_pressed(Key::ArrowRight)) {
-                        Some(egui::vec2(16., 0.))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
-                separator.min.dim_point = map_to_pixel(
-                    midpoint - style.separator.width * 0.5,
-                    pixels_per_point,
-                    f32::round,
-                );
-                separator.max.dim_point = map_to_pixel(
-                    midpoint + style.separator.width * 0.5,
-                    pixels_per_point,
-                    f32::round,
-                );
-
-                let color = if response.dragged() {
-                    style.separator.color_dragged
-                } else if response.hovered() || response.has_focus() {
-                    style.separator.color_hovered
-                } else {
-                    style.separator.color_idle
-                };
-
-                ui.painter().rect_filled(separator, CornerRadius::ZERO, color);
-
-                // Update 'fraction' interaction after drawing separator,
-                // otherwise it may overlap on other separator / bodies when
-                // shrunk fast.
-                let range = rect.max.dim_point - rect.min.dim_point;
-                if range > 0.0 {
-                    let min = (style.separator.extra / range).min(1.0);
-                    let max = 1.0 - min;
-                    let (min, max) = (min.min(max), max.max(min));
-                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
-                    split.fraction = (split.fraction + delta / range).clamp(min, max);
-                }
-
-                if response.double_clicked() {
-                    split.fraction = 0.5;
-                }
-            }
-        }
-    }
 }

--- a/src/widgets/dock_area/show/mod.rs
+++ b/src/widgets/dock_area/show/mod.rs
@@ -301,14 +301,19 @@ impl<Tab> DockArea<'_, Tab> {
         // Finally, draw separators so that their "interaction zone" is above
         // bodies (see `SeparatorStyle::extra_interact_width`).
         let fade_style = fade_style.map(|(style, _)| style);
+        let mut separators = Vec::new();
         for node_index in self.dock_state[surf_index].breadth_first_index_iter() {
             let path = NodePath {
                 surface: surf_index,
                 node: node_index,
             };
             if self.dock_state[surf_index][node_index].is_parent() {
-                self.show_separator(ui, path, fade_style);
+                separators.extend(self.show_separator(ui, path, fade_style));
             }
+        }
+
+        if self.draggable_separator_junctions {
+            self.show_separator_junctions(ui, &separators, fade_style);
         }
     }
 
@@ -442,5 +447,4 @@ impl<Tab> DockArea<'_, Tab> {
             }
         }
     }
-
 }

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -158,7 +158,12 @@ fn arrow_key_offset(ui: &Ui, response: &Response) -> Option<Vec2> {
     })
 }
 
-fn apply_separator_delta(split: &mut SplitNode, axis: SeparatorAxis, delta: Vec2, style: &SeparatorStyle) {
+fn apply_separator_delta(
+    split: &mut SplitNode,
+    axis: SeparatorAxis,
+    delta: Vec2,
+    style: &SeparatorStyle,
+) {
     let (range, delta) = match axis {
         SeparatorAxis::X => (split.rect.width(), delta.x),
         SeparatorAxis::Y => (split.rect.height(), delta.y),

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(in crate::widgets::dock_area) enum Axis {
+pub(in crate::widgets::dock_area) enum SeparatorAxis {
     /// vertical line, left/right split
     X,
     /// horizontal line, top/bottom split
@@ -18,7 +18,7 @@ pub(in crate::widgets::dock_area) enum Axis {
 #[derive(Copy, Clone, Debug)]
 pub(super) struct SeparatorHandle {
     pub(super) path: NodePath,
-    pub(super) axis: Axis,
+    pub(super) axis: SeparatorAxis,
     /// Painted rect
     pub(super) separator: Rect,
     /// Grab area
@@ -35,8 +35,8 @@ pub(super) struct SeparatorJunction {
 fn find_junctions(handles: &[SeparatorHandle], merge_distance: f32) -> Vec<SeparatorJunction> {
     let (x_seps, y_seps): (Vec<_>, Vec<_>) =
         (0..handles.len()).partition(|&i| match handles[i].axis {
-            Axis::X => true,
-            Axis::Y => false,
+            SeparatorAxis::X => true,
+            SeparatorAxis::Y => false,
         });
 
     // Filter for perpendicular separators pairs only
@@ -82,7 +82,7 @@ fn find_junctions(handles: &[SeparatorHandle], merge_distance: f32) -> Vec<Separ
 }
 
 /// Returns the index in `handles` of the members of the junction being dragged, if any.
-fn frozen_members(
+fn junction_frozen_members(
     state: &mut State,
     surf_index: SurfaceIndex,
     handles: &[SeparatorHandle],
@@ -158,10 +158,10 @@ fn arrow_key_offset(ui: &Ui, response: &Response) -> Option<Vec2> {
     })
 }
 
-fn apply_separator_delta(split: &mut SplitNode, axis: Axis, delta: Vec2, style: &SeparatorStyle) {
+fn apply_separator_delta(split: &mut SplitNode, axis: SeparatorAxis, delta: Vec2, style: &SeparatorStyle) {
     let (range, delta) = match axis {
-        Axis::X => (split.rect.width(), delta.x),
-        Axis::Y => (split.rect.height(), delta.y),
+        SeparatorAxis::X => (split.rect.width(), delta.x),
+        SeparatorAxis::Y => (split.rect.height(), delta.y),
     };
 
     if range > 0.0 {
@@ -241,7 +241,7 @@ impl<Tab> DockArea<'_, Tab> {
 
                 handle = Some(SeparatorHandle {
                     path,
-                    axis: Axis::sep_axis,
+                    axis: SeparatorAxis::sep_axis,
                     separator,
                     interact_rect,
                 });
@@ -250,7 +250,7 @@ impl<Tab> DockArea<'_, Tab> {
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
                 let delta = arrow_key_offset.unwrap_or(response.drag_delta());
-                apply_separator_delta(split, Axis::sep_axis, delta, &style.separator);
+                apply_separator_delta(split, SeparatorAxis::sep_axis, delta, &style.separator);
 
                 if response.double_clicked() {
                     split.fraction = 0.5;
@@ -273,7 +273,7 @@ impl<Tab> DockArea<'_, Tab> {
         let mut junctions = find_junctions(handles, style.separator.junction_merge_distance);
 
         // Keep junctions that are being dragged consistent across frames
-        if let Some(frozen) = frozen_members(state, surf_index, handles) {
+        if let Some(frozen) = junction_frozen_members(state, surf_index, handles) {
             junctions.retain(|junction| !junction.members.iter().any(|m| frozen.contains(m)));
             junctions.insert(
                 0,

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -2,10 +2,13 @@ use duplicate::duplicate;
 use egui::{CornerRadius, CursorIcon, EventFilter, Key, Rect, Response, Sense, Ui, Vec2, vec2};
 use paste::paste;
 
-use crate::{DockArea, Node, NodePath, SeparatorStyle, SplitNode, Style, utils::map_to_pixel};
+use crate::{
+    DockArea, Node, NodePath, SeparatorStyle, SplitNode, Style, SurfaceIndex,
+    dock_area::state::State, utils::map_to_pixel,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(super) enum Axis {
+pub(in crate::widgets::dock_area) enum Axis {
     /// vertical line, left/right split
     X,
     /// horizontal line, top/bottom split
@@ -76,6 +79,45 @@ fn find_junctions(handles: &[SeparatorHandle], merge_distance: f32) -> Vec<Separ
     }
 
     junctions
+}
+
+/// Returns the index in `handles` of the members of the junction being dragged, if any.
+fn frozen_members(
+    state: &mut State,
+    surf_index: SurfaceIndex,
+    handles: &[SeparatorHandle],
+) -> Option<Vec<usize>> {
+    let members = state.dragged_junction.as_ref()?;
+    if members.first()?.0.surface != surf_index {
+        return None;
+    }
+
+    let resolved = members
+        .iter()
+        .map(|&(path, axis)| {
+            handles
+                .iter()
+                .position(|handle| handle.path == path && handle.axis == axis)
+        })
+        .collect::<Option<Vec<_>>>();
+
+    if resolved.is_none() {
+        state.dragged_junction = None;
+    }
+    resolved
+}
+
+fn junction_rect(handles: &[SeparatorHandle], members: &[usize]) -> Rect {
+    let mut rect = Rect::NOTHING;
+    for &a in members {
+        for &b in members {
+            let (ra, rb) = (handles[a].interact_rect, handles[b].interact_rect);
+            if handles[a].axis != handles[b].axis && ra.intersects(rb) {
+                rect = rect.union(ra.intersect(rb));
+            }
+        }
+    }
+    rect
 }
 
 fn arrow_key_offset(ui: &Ui, response: &Response) -> Option<Vec2> {
@@ -219,30 +261,56 @@ impl<Tab> DockArea<'_, Tab> {
         handle
     }
 
-    /// Drags every separator meeting at a junction at once.
-    ///
-    /// Must be called after all separators of a surface have been shown, so that the junctions are
-    /// allocated on top of them and take the clicks they overlap.
     pub(super) fn show_separator_junctions(
         &mut self,
         ui: &mut Ui,
+        state: &mut State,
+        surf_index: SurfaceIndex,
         handles: &[SeparatorHandle],
         fade_style: Option<&Style>,
     ) {
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
-        let junctions = find_junctions(handles, style.separator.junction_merge_distance);
+        let mut junctions = find_junctions(handles, style.separator.junction_merge_distance);
+
+        // Keep junctions that are being dragged consistent across frames
+        if let Some(frozen) = frozen_members(state, surf_index, handles) {
+            junctions.retain(|junction| !junction.members.iter().any(|m| frozen.contains(m)));
+            junctions.insert(
+                0,
+                SeparatorJunction {
+                    rect: junction_rect(handles, &frozen),
+                    members: frozen,
+                },
+            );
+        }
 
         for junction in junctions {
             let interact_rect = junction
                 .rect
                 .expand(style.separator.extra_interact_width / 2.0);
+
+            // Keying on the members is necessary to keep the drag going in case the tree is
+            // restructured between frames.
+            let mut paths: Vec<NodePath> =
+                junction.members.iter().map(|&m| handles[m].path).collect();
+            paths.sort_unstable_by_key(|path| (path.surface.0, path.node.0));
+            let id = self.id.with("separator_junction").with(&paths);
             let response = ui
-                .allocate_rect(interact_rect, Sense::click_and_drag())
+                .interact(interact_rect, id, Sense::click_and_drag())
                 .on_hover_and_drag_cursor(CursorIcon::Move);
+
+            if response.drag_started() {
+                state.dragged_junction = Some(
+                    junction
+                        .members
+                        .iter()
+                        .map(|&m| (handles[m].path, handles[m].axis))
+                        .collect(),
+                );
+            }
 
             let arrow_key_offset = arrow_key_offset(ui, &response);
 
-            // The members drew themselves as idle before they could know the junction was hit.
             if response.dragged() || response.hovered() || response.has_focus() {
                 let color = if response.dragged() {
                     style.separator.color_dragged

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -1,0 +1,117 @@
+use duplicate::duplicate;
+use egui::{CornerRadius, CursorIcon, EventFilter, Key, Sense, Ui, Vec2};
+use paste::paste;
+
+use crate::{DockArea, Node, NodePath, Style, utils::map_to_pixel};
+
+impl<Tab> DockArea<'_, Tab> {
+    pub(super) fn show_separator(
+        &mut self,
+        ui: &mut Ui,
+        path: NodePath,
+        fade_style: Option<&Style>,
+    ) {
+        assert!(self.dock_state[path.surface][path.node].is_parent());
+
+        // If either of the children is collapsed, we don't want the user to interact with the separator
+        if (self.dock_state[path.left_node()].is_collapsed()
+            || self.dock_state[path.right_node()].is_collapsed())
+            && self.dock_state[path.surface][path.node].is_vertical()
+        {
+            return;
+        }
+
+        let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
+        let pixels_per_point = ui.ctx().pixels_per_point();
+
+        duplicate! {
+            [
+                orientation   dim_point  dim_size;
+                [Horizontal]  [x]        [width];
+                [Vertical]    [y]        [height];
+            ]
+            if let Node::orientation(split) = &mut self.dock_state[path.surface][path.node] {
+                let rect = split.rect;
+                let mut separator = rect;
+
+                let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
+                separator.min.dim_point = midpoint - style.separator.width * 0.5;
+                separator.max.dim_point = midpoint + style.separator.width * 0.5;
+
+                let mut expand = Vec2::ZERO;
+                expand.dim_point += style.separator.extra_interact_width / 2.0;
+                let interact_rect = separator.expand2(expand);
+
+                let response = ui.allocate_rect(interact_rect, Sense::click_and_drag())
+                    .on_hover_and_drag_cursor(paste!{ CursorIcon::[<Resize orientation>]});
+
+                let should_respond_to_arrow_keys = ui.input(|i| i.modifiers.command || i.modifiers.shift);
+
+                if response.has_focus() {
+                    // Prevent the default behaviour of removing focus from the separators when the
+                    // arrow keys are pressed
+                    ui.memory_mut(|m| m.set_focus_lock_filter(response.id, EventFilter {
+                        horizontal_arrows: should_respond_to_arrow_keys,
+                        vertical_arrows: should_respond_to_arrow_keys,
+                        tab: false,
+                        escape: false
+                    }));
+                }
+
+                let arrow_key_offset = if response.has_focus() && should_respond_to_arrow_keys {
+                    if ui.input(|i| i.key_pressed(Key::ArrowUp)) {
+                        Some(egui::vec2(0., -16.))
+                    } else if ui.input(|i| i.key_pressed(Key::ArrowDown)) {
+                        Some(egui::vec2(0., 16.))
+                    } else if ui.input(|i| i.key_pressed(Key::ArrowLeft)) {
+                        Some(egui::vec2(-16., 0.))
+                    } else if ui.input(|i| i.key_pressed(Key::ArrowRight)) {
+                        Some(egui::vec2(16., 0.))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
+                separator.min.dim_point = map_to_pixel(
+                    midpoint - style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round,
+                );
+                separator.max.dim_point = map_to_pixel(
+                    midpoint + style.separator.width * 0.5,
+                    pixels_per_point,
+                    f32::round,
+                );
+
+                let color = if response.dragged() {
+                    style.separator.color_dragged
+                } else if response.hovered() || response.has_focus() {
+                    style.separator.color_hovered
+                } else {
+                    style.separator.color_idle
+                };
+
+                ui.painter().rect_filled(separator, CornerRadius::ZERO, color);
+
+                // Update 'fraction' interaction after drawing separator,
+                // otherwise it may overlap on other separator / bodies when
+                // shrunk fast.
+                let range = rect.max.dim_point - rect.min.dim_point;
+                if range > 0.0 {
+                    let min = (style.separator.extra / range).min(1.0);
+                    let max = 1.0 - min;
+                    let (min, max) = (min.min(max), max.max(min));
+                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
+                    split.fraction = (split.fraction + delta / range).clamp(min, max);
+                }
+
+                if response.double_clicked() {
+                    split.fraction = 0.5;
+                }
+            }
+        }
+    }
+}

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -1,16 +1,143 @@
 use duplicate::duplicate;
-use egui::{CornerRadius, CursorIcon, EventFilter, Key, Sense, Ui, Vec2};
+use egui::{CornerRadius, CursorIcon, EventFilter, Key, Rect, Response, Sense, Ui, Vec2, vec2};
 use paste::paste;
 
-use crate::{DockArea, Node, NodePath, Style, utils::map_to_pixel};
+use crate::{DockArea, Node, NodePath, SeparatorStyle, SplitNode, Style, utils::map_to_pixel};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum Axis {
+    /// vertical line, left/right split
+    X,
+    /// horizontal line, top/bottom split
+    Y,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(super) struct SeparatorHandle {
+    pub(super) path: NodePath,
+    pub(super) axis: Axis,
+    /// Painted rect
+    pub(super) separator: Rect,
+    /// Grab area
+    pub(super) interact_rect: Rect,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SeparatorJunction {
+    pub(super) members: Vec<usize>,
+    pub(super) rect: Rect,
+}
+
+/// Returns the junctions of perpendicular separators.
+fn find_junctions(handles: &[SeparatorHandle], merge_distance: f32) -> Vec<SeparatorJunction> {
+    let (x_seps, y_seps): (Vec<_>, Vec<_>) =
+        (0..handles.len()).partition(|&i| match handles[i].axis {
+            Axis::X => true,
+            Axis::Y => false,
+        });
+
+    // Filter for perpendicular separators pairs only
+    let mut junctions: Vec<SeparatorJunction> = Vec::new();
+    for &x in &x_seps {
+        for &y in &y_seps {
+            let (a, b) = (handles[x].interact_rect, handles[y].interact_rect);
+            if a.intersects(b) {
+                junctions.push(SeparatorJunction {
+                    members: vec![x, y],
+                    rect: a.intersect(b),
+                });
+            }
+        }
+    }
+
+    // Merge to a point
+    let merge_pad = merge_distance / 2.0;
+    let mut merging = true;
+    while merging {
+        merging = false;
+        'scan: for a in 0..junctions.len() {
+            for b in (a + 1)..junctions.len() {
+                if !junctions[a]
+                    .rect
+                    .expand(merge_pad)
+                    .intersects(junctions[b].rect.expand(merge_pad))
+                {
+                    continue;
+                }
+                let other = junctions.remove(b);
+                junctions[a].rect = junctions[a].rect.union(other.rect);
+                junctions[a].members.extend(other.members);
+                junctions[a].members.sort_unstable();
+                junctions[a].members.dedup();
+                merging = true;
+                break 'scan; // this is needed to recompute `junctions.len()` after `remove()`
+            }
+        }
+    }
+
+    junctions
+}
+
+fn arrow_key_offset(ui: &Ui, response: &Response) -> Option<Vec2> {
+    let should_respond = ui.input(|i| i.modifiers.command || i.modifiers.shift);
+
+    if response.has_focus() {
+        // Prevent the default behaviour of removing focus from the separators when the
+        // arrow keys are pressed
+        ui.memory_mut(|m| {
+            m.set_focus_lock_filter(
+                response.id,
+                EventFilter {
+                    horizontal_arrows: should_respond,
+                    vertical_arrows: should_respond,
+                    tab: false,
+                    escape: false,
+                },
+            )
+        });
+    }
+
+    if !response.has_focus() || !should_respond {
+        return None;
+    }
+
+    ui.input(|i| {
+        if i.key_pressed(Key::ArrowUp) {
+            Some(vec2(0., -16.))
+        } else if i.key_pressed(Key::ArrowDown) {
+            Some(vec2(0., 16.))
+        } else if i.key_pressed(Key::ArrowLeft) {
+            Some(vec2(-16., 0.))
+        } else if i.key_pressed(Key::ArrowRight) {
+            Some(vec2(16., 0.))
+        } else {
+            None
+        }
+    })
+}
+
+fn apply_separator_delta(split: &mut SplitNode, axis: Axis, delta: Vec2, style: &SeparatorStyle) {
+    let (range, delta) = match axis {
+        Axis::X => (split.rect.width(), delta.x),
+        Axis::Y => (split.rect.height(), delta.y),
+    };
+
+    if range > 0.0 {
+        let min = (style.extra / range).min(1.0);
+        let max = 1.0 - min;
+        let (min, max) = (min.min(max), max.max(min));
+        split.fraction = (split.fraction + delta / range).clamp(min, max);
+    }
+}
 
 impl<Tab> DockArea<'_, Tab> {
+    /// Attempts to show a separator and returns an [`SeparatorHandle`] if drawn.
     pub(super) fn show_separator(
         &mut self,
         ui: &mut Ui,
         path: NodePath,
         fade_style: Option<&Style>,
-    ) {
+    ) -> Option<SeparatorHandle> {
         assert!(self.dock_state[path.surface][path.node].is_parent());
 
         // If either of the children is collapsed, we don't want the user to interact with the separator
@@ -18,17 +145,18 @@ impl<Tab> DockArea<'_, Tab> {
             || self.dock_state[path.right_node()].is_collapsed())
             && self.dock_state[path.surface][path.node].is_vertical()
         {
-            return;
+            return None;
         }
 
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let pixels_per_point = ui.ctx().pixels_per_point();
+        let mut handle = None;
 
         duplicate! {
             [
-                orientation   dim_point  dim_size;
-                [Horizontal]  [x]        [width];
-                [Vertical]    [y]        [height];
+                orientation   dim_point  dim_size  sep_axis;
+                [Horizontal]  [x]        [width]   [X];
+                [Vertical]    [y]        [height]  [Y];
             ]
             if let Node::orientation(split) = &mut self.dock_state[path.surface][path.node] {
                 let rect = split.rect;
@@ -45,34 +173,7 @@ impl<Tab> DockArea<'_, Tab> {
                 let response = ui.allocate_rect(interact_rect, Sense::click_and_drag())
                     .on_hover_and_drag_cursor(paste!{ CursorIcon::[<Resize orientation>]});
 
-                let should_respond_to_arrow_keys = ui.input(|i| i.modifiers.command || i.modifiers.shift);
-
-                if response.has_focus() {
-                    // Prevent the default behaviour of removing focus from the separators when the
-                    // arrow keys are pressed
-                    ui.memory_mut(|m| m.set_focus_lock_filter(response.id, EventFilter {
-                        horizontal_arrows: should_respond_to_arrow_keys,
-                        vertical_arrows: should_respond_to_arrow_keys,
-                        tab: false,
-                        escape: false
-                    }));
-                }
-
-                let arrow_key_offset = if response.has_focus() && should_respond_to_arrow_keys {
-                    if ui.input(|i| i.key_pressed(Key::ArrowUp)) {
-                        Some(egui::vec2(0., -16.))
-                    } else if ui.input(|i| i.key_pressed(Key::ArrowDown)) {
-                        Some(egui::vec2(0., 16.))
-                    } else if ui.input(|i| i.key_pressed(Key::ArrowLeft)) {
-                        Some(egui::vec2(-16., 0.))
-                    } else if ui.input(|i| i.key_pressed(Key::ArrowRight)) {
-                        Some(egui::vec2(16., 0.))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+                let arrow_key_offset = arrow_key_offset(ui, &response);
 
                 let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
                 separator.min.dim_point = map_to_pixel(
@@ -96,20 +197,78 @@ impl<Tab> DockArea<'_, Tab> {
 
                 ui.painter().rect_filled(separator, CornerRadius::ZERO, color);
 
+                handle = Some(SeparatorHandle {
+                    path,
+                    axis: Axis::sep_axis,
+                    separator,
+                    interact_rect,
+                });
+
                 // Update 'fraction' interaction after drawing separator,
                 // otherwise it may overlap on other separator / bodies when
                 // shrunk fast.
-                let range = rect.max.dim_point - rect.min.dim_point;
-                if range > 0.0 {
-                    let min = (style.separator.extra / range).min(1.0);
-                    let max = 1.0 - min;
-                    let (min, max) = (min.min(max), max.max(min));
-                    let delta = arrow_key_offset.unwrap_or(response.drag_delta()).dim_point;
-                    split.fraction = (split.fraction + delta / range).clamp(min, max);
-                }
+                let delta = arrow_key_offset.unwrap_or(response.drag_delta());
+                apply_separator_delta(split, Axis::sep_axis, delta, &style.separator);
 
                 if response.double_clicked() {
                     split.fraction = 0.5;
+                }
+            }
+        }
+
+        handle
+    }
+
+    /// Drags every separator meeting at a junction at once.
+    ///
+    /// Must be called after all separators of a surface have been shown, so that the junctions are
+    /// allocated on top of them and take the clicks they overlap.
+    pub(super) fn show_separator_junctions(
+        &mut self,
+        ui: &mut Ui,
+        handles: &[SeparatorHandle],
+        fade_style: Option<&Style>,
+    ) {
+        let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
+        let junctions = find_junctions(handles, style.separator.junction_merge_distance);
+
+        for junction in junctions {
+            let interact_rect = junction
+                .rect
+                .expand(style.separator.extra_interact_width / 2.0);
+            let response = ui
+                .allocate_rect(interact_rect, Sense::click_and_drag())
+                .on_hover_and_drag_cursor(CursorIcon::Move);
+
+            let arrow_key_offset = arrow_key_offset(ui, &response);
+
+            // The members drew themselves as idle before they could know the junction was hit.
+            if response.dragged() || response.hovered() || response.has_focus() {
+                let color = if response.dragged() {
+                    style.separator.color_dragged
+                } else {
+                    style.separator.color_hovered
+                };
+                for &member in &junction.members {
+                    ui.painter()
+                        .rect_filled(handles[member].separator, CornerRadius::ZERO, color);
+                }
+            }
+
+            // Each member takes the same offset in pixels, clamped against its own bounds, so
+            // members that are only near-aligned keep the offset between them.
+            let delta = arrow_key_offset.unwrap_or(response.drag_delta());
+            let reset = response.double_clicked();
+            for &member in &junction.members {
+                let handle = handles[member];
+                if let Node::Horizontal(split) | Node::Vertical(split) =
+                    &mut self.dock_state[handle.path]
+                {
+                    if reset {
+                        split.fraction = 0.5;
+                    } else {
+                        apply_separator_delta(split, handle.axis, delta, &style.separator);
+                    }
                 }
             }
         }

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -41,8 +41,8 @@ fn find_junctions(handles: &[SeparatorHandle], merge_distance: f32) -> Vec<Separ
 
     // Filter for perpendicular separators pairs only
     let mut junctions: Vec<SeparatorJunction> = Vec::new();
-    for &x in &x_seps {
-        for &y in &y_seps {
+    for &x in x_seps.iter() {
+        for &y in y_seps.iter() {
             let (a, b) = (handles[x].interact_rect, handles[y].interact_rect);
             if a.intersects(b) {
                 junctions.push(SeparatorJunction {
@@ -322,7 +322,7 @@ impl<Tab> DockArea<'_, Tab> {
                 } else {
                     style.separator.color_hovered
                 };
-                for &member in &junction.members {
+                for &member in junction.members.iter() {
                     ui.painter()
                         .rect_filled(handles[member].separator, CornerRadius::ZERO, color);
                 }
@@ -332,7 +332,7 @@ impl<Tab> DockArea<'_, Tab> {
             // members that are only near-aligned keep the offset between them.
             let delta = arrow_key_offset.unwrap_or(response.drag_delta());
             let reset = response.double_clicked();
-            for &member in &junction.members {
+            for &member in junction.members.iter() {
                 let handle = handles[member];
                 if let Node::Horizontal(split) | Node::Vertical(split) =
                     &mut self.dock_state[handle.path]

--- a/src/widgets/dock_area/show/separator.rs
+++ b/src/widgets/dock_area/show/separator.rs
@@ -120,7 +120,7 @@ fn junction_rect(handles: &[SeparatorHandle], members: &[usize]) -> Rect {
     rect
 }
 
-fn arrow_key_offset(ui: &Ui, response: &Response) -> Option<Vec2> {
+fn arrow_key_offset(ui: &Ui, response: &Response, step: f32) -> Option<Vec2> {
     let should_respond = ui.input(|i| i.modifiers.command || i.modifiers.shift);
 
     if response.has_focus() {
@@ -145,13 +145,13 @@ fn arrow_key_offset(ui: &Ui, response: &Response) -> Option<Vec2> {
 
     ui.input(|i| {
         if i.key_pressed(Key::ArrowUp) {
-            Some(vec2(0., -16.))
+            Some(vec2(0., -step))
         } else if i.key_pressed(Key::ArrowDown) {
-            Some(vec2(0., 16.))
+            Some(vec2(0., step))
         } else if i.key_pressed(Key::ArrowLeft) {
-            Some(vec2(-16., 0.))
+            Some(vec2(-step, 0.))
         } else if i.key_pressed(Key::ArrowRight) {
-            Some(vec2(16., 0.))
+            Some(vec2(step, 0.))
         } else {
             None
         }
@@ -220,7 +220,7 @@ impl<Tab> DockArea<'_, Tab> {
                 let response = ui.allocate_rect(interact_rect, Sense::click_and_drag())
                     .on_hover_and_drag_cursor(paste!{ CursorIcon::[<Resize orientation>]});
 
-                let arrow_key_offset = arrow_key_offset(ui, &response);
+                let arrow_key_offset = arrow_key_offset(ui, &response, style.separator.arrow_key_step_distance);
 
                 let midpoint = rect.min.dim_point + rect.dim_size() * split.fraction;
                 separator.min.dim_point = map_to_pixel(
@@ -277,7 +277,7 @@ impl<Tab> DockArea<'_, Tab> {
         let style = fade_style.unwrap_or_else(|| self.style.as_ref().unwrap());
         let mut junctions = find_junctions(handles, style.separator.junction_merge_distance);
 
-        // Keep junctions that are being dragged consistent across frames
+        // Keep the junction that is being dragged consistent across frames
         if let Some(frozen) = junction_frozen_members(state, surf_index, handles) {
             junctions.retain(|junction| !junction.members.iter().any(|m| frozen.contains(m)));
             junctions.insert(
@@ -314,7 +314,8 @@ impl<Tab> DockArea<'_, Tab> {
                 );
             }
 
-            let arrow_key_offset = arrow_key_offset(ui, &response);
+            let arrow_key_offset =
+                arrow_key_offset(ui, &response, style.separator.arrow_key_step_distance);
 
             if response.dragged() || response.hovered() || response.has_focus() {
                 let color = if response.dragged() {

--- a/src/widgets/dock_area/state.rs
+++ b/src/widgets/dock_area/state.rs
@@ -1,7 +1,8 @@
 use egui::{Context, Id, Pos2};
 
 use super::drag_and_drop::{DragData, DragDropState, HoverData};
-use crate::{Style, SurfaceIndex};
+use super::show::Axis;
+use crate::{NodePath, Style, SurfaceIndex};
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct State {
@@ -9,17 +10,13 @@ pub(super) struct State {
     pub last_hover_pos: Option<Pos2>,
     pub dnd: Option<DragDropState>,
     pub window_fade: Option<(f64, SurfaceIndex)>,
+    pub dragged_junction: Option<Vec<(NodePath, Axis)>>,
 }
 
 impl State {
     #[inline(always)]
     pub(super) fn load(ctx: &Context, id: Id) -> Self {
-        ctx.data_mut(|d| d.get_temp(id)).unwrap_or(Self {
-            drag_start: None,
-            last_hover_pos: None,
-            dnd: None,
-            window_fade: None,
-        })
+        ctx.data_mut(|d| d.get_temp(id)).unwrap_or_default()
     }
 
     #[inline(always)]
@@ -31,6 +28,7 @@ impl State {
         self.dnd = None;
         self.window_fade = None;
         self.drag_start = None;
+        self.dragged_junction = None;
     }
 
     pub(super) fn set_drag_and_drop(

--- a/src/widgets/dock_area/state.rs
+++ b/src/widgets/dock_area/state.rs
@@ -1,7 +1,7 @@
 use egui::{Context, Id, Pos2};
 
 use super::drag_and_drop::{DragData, DragDropState, HoverData};
-use super::show::Axis;
+use super::show::SeparatorAxis;
 use crate::{NodePath, Style, SurfaceIndex};
 
 #[derive(Clone, Debug, Default)]
@@ -10,7 +10,7 @@ pub(super) struct State {
     pub last_hover_pos: Option<Pos2>,
     pub dnd: Option<DragDropState>,
     pub window_fade: Option<(f64, SurfaceIndex)>,
-    pub dragged_junction: Option<Vec<(NodePath, Axis)>>,
+    pub dragged_junction: Option<Vec<(NodePath, SeparatorAxis)>>,
 }
 
 impl State {


### PR DESCRIPTION
Closes #200.

Dragging two perpendicular splitters ("junction") at the same time is now possible within the region defined by `SeparatorStyle::junction_merge_distance`

https://github.com/user-attachments/assets/a2d61219-6266-4e05-b016-eeb2248f26ce

This should also complete the missing four-way junction dragging leftover from #155. Unfortunately, that PR has been closed and #237 changed much of the related codebase.

The idea is that once a junction drag has started, no more members will be added along the way. The members within the active dragging junction are frozen until either the drag finishes, or the tree has changed so that the junction is no longer intact.

**This PR introduces breaking changes (by adding fields; see changelog) so it should be merged to a release branch, though I didn't find one for 0.22 for now. I'm happy to switch the base whenever @anhosh creates that branch!**

## AI Usage Disclosure and Vouching

I have previously contributed (a while ago!) at #237, so I should already be vouched.

Claude Code on Opus 5 (Effort Extra) has been used to quickly get me through the changes from https://github.com/anhosh/egui_dock/commit/dc841ce98af55d4ce08886ae445c104517ee075e (where I was familar with) to HEAD, and generate code. I have reviewed every line of code generated and very often edited the output.